### PR TITLE
Add get linked folders(tree and list) and sites with propert(y/ies)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/PropertiesController.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/PropertiesController.cs
@@ -22,18 +22,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using BackendConfiguration.Pn.Infrastructure.Helpers;
-
 namespace BackendConfiguration.Pn.Controllers
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
+    using Infrastructure.Helpers;
     using Infrastructure.Models.Properties;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microting.eFormApi.BasePn.Infrastructure.Models.API;
     using Microting.eFormApi.BasePn.Infrastructure.Models.Common;
     using Services.BackendConfigurationPropertiesService;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     [Authorize]
     [Route("api/backend-configuration-pn/properties")]
@@ -98,6 +97,48 @@ namespace BackendConfiguration.Pn.Controllers
         public async Task<OperationDataResult<ChrResult>> GetChrInformation(int cvrNumber)
         {
             return await _backendConfigurationPropertiesService.GetChrInformation(cvrNumber).ConfigureAwait(false);
+        }
+
+        [HttpGet]
+        [Route("get-folder-dtos")]
+        public async Task<OperationDataResult<List<PropertyFolderModel>>> GetFolderDtos(int propertyId)
+        {
+            return await _backendConfigurationPropertiesService.GetLinkedFolderDtos(propertyId);
+        }
+
+        [HttpPost]
+        [Route("get-folder-dtos")]
+        public async Task<OperationDataResult<List<PropertyFolderModel>>> GetFolderDtos([FromBody] List<int> propertyIds)
+        {
+            return await _backendConfigurationPropertiesService.GetLinkedFolderDtos(propertyIds);
+        }
+
+        [HttpGet]
+        [Route("get-folder-list")]
+        public async Task<OperationDataResult<List<CommonDictionaryModel>>> GetFolderList(int propertyId)
+        {
+            return await _backendConfigurationPropertiesService.GetLinkedFoldersList(propertyId);
+        }
+
+        [HttpPost]
+        [Route("get-folder-list")]
+        public async Task<OperationDataResult<List<CommonDictionaryModel>>> GetFolderList([FromBody] List<int> propertyIds)
+        {
+            return await _backendConfigurationPropertiesService.GetLinkedFoldersList(propertyIds);
+        }
+
+        [HttpGet]
+        [Route("get-linked-sites")]
+        public async Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedSites(int propertyId)
+        {
+            return await _backendConfigurationPropertiesService.GetLinkedSites(propertyId);
+        }
+
+        [HttpPost]
+        [Route("get-linked-sites")]
+        public async Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedSites([FromBody] List<int> propertyIds)
+        {
+            return await _backendConfigurationPropertiesService.GetLinkedSites(propertyIds);
         }
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Properties/PropertyFolderModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Properties/PropertyFolderModel.cs
@@ -1,0 +1,14 @@
+﻿namespace BackendConfiguration.Pn.Infrastructure.Models.Properties;
+
+using System.Collections.Generic;
+
+public class PropertyFolderModel
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public int? ParentId { get; set; }
+    public int? MicrotingUId { get; set; }
+    public List<PropertyFolderModel> Children { get; set; }
+        = new ();
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationPropertiesService/BackendConfigurationPropertiesService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationPropertiesService/BackendConfigurationPropertiesService.cs
@@ -137,9 +137,12 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService
             var maxCvrNumbers = _options.Value.MaxCvrNumbers;
             var maxChrNumbers = _options.Value.MaxChrNumbers;
 
-            var result = await BackendConfigurationPropertiesServiceHelper.Create(propertyCreateModel, await _coreHelper.GetCore(), _userService.UserId, _backendConfigurationPnDbContext, _itemsPlanningPnDbContext, maxChrNumbers, maxCvrNumbers).ConfigureAwait(false);
+            var result = await BackendConfigurationPropertiesServiceHelper.Create(propertyCreateModel,
+                await _coreHelper.GetCore(), _userService.UserId, _backendConfigurationPnDbContext,
+                _itemsPlanningPnDbContext, maxChrNumbers, maxCvrNumbers).ConfigureAwait(false);
 
-            return new OperationResult(result.Success, _backendConfigurationLocalizationService.GetString(result.Message));
+            return new OperationResult(result.Success,
+                _backendConfigurationLocalizationService.GetString(result.Message));
         }
 
         public async Task<OperationDataResult<PropertiesModel>> Read(int id)
@@ -187,9 +190,12 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService
 
         public async Task<OperationResult> Update(PropertiesUpdateModel updateModel)
         {
-            var result =  await BackendConfigurationPropertiesServiceHelper.Update(updateModel, await _coreHelper.GetCore(), _userService.UserId, _backendConfigurationPnDbContext, _itemsPlanningPnDbContext, _backendConfigurationLocalizationService).ConfigureAwait(false);
+            var result = await BackendConfigurationPropertiesServiceHelper.Update(updateModel,
+                await _coreHelper.GetCore(), _userService.UserId, _backendConfigurationPnDbContext,
+                _itemsPlanningPnDbContext, _backendConfigurationLocalizationService).ConfigureAwait(false);
 
-            return new OperationResult(result.Success, _backendConfigurationLocalizationService.GetString(result.Message));
+            return new OperationResult(result.Success,
+                _backendConfigurationLocalizationService.GetString(result.Message));
         }
 
         public async Task<OperationResult> Delete(int id)
@@ -201,9 +207,10 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService
                     .Where(x => x.Id == id)
                     .Include(x => x.SelectedLanguages)
                     .Include(x => x.SelectedLanguages)
-					.Include(x => x.PropertyWorkers)
+                    .Include(x => x.PropertyWorkers)
                     .Include(x => x.AreaProperties)
                     .ThenInclude(x => x.ProperyAreaFolders)
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                     .FirstOrDefaultAsync().ConfigureAwait(false);
 
                 if (property == null)
@@ -246,9 +253,12 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService
                         .Select(x => x.CheckListId)
                         .FirstAsync();*/
 
-                    await WorkOrderHelper.RetractEform(property.PropertyWorkers, true, core, _userService.UserId, _backendConfigurationPnDbContext).ConfigureAwait(false);
-                    await WorkOrderHelper.RetractEform(property.PropertyWorkers, false, core, _userService.UserId, _backendConfigurationPnDbContext).ConfigureAwait(false);
-                    await WorkOrderHelper.RetractEform(property.PropertyWorkers, false, core, _userService.UserId, _backendConfigurationPnDbContext).ConfigureAwait(false);
+                    await WorkOrderHelper.RetractEform(property.PropertyWorkers, true, core, _userService.UserId,
+                        _backendConfigurationPnDbContext).ConfigureAwait(false);
+                    await WorkOrderHelper.RetractEform(property.PropertyWorkers, false, core, _userService.UserId,
+                        _backendConfigurationPnDbContext).ConfigureAwait(false);
+                    await WorkOrderHelper.RetractEform(property.PropertyWorkers, false, core, _userService.UserId,
+                        _backendConfigurationPnDbContext).ConfigureAwait(false);
                 }
 
                 // delete property workers
@@ -278,6 +288,7 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService
                     {
                         await core.EntityGroupDelete(areaProperty.GroupMicrotingUuid.ToString()).ConfigureAwait(false);
                     }
+
                     // get areaRules and select all linked entity for delete
                     var areaRules = await _backendConfigurationPnDbContext.AreaRules
                         .Where(x => x.PropertyId == areaProperty.PropertyId)
@@ -320,7 +331,8 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService
                                      x.WorkflowState != Constants.WorkflowStates.Removed))
                         {
                             areaRuleAreaRuleTranslation.UpdatedByUserId = _userService.UserId;
-                            await areaRuleAreaRuleTranslation.Delete(_backendConfigurationPnDbContext).ConfigureAwait(false);
+                            await areaRuleAreaRuleTranslation.Delete(_backendConfigurationPnDbContext)
+                                .ConfigureAwait(false);
                         }
 
                         // delete plannings area rules and items planning
@@ -366,7 +378,7 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService
                                             var result =
                                                 await sdkDbContext.Cases.SingleOrDefaultAsync(x =>
                                                     x.Id == planningCaseSite.MicrotingSdkCaseId).ConfigureAwait(false);
-                                            if (result is {MicrotingUid: { }})
+                                            if (result is { MicrotingUid: { } })
                                             {
                                                 await core.CaseDelete((int)result.MicrotingUid).ConfigureAwait(false);
                                             }
@@ -402,7 +414,8 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService
                     // delete entity search group. only for type 10 Pool inspections
                     if (property.EntitySearchListPoolWorkers != null)
                     {
-                        await core.EntityGroupDelete(property.EntitySearchListPoolWorkers.ToString()).ConfigureAwait(false);
+                        await core.EntityGroupDelete(property.EntitySearchListPoolWorkers.ToString())
+                            .ConfigureAwait(false);
                     }
 
                     areaProperty.UpdatedByUserId = _userService.UserId;
@@ -438,39 +451,42 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService
 
                 // delete linked files
                 var propertyFiles = await _backendConfigurationPnDbContext.PropertyFiles
-	                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-	                .Where(x => x.PropertyId == property.Id)
-	                .Include(x => x.File)
-	                .ThenInclude(x => x.FileTags)
-	                .ToListAsync();
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Where(x => x.PropertyId == property.Id)
+                    .Include(x => x.File)
+                    .ThenInclude(x => x.FileTags)
+                    .ToListAsync();
                 foreach (var propertyFile in propertyFiles)
                 {
                     // delete tags linked to file
-	                foreach (var fileFileTag in propertyFile.File.FileTags)
-	                {
-		                fileFileTag.UpdatedByUserId = _userService.UserId;
-		                await fileFileTag.Delete(_backendConfigurationPnDbContext);
-					}
+                    foreach (var fileFileTag in propertyFile.File.FileTags)
+                    {
+                        fileFileTag.UpdatedByUserId = _userService.UserId;
+                        await fileFileTag.Delete(_backendConfigurationPnDbContext);
+                    }
 
-					propertyFile.File.UpdatedByUserId = _userService.UserId;
-					await propertyFile.File.Delete(_backendConfigurationPnDbContext);
+                    propertyFile.File.UpdatedByUserId = _userService.UserId;
+                    await propertyFile.File.Delete(_backendConfigurationPnDbContext);
 
-					propertyFile.UpdatedByUserId = _userService.UserId;
-					await propertyFile.Delete(_backendConfigurationPnDbContext);
+                    propertyFile.UpdatedByUserId = _userService.UserId;
+                    await propertyFile.Delete(_backendConfigurationPnDbContext);
                 }
 
-				// delete property
-				property.UpdatedByUserId = _userService.UserId;
+                // delete property
+                property.UpdatedByUserId = _userService.UserId;
                 await property.Delete(_backendConfigurationPnDbContext).ConfigureAwait(false);
 
                 if (property.EntitySelectListAreas != null)
                 {
-                    var eg = await sdkDbContext.EntityGroups.SingleAsync(x => x.Id == property.EntitySelectListAreas).ConfigureAwait(false);
+                    var eg = await sdkDbContext.EntityGroups.SingleAsync(x => x.Id == property.EntitySelectListAreas)
+                        .ConfigureAwait(false);
                     await core.EntityGroupDelete(eg.MicrotingUid).ConfigureAwait(false);
                 }
 
-                if (property.EntitySelectListDeviceUsers != null) {
-                    var eg = await sdkDbContext.EntityGroups.SingleAsync(x => x.Id == property.EntitySelectListDeviceUsers).ConfigureAwait(false);
+                if (property.EntitySelectListDeviceUsers != null)
+                {
+                    var eg = await sdkDbContext.EntityGroups
+                        .SingleAsync(x => x.Id == property.EntitySelectListDeviceUsers).ConfigureAwait(false);
                     await core.EntityGroupDelete(eg.MicrotingUid).ConfigureAwait(false);
                 }
 
@@ -520,14 +536,286 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService
         public async Task<OperationDataResult<ChrResult>> GetChrInformation(int chrNumber)
         {
             var chrHelper = new ChrHelper();
-            try {
+            try
+            {
                 var chr = await chrHelper.GetCompanyInfo(chrNumber).ConfigureAwait(false);
 
                 return new OperationDataResult<ChrResult>(true, chr);
-            } catch (Exception e) {
+            }
+            catch (Exception e)
+            {
                 return new OperationDataResult<ChrResult>(false, e.Message);
             }
+        }
 
+        public async Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedFoldersList(int propertyId)
+        {
+            try
+            {
+                var core = await _coreHelper.GetCore();
+                var sdkDbContext = core.DbContextHelper.GetDbContext();
+                var userLanguage = await _userService.GetCurrentUserLanguage();
+
+                var folderIds = await _backendConfigurationPnDbContext.ProperyAreaFolders
+                    .Where(x => x.AreaProperty.PropertyId == propertyId)
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(x => x.FolderId)
+                    .ToListAsync();
+                folderIds = folderIds.Distinct().ToList();
+
+
+                var folders = await sdkDbContext.Folders
+                    .Include(x => x.FolderTranslations)
+                    .ToListAsync();
+
+                var folderList = folders
+                    .Where(f => f.ParentId == null)
+                    .Select(f => MapFolder(f, folders, userLanguage))
+                    .Where(x => HaveFolderWithId(folderIds, x))
+                    .SelectMany(x => MapFolder(x))
+                    .ToList();
+
+                return new OperationDataResult<List<CommonDictionaryModel>>(true, folderList);
+            }
+            catch (Exception e)
+            {
+                return new OperationDataResult<List<CommonDictionaryModel>>(false, e.Message);
+            }
+        }
+
+        public async Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedFoldersList(List<int> propertyIds)
+        {
+            try
+            {
+                var core = await _coreHelper.GetCore();
+                var sdkDbContext = core.DbContextHelper.GetDbContext();
+                var userLanguage = await _userService.GetCurrentUserLanguage();
+
+                var folderIds = await _backendConfigurationPnDbContext.ProperyAreaFolders
+                    .Where(x => propertyIds.Contains(x.AreaProperty.PropertyId))
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(x => x.FolderId)
+                    .ToListAsync();
+                folderIds = folderIds.Distinct().ToList();
+
+                var folders = await sdkDbContext.Folders
+                    .Include(x => x.FolderTranslations)
+                    .ToListAsync();
+
+                var folderList = folders
+                    .Where(f => f.ParentId == null)
+                    .Select(f => MapFolder(f, folders, userLanguage))
+                    .Where(x => HaveFolderWithId(folderIds, x))
+                    .SelectMany(x => MapFolder(x))
+                    .ToList();
+
+                return new OperationDataResult<List<CommonDictionaryModel>>(true, folderList);
+            }
+            catch (Exception e)
+            {
+                return new OperationDataResult<List<CommonDictionaryModel>>(false, e.Message);
+            }
+        }
+
+        public async Task<OperationDataResult<List<PropertyFolderModel>>> GetLinkedFolderDtos(int propertyId)
+        {
+            try
+            {
+                var core = await _coreHelper.GetCore();
+                var sdkDbContext = core.DbContextHelper.GetDbContext();
+                var userLanguage = await _userService.GetCurrentUserLanguage();
+
+                var folderIds = await _backendConfigurationPnDbContext.Properties
+                    .Where(x => x.Id == propertyId)
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Where(x => x.FolderId.HasValue)
+                    .Select(x => x.FolderId.Value)
+                    .ToListAsync();
+
+                folderIds.AddRange(await _backendConfigurationPnDbContext.ProperyAreaFolders
+                    .Where(x => x.AreaProperty.PropertyId == propertyId)
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(x => x.FolderId)
+                    .ToListAsync());
+                folderIds = folderIds.Distinct().ToList();
+
+                var folders = await sdkDbContext.Folders
+                    .Include(x => x.FolderTranslations)
+                    .ToListAsync();
+
+                var folderModels = folders
+                    .Where(f => f.ParentId == null)
+                    .Select(f => MapFolder(f, folders, userLanguage))
+                    .Where(x => HaveFolderWithId(folderIds, x))
+                    .ToList();
+
+                return new OperationDataResult<List<PropertyFolderModel>>(true, folderModels);
+            }
+            catch (Exception e)
+            {
+                return new OperationDataResult<List<PropertyFolderModel>>(false, e.Message);
+            }
+        }
+        
+        public async Task<OperationDataResult<List<PropertyFolderModel>>> GetLinkedFolderDtos(List<int> propertyIds)
+        {
+            try
+            {
+                var core = await _coreHelper.GetCore();
+                var sdkDbContext = core.DbContextHelper.GetDbContext();
+                var userLanguage = await _userService.GetCurrentUserLanguage();
+
+                var folderIds = await _backendConfigurationPnDbContext.Properties
+                    .Where(x => propertyIds.Contains(x.Id))
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Where(x => x.FolderId.HasValue)
+                    .Select(x => x.FolderId.Value)
+                    .ToListAsync();
+
+                folderIds.AddRange(await _backendConfigurationPnDbContext.ProperyAreaFolders
+                    .Where(x => propertyIds.Contains(x.AreaProperty.PropertyId))
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(x => x.FolderId)
+                    .ToListAsync());
+                folderIds = folderIds.Distinct().ToList();
+
+                var folders = await sdkDbContext.Folders
+                    .Include(x => x.FolderTranslations)
+                    .ToListAsync();
+                
+                var folderModels = folders
+                    .Where(f => f.ParentId == null)
+                    .Select(f => MapFolder(f, folders, userLanguage))
+                    .Where(x => HaveFolderWithId(folderIds, x))
+                    .ToList();
+
+                return new OperationDataResult<List<PropertyFolderModel>>(true, folderModels);
+            }
+            catch (Exception e)
+            {
+                return new OperationDataResult<List<PropertyFolderModel>>(false, e.Message);
+            }
+        }
+
+        public async Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedSites(int propertyId)
+        {
+            try
+            {
+                var core = await _coreHelper.GetCore();
+                var sdkDbContext = core.DbContextHelper.GetDbContext();
+
+                var siteIds = await _backendConfigurationPnDbContext.PropertyWorkers
+                    .Where(x => x.PropertyId == propertyId)
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(x => x.WorkerId)
+                    .ToListAsync();
+
+                var sites = await sdkDbContext.Sites
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Where(x => siteIds.Contains(x.Id))
+                    .Select(x => new CommonDictionaryModel
+                    {
+                        Name = x.Name,
+                        Id = x.Id
+                    })
+                    .ToListAsync();
+
+                return new OperationDataResult<List<CommonDictionaryModel>>(true, sites);
+            }
+            catch (Exception e)
+            {
+                return new OperationDataResult<List<CommonDictionaryModel>>(false, e.Message);
+            }
+        }
+
+        public async Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedSites(List<int> propertyIds)
+        {
+            try
+            {
+                var core = await _coreHelper.GetCore();
+                var sdkDbContext = core.DbContextHelper.GetDbContext();
+
+                var siteIds = await _backendConfigurationPnDbContext.PropertyWorkers
+                    .Where(x => propertyIds.Contains(x.PropertyId))
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(x => x.WorkerId)
+                    .ToListAsync();
+
+                var sites = await sdkDbContext.Sites
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Where(x => siteIds.Contains(x.Id))
+                    .Select(x => new CommonDictionaryModel
+                    {
+                        Name = x.Name,
+                        Id = x.Id
+                    })
+                    .ToListAsync();
+
+                return new OperationDataResult<List<CommonDictionaryModel>>(true, sites);
+            }
+            catch (Exception e)
+            {
+                return new OperationDataResult<List<CommonDictionaryModel>>(false, e.Message);
+            }
+        }
+
+        private static PropertyFolderModel MapFolder(Folder folder, List<Folder> allFolders, Language userLanguage)
+        {
+            var propertyFolderModel = new PropertyFolderModel
+            {
+                Id = folder.Id,
+                Name = folder.FolderTranslations
+                    .Where(x => x.LanguageId == userLanguage.Id)
+                    .Select(x => x.Name)
+                    .FirstOrDefault(),
+                Description = folder.FolderTranslations
+                    .Where(x => x.LanguageId == userLanguage.Id)
+                    .Select(x => x.Description)
+                    .FirstOrDefault(),
+                MicrotingUId = folder.MicrotingUid,
+                ParentId = folder.ParentId,
+                Children = new List<PropertyFolderModel>(),
+            };
+
+            foreach (var childFolder in allFolders.Where(f => f.ParentId == folder.Id))
+            {
+                propertyFolderModel.Children.Add(MapFolder(childFolder, allFolders, userLanguage));
+            }
+
+            return propertyFolderModel;
+        }
+        private static List<CommonDictionaryModel> MapFolder(PropertyFolderModel folder, string rootFolderName = "")
+        {
+            var result = new List<CommonDictionaryModel>();
+            var fullName = string.IsNullOrEmpty(rootFolderName) ? folder.Name : $"{rootFolderName} - {folder.Name}";
+            if (!folder.Children.Any())
+            {
+                result.Add(new CommonDictionaryModel
+                {
+                    Id = folder.Id,
+                    Description = folder.Description,
+                    Name = fullName
+                });
+            }
+            else
+            {
+                foreach (var childFolder in folder.Children)
+                {
+                    result.AddRange(MapFolder(childFolder, fullName));
+                }
+            }
+
+            return result;
+        }
+
+        private static bool HaveFolderWithId(int folderId, PropertyFolderModel folder)
+        {
+            return folder.Id == folderId || folder.Children.Any(f => HaveFolderWithId(folderId, f));
+        }
+
+        private static bool HaveFolderWithId(List<int> folderIds, PropertyFolderModel folder)
+        {
+            return folderIds.Contains(folder.Id) || folder.Children.Any(f => HaveFolderWithId(folderIds, f));
         }
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationPropertiesService/IBackendConfigurationPropertiesService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationPropertiesService/IBackendConfigurationPropertiesService.cs
@@ -22,32 +22,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using BackendConfiguration.Pn.Infrastructure.Helpers;
 
-namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService
+namespace BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService;
+
+using Infrastructure.Helpers;
+using Infrastructure.Models.Properties;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.eFormApi.BasePn.Infrastructure.Models.Common;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public interface IBackendConfigurationPropertiesService
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using Infrastructure.Models.Properties;
-    using Microting.eFormApi.BasePn.Infrastructure.Models.API;
-    using Microting.eFormApi.BasePn.Infrastructure.Models.Common;
-
-    public interface IBackendConfigurationPropertiesService
-    {
-        Task<OperationDataResult<Paged<PropertiesModel>>> Index(PropertiesRequestModel request);
-
-        Task<OperationResult> Create(PropertyCreateModel createModel);
-
-        Task<OperationDataResult<PropertiesModel>> Read(int id);
-
-        Task<OperationResult> Update(PropertiesUpdateModel updateModel);
-
-        Task<OperationResult> Delete(int id);
-
-        Task<OperationDataResult<List<CommonDictionaryModel>>> GetCommonDictionary(bool fullNames);
-
-        Task<OperationDataResult<Result>> GetCompanyType(int number);
-
-        Task<OperationDataResult<ChrResult>> GetChrInformation(int number);
-    }
+    Task<OperationDataResult<Paged<PropertiesModel>>> Index(PropertiesRequestModel request);
+    Task<OperationResult> Create(PropertyCreateModel createModel);
+    Task<OperationDataResult<PropertiesModel>> Read(int id);
+    Task<OperationResult> Update(PropertiesUpdateModel updateModel);
+    Task<OperationResult> Delete(int id);
+    Task<OperationDataResult<List<CommonDictionaryModel>>> GetCommonDictionary(bool fullNames);
+    Task<OperationDataResult<Result>> GetCompanyType(int number);
+    Task<OperationDataResult<ChrResult>> GetChrInformation(int number);
+    Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedFoldersList(int propertyId);
+    Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedFoldersList(List<int> propertyIds);
+    Task<OperationDataResult<List<PropertyFolderModel>>> GetLinkedFolderDtos(int propertyId);
+    Task<OperationDataResult<List<PropertyFolderModel>>> GetLinkedFolderDtos(List<int> propertyIds);
+    Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedSites(int propertyId);
+    Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedSites(List<int> propertyId);
 }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/properties/index.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/properties/index.ts
@@ -6,3 +6,5 @@ export * from './property-areas-update.model';
 export * from './property-area.model';
 export * from './property-workers-assignment.model';
 export * from './result.model';
+export * from './chr-result.model';
+export * from './property-folder.model';

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/properties/property-folder.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/properties/property-folder.model.ts
@@ -1,0 +1,8 @@
+export interface PropertyFolderModel {
+  id: number;
+  name: string;
+  description?: string;
+  parentId?: number;
+  microtingUId?: number;
+  children?: PropertyFolderModel[];
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/store/task-wizard.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/store/task-wizard.service.ts
@@ -8,6 +8,8 @@ import {Observable, filter} from 'rxjs';
 import {BackendConfigurationPnTaskWizardService} from '../../../../services';
 import {CommonDictionaryModel} from 'src/app/common/models';
 import {updateTableSort} from 'src/app/common/helpers';
+import * as R from 'ramda';
+import {TaskWizardStatusesEnum} from 'src/app/plugins/modules/backend-configuration-pn/enums';
 
 @Injectable({providedIn: 'root'})
 export class TaskWizardStateService {
@@ -32,13 +34,59 @@ export class TaskWizardStateService {
     return this.query.selectFilters$;
   }
 
-  updateFilters(taskManagementFiltrationModel: TaskWizardFiltrationModel) {
-    this.store.update((state) => ({
-      filters: {
-        ...state.filters,
-        ...taskManagementFiltrationModel
-      },
-    }));
+  updatePropertyIds(propertyIds: number[]) {
+    if(!R.equals(this.store.getValue().filters.propertyIds, propertyIds)) {
+      this.store.update((state) => ({
+        filters: {
+          ...state.filters,
+          propertyIds: propertyIds,
+        },
+      }));
+    }
+  }
+
+  updateFolderIds(folderIds: number[]) {
+    if(!R.equals(this.store.getValue().filters.folderIds, folderIds)) {
+      this.store.update((state) => ({
+        filters: {
+          ...state.filters,
+          folderIds: folderIds,
+        },
+      }));
+    }
+  }
+
+  updateTagIds(tagIds: number[]) {
+    if(!R.equals(this.store.getValue().filters.tagIds, tagIds)) {
+      this.store.update((state) => ({
+        filters: {
+          ...state.filters,
+          tagIds: tagIds,
+        },
+      }));
+    }
+  }
+
+  updateStatus(status: TaskWizardStatusesEnum) {
+    if(!R.equals(this.store.getValue().filters.status, status)) {
+      this.store.update((state) => ({
+        filters: {
+          ...state.filters,
+          status: status,
+        },
+      }));
+    }
+  }
+
+  updateAssignToIds(assignToIds: number[]) {
+    if(!R.equals(this.store.getValue().filters.assignToIds, assignToIds)) {
+      this.store.update((state) => ({
+        filters: {
+          ...state.filters,
+          assignToIds: assignToIds,
+        },
+      }));
+    }
   }
 
   addTagToFilters(tag: CommonDictionaryModel) {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-create-modal/task-wizard-create-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-create-modal/task-wizard-create-modal.component.ts
@@ -37,9 +37,9 @@ import {AuthStateService} from 'src/app/common/store';
 export class TaskWizardCreateModalComponent implements OnInit, OnDestroy {
   planningTagsModal: PlanningTagsComponent
   createTask: EventEmitter<TaskWizardCreateModel> = new EventEmitter<TaskWizardCreateModel>();
+  changeProperty: EventEmitter<number> = new EventEmitter<number>();
   typeahead = new EventEmitter<string>();
   properties: CommonDictionaryModel[] = [];
-  folders: FolderDto[] = [];
   tags: CommonDictionaryModel[] = [];
   sites: CommonDictionaryModel[] = [];
   foldersTreeDto: FolderDto[] = [];
@@ -160,6 +160,10 @@ export class TaskWizardCreateModalComponent implements OnInit, OnDestroy {
 
   changePropertyId(property: CommonDictionaryModel) {
     this.model.propertyId = property.id;
+    this.changeProperty.emit(property.id);
+    this.model.folderId = null;
+    this.model.sites = [];
+    this.selectedFolderName = '';
   }
 
   changeTagIds(tags: SharedTagModel[]) {
@@ -244,7 +248,7 @@ export class TaskWizardCreateModalComponent implements OnInit, OnDestroy {
     foldersModal.backdropClick().pipe(take(1)).subscribe(_ => foldersModal.close());
     foldersModal.componentInstance.folders = this.foldersTreeDto;
     foldersModal.componentInstance.eFormSdkFolderId =
-      this.model.folderId ? this.folders.filter(x => x.id === this.model.folderId)[0].id : null;
+      this.model.folderId ? this.model.folderId : null;
     this.folderSelectedSub$ = foldersModal.componentInstance.folderSelected.subscribe(x => {
       this.model.folderId = x.id;
       this.selectedFolderName = findFullNameById(

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-update-modal/task-wizard-update-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-update-modal/task-wizard-update-modal.component.ts
@@ -35,11 +35,11 @@ import {AuthStateService} from 'src/app/common/store';
   styleUrls: ['./task-wizard-update-modal.component.scss'],
 })
 export class TaskWizardUpdateModalComponent implements OnInit, OnDestroy {
-  planningTagsModal: PlanningTagsComponent
+  planningTagsModal: PlanningTagsComponent;
   updateTask: EventEmitter<TaskWizardCreateModel> = new EventEmitter<TaskWizardCreateModel>();
   typeahead = new EventEmitter<string>();
+  changeProperty: EventEmitter<number> = new EventEmitter<number>();
   properties: CommonDictionaryModel[] = [];
-  folders: FolderDto[] = [];
   tags: CommonDictionaryModel[] = [];
   sites: CommonDictionaryModel[] = [];
   repeatEveryArr: { id: number, name: string }[] = [];
@@ -118,7 +118,7 @@ export class TaskWizardUpdateModalComponent implements OnInit, OnDestroy {
     this.model.translates = fixTranslationsByLanguages(this.model.translates,
       this.appLanguages.languages
         .filter(x => x.isActive)
-        .map(x => ({languageId: x.id})))
+        .map(x => ({languageId: x.id})));
     this.repeatEveryArr = generateWeeksList(this.translateService, 52);
     this.repeatTypeArr = Object.keys(RepeatTypeEnum)
       .filter(key => isNaN(Number(key))) // Filter out numeric keys that TypeScript adds to enumerations
@@ -164,15 +164,19 @@ export class TaskWizardUpdateModalComponent implements OnInit, OnDestroy {
 
   changePropertyId(property: CommonDictionaryModel) {
     this.model.propertyId = property.id;
+    this.changeProperty.emit(property.id);
+    this.model.folderId = null;
+    this.model.sites = [];
+    this.selectedFolderName = '';
   }
 
   changeTagIds(tags: SharedTagModel[]) {
     this.model.tagIds = tags.map(x => x.id);
   }
 
-/*  updateLanguageModel(translationsModel: CommonTranslationsModel, index: number) {
-    this.model.translates[index] = translationsModel;
-  }*/
+  /*updateLanguageModel(translationsModel: CommonTranslationsModel, index: number) {
+      this.model.translates[index] = translationsModel;
+    }*/
 
   updateName(name: string, index: number) {
     this.model.translates[index].name = name;
@@ -247,7 +251,7 @@ export class TaskWizardUpdateModalComponent implements OnInit, OnDestroy {
       {...dialogConfigHelper(this.overlay), hasBackdrop: true});
     foldersModal.backdropClick().pipe(take(1)).subscribe(_ => foldersModal.close());
     foldersModal.componentInstance.folders = this.foldersTreeDto;
-    foldersModal.componentInstance.eFormSdkFolderId = this.folders.filter(x => x.id === this.model.folderId)[0].id;
+    foldersModal.componentInstance.eFormSdkFolderId = this.model.folderId;
     this.folderSelectedSub$ = foldersModal.componentInstance.folderSelected.subscribe(x => {
       this.model.folderId = x.id;
       this.selectedFolderName = findFullNameById(

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-filters/task-wizard-filters.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-filters/task-wizard-filters.component.ts
@@ -12,7 +12,7 @@ import {filter, tap} from 'rxjs/operators';
 import {TaskWizardStateService} from '../store';
 import {TaskWizardStatusesEnum} from '../../../../enums';
 import {TranslateService} from '@ngx-translate/core';
-import * as R from 'ramda'
+import * as R from 'ramda';
 import {Subscription} from 'rxjs';
 
 @AutoUnsubscribe()
@@ -36,8 +36,13 @@ export class TaskWizardFiltersComponent implements OnInit, OnDestroy {
     status: FormControl<TaskWizardStatusesEnum | null>,
     folderIds: FormControl<number[]>
   }>;
+
   getFiltersAsyncSub$: Subscription;
-  valueChangesSub$: Subscription;
+  valueChangesStatusSub$: Subscription;
+  valueChangesAssignToIdsSub$: Subscription;
+  valueChangesTagIdsSub$: Subscription;
+  valueChangesFolderIdsSub$: Subscription;
+  valueChangesPropertyIdsSub$: Subscription;
 
   constructor(
     private taskWizardStateService: TaskWizardStateService,
@@ -45,10 +50,10 @@ export class TaskWizardFiltersComponent implements OnInit, OnDestroy {
   ) {
     this.filtersForm = new FormGroup({
       propertyIds: new FormControl([]),
-      folderIds: new FormControl([]),
+      folderIds: new FormControl({value: [], disabled: true}),
       tagIds: new FormControl([]),
       status: new FormControl(null),
-      assignToIds: new FormControl([]),
+      assignToIds: new FormControl({value: [], disabled: true}),
     });
   }
 
@@ -63,32 +68,88 @@ export class TaskWizardFiltersComponent implements OnInit, OnDestroy {
       });
     this.getFiltersAsyncSub$ = this.taskWizardStateService.getFiltersAsync()
       .pipe(
-        filter(value => !R.equals(value, this.filtersForm.getRawValue())),
+        // filter(value => !R.equals(value.tagIds, this.filtersForm.getRawValue().tagIds)),
         tap(filters => {
+          if(!R.equals(filters.tagIds, this.filtersForm.getRawValue().tagIds)) {
+            this.updateTable.emit()
+          }
           this.filtersForm.patchValue({
             propertyIds: filters.propertyIds,
             folderIds: filters.folderIds,
             tagIds: filters.tagIds,
             status: filters.status,
             assignToIds: filters.assignToIds,
-          }, {emitEvent: false});
-        }))
-      .subscribe();
-    this.valueChangesSub$ = this.filtersForm.valueChanges
-      .pipe(
-        filter(value => !R.equals(this.taskWizardStateService.store.getValue().filters, value)),
-        tap(value => {
-          this.taskWizardStateService.updateFilters({
-            propertyIds: value.propertyIds,
-            folderIds: value.folderIds,
-            tagIds: value.tagIds,
-            status: value.status,
-            assignToIds: value.assignToIds,
           });
-        }),
-        tap(() => this.updateTable.emit())
-      )
-      .subscribe();
+          this.propertyIdsChange(filters.propertyIds);
+        })).subscribe();
+
+    this.valueChangesPropertyIdsSub$ = this.filtersForm.get('propertyIds').valueChanges.pipe(
+      filter(value => !R.equals(value, this.taskWizardStateService.store.getValue().filters.propertyIds)),
+      tap(value => {
+        this.propertyIdsChange(value);
+      }),
+      tap(() => this.updateTable.emit())
+    ).subscribe();
+
+    this.valueChangesFolderIdsSub$ = this.filtersForm.get('folderIds').valueChanges.pipe(
+      filter(value => !R.equals(value, this.taskWizardStateService.store.getValue().filters.folderIds)),
+      tap(value => {
+        this.folderIdsChange(value);
+      }),
+      tap(() => this.updateTable.emit())
+    ).subscribe();
+
+    this.valueChangesTagIdsSub$ = this.filtersForm.get('tagIds').valueChanges.pipe(
+      filter(value => !R.equals(value, this.taskWizardStateService.store.getValue().filters.tagIds)),
+      tap(value => {
+        this.tagIdsChange(value);
+      }),
+      tap(() => this.updateTable.emit())
+    ).subscribe();
+
+    this.valueChangesAssignToIdsSub$ = this.filtersForm.get('assignToIds').valueChanges.pipe(
+      filter(value => !R.equals(value, this.taskWizardStateService.store.getValue().filters.assignToIds)),
+      tap(value => {
+        this.assignToIdsChange(value);
+      }),
+      tap(() => this.updateTable.emit())
+    ).subscribe();
+
+    this.valueChangesStatusSub$ = this.filtersForm.get('status').valueChanges.pipe(
+      filter(value => !R.equals(value, this.taskWizardStateService.store.getValue().filters.status)),
+      tap(value => {
+        this.statusChange(value);
+      }),
+      tap(() => this.updateTable.emit())
+    ).subscribe();
+  }
+
+  propertyIdsChange(value: number[]) {
+    if (value.length !== 0) {
+      this.filtersForm.get('folderIds').enable();
+      this.filtersForm.get('assignToIds').enable();
+    } else {
+      this.filtersForm.get('folderIds').disable();
+      this.filtersForm.get('assignToIds').disable();
+    }
+    this.filtersForm.patchValue({folderIds: [], assignToIds: []});
+    this.taskWizardStateService.updatePropertyIds(value);
+  }
+
+  folderIdsChange(value: number[]) {
+    this.taskWizardStateService.updateFolderIds(value);
+  }
+
+  assignToIdsChange(value: number[]) {
+    this.taskWizardStateService.updateAssignToIds(value);
+  }
+
+  tagIdsChange(value: number[]) {
+    this.taskWizardStateService.updateTagIds(value);
+  }
+
+  statusChange(value: TaskWizardStatusesEnum) {
+    this.taskWizardStateService.updateStatus(value);
   }
 
   ngOnDestroy(): void {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-properties.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-properties.service.ts
@@ -5,7 +5,7 @@ import {
   CommonDictionaryModel, DeviceUserRequestModel,
   OperationDataResult,
   OperationResult,
-  Paged,
+  Paged, FolderDto,
 } from 'src/app/common/models';
 import {
   PropertyCreateModel,
@@ -13,12 +13,10 @@ import {
   PropertiesRequestModel,
   PropertyUpdateModel,
   PropertyAreaModel,
-  PropertyAreasUpdateModel,
-  PropertyAssignWorkersModel, ResultModel,
+  PropertyAreasUpdateModel, DeviceUserModel,
+  PropertyAssignWorkersModel, ResultModel, ChrResultModel, PropertyFolderModel,
 } from '../models';
 import { ApiBaseService } from 'src/app/common/services';
-import {DeviceUserModel} from 'src/app/plugins/modules/backend-configuration-pn/models/device-users';
-import {ChrResultModel} from 'src/app/plugins/modules/backend-configuration-pn/models/properties/chr-result.model';
 
 export let BackendConfigurationPnPropertiesMethods = {
   Properties: 'api/backend-configuration-pn/properties',
@@ -32,6 +30,9 @@ export let BackendConfigurationPnPropertiesMethods = {
   GetCompanyType: 'api/backend-configuration-pn/properties/get-company-type',
   GetChrInformation: 'api/backend-configuration-pn/properties/get-chr-information',
   DictionaryProperties: 'api/backend-configuration-pn/properties/dictionary',
+  GetFolderDtos: 'api/backend-configuration-pn/properties/get-folder-dtos',
+  GetFolderList: 'api/backend-configuration-pn/properties/get-folder-list',
+  GetLinkedSites: 'api/backend-configuration-pn/properties/get-linked-sites',
 }
 
 @Injectable({
@@ -180,6 +181,48 @@ export class BackendConfigurationPnPropertiesService {
     return this.apiBaseService.post(
       BackendConfigurationPnPropertiesMethods.CreateEntityList + propertyAreaId,
       model
+    );
+  }
+
+  getLinkedFolderDtos(id: number): Observable<OperationDataResult<PropertyFolderModel[]>> {
+    return this.apiBaseService.get(
+      BackendConfigurationPnPropertiesMethods.GetFolderDtos,
+      { propertyId: id }
+    );
+  }
+
+  getLinkedFolderDtosByMultipleProperties(ids: number[]): Observable<OperationDataResult<PropertyFolderModel[]>> {
+    return this.apiBaseService.post(
+      BackendConfigurationPnPropertiesMethods.GetFolderDtos,
+      ids
+    );
+  }
+
+  getLinkedFolderList(id: number): Observable<OperationDataResult<CommonDictionaryModel[]>> {
+    return this.apiBaseService.get(
+      BackendConfigurationPnPropertiesMethods.GetFolderList,
+      { propertyId: id }
+    );
+  }
+
+  getLinkedFolderListByMultipleProperties(ids: number[]): Observable<OperationDataResult<CommonDictionaryModel[]>> {
+    return this.apiBaseService.post(
+      BackendConfigurationPnPropertiesMethods.GetFolderList,
+      ids
+    );
+  }
+
+  getLinkedSites(id: number): Observable<OperationDataResult<CommonDictionaryModel[]>> {
+    return this.apiBaseService.get(
+      BackendConfigurationPnPropertiesMethods.GetLinkedSites,
+      { propertyId: id }
+    );
+  }
+
+  getLinkedSitesByMultipleProperties(ids: number[]): Observable<OperationDataResult<CommonDictionaryModel[]>> {
+    return this.apiBaseService.post(
+      BackendConfigurationPnPropertiesMethods.GetLinkedSites,
+      ids
     );
   }
 }


### PR DESCRIPTION
- Added `chr-result.model.ts` and `property-folder.model.ts` to the properties folder.
- Updated `task-wizard.service.ts`:
  - Updated the `updateFilters()` method to include updating of propertyIds, folderIds, tagIds, status, and assignToIds.
- Updated `task-wizard-create-modal.component.ts`:
  - Added EventEmitter for changing property.
  - Updated the `changePropertyId()` method to emit the selected property id and reset folderId, sites, and selectedFolderName.
- Updated `task-wizard-update-modal.component.ts`:
  - Added EventEmitter for changing property.
  - Updated the `changePropertyId()` method to emit the selected property id and reset folderId, sites, and selectedFolderName.
- Updated `task-wizard-filters.component.ts`:
  - Disabled folderIds FormControl by default.