### PR TITLE
Add new field to tasks

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <OutputPath>../../../../../eform-angular-frontend/eFormAPI/eFormAPI.Web/Plugins/BackendConfiguration.Pn</OutputPath>
+      <OutputPath>../../../eFormAPI.Web/Plugins/BackendConfiguration.Pn</OutputPath>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -550,16 +550,16 @@
     <ItemGroup>
       <PackageReference Include="ChemicalsBase" Version="7.0.1" />
       <PackageReference Include="Ical.Net" Version="4.2.0" />
-      <PackageReference Include="Microting.eForm" Version="7.0.58" />
-      <PackageReference Include="Microting.EformAngularFrontendBase" Version="7.0.47" />
-      <PackageReference Include="Microting.eFormApi.BasePn" Version="7.0.49" />
+      <PackageReference Include="Microting.eForm" Version="7.0.55" />
+      <PackageReference Include="Microting.EformAngularFrontendBase" Version="7.0.46" />
+      <PackageReference Include="Microting.eFormApi.BasePn" Version="7.0.47" />
       <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />
       <PackageReference Include="Microting.EformBackendConfigurationBase" Version="7.0.53" />
-      <PackageReference Include="Microting.eFormCaseTemplateBase" Version="7.0.48" />
+      <PackageReference Include="Microting.eFormCaseTemplateBase" Version="7.0.47" />
       <PackageReference Include="Microting.HtmlToOpenXml.dll" Version="2.3.1" />
-      <PackageReference Include="Microting.ItemsPlanningBase" Version="7.0.49" />
+      <PackageReference Include="Microting.ItemsPlanningBase" Version="7.0.48" />
       <PackageReference Include="ClosedXML" Version="0.102.0" />
-      <PackageReference Include="Microting.TimePlanningBase" Version="7.0.46" />
+      <PackageReference Include="Microting.TimePlanningBase" Version="7.0.45" />
     </ItemGroup>
 
     <ItemGroup>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <OutputPath>../../../eFormAPI.Web/Plugins/BackendConfiguration.Pn</OutputPath>
+      <OutputPath>../../../../../eform-angular-frontend/eFormAPI/eFormAPI.Web/Plugins/BackendConfiguration.Pn</OutputPath>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -550,16 +550,16 @@
     <ItemGroup>
       <PackageReference Include="ChemicalsBase" Version="7.0.1" />
       <PackageReference Include="Ical.Net" Version="4.2.0" />
-      <PackageReference Include="Microting.eForm" Version="7.0.55" />
-      <PackageReference Include="Microting.EformAngularFrontendBase" Version="7.0.46" />
-      <PackageReference Include="Microting.eFormApi.BasePn" Version="7.0.47" />
+      <PackageReference Include="Microting.eForm" Version="7.0.58" />
+      <PackageReference Include="Microting.EformAngularFrontendBase" Version="7.0.47" />
+      <PackageReference Include="Microting.eFormApi.BasePn" Version="7.0.49" />
       <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />
-      <PackageReference Include="Microting.EformBackendConfigurationBase" Version="7.0.51" />
-      <PackageReference Include="Microting.eFormCaseTemplateBase" Version="7.0.47" />
+      <PackageReference Include="Microting.EformBackendConfigurationBase" Version="7.0.53" />
+      <PackageReference Include="Microting.eFormCaseTemplateBase" Version="7.0.48" />
       <PackageReference Include="Microting.HtmlToOpenXml.dll" Version="2.3.1" />
-      <PackageReference Include="Microting.ItemsPlanningBase" Version="7.0.48" />
+      <PackageReference Include="Microting.ItemsPlanningBase" Version="7.0.49" />
       <PackageReference Include="ClosedXML" Version="0.102.0" />
-      <PackageReference Include="Microting.TimePlanningBase" Version="7.0.45" />
+      <PackageReference Include="Microting.TimePlanningBase" Version="7.0.46" />
     </ItemGroup>
 
     <ItemGroup>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -550,16 +550,16 @@
     <ItemGroup>
       <PackageReference Include="ChemicalsBase" Version="7.0.1" />
       <PackageReference Include="Ical.Net" Version="4.2.0" />
-      <PackageReference Include="Microting.eForm" Version="7.0.55" />
-      <PackageReference Include="Microting.EformAngularFrontendBase" Version="7.0.46" />
-      <PackageReference Include="Microting.eFormApi.BasePn" Version="7.0.47" />
+      <PackageReference Include="Microting.eForm" Version="7.0.58" />
+      <PackageReference Include="Microting.EformAngularFrontendBase" Version="7.0.47" />
+      <PackageReference Include="Microting.eFormApi.BasePn" Version="7.0.49" />
       <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />
       <PackageReference Include="Microting.EformBackendConfigurationBase" Version="7.0.53" />
-      <PackageReference Include="Microting.eFormCaseTemplateBase" Version="7.0.47" />
+      <PackageReference Include="Microting.eFormCaseTemplateBase" Version="7.0.48" />
       <PackageReference Include="Microting.HtmlToOpenXml.dll" Version="2.3.1" />
-      <PackageReference Include="Microting.ItemsPlanningBase" Version="7.0.48" />
+      <PackageReference Include="Microting.ItemsPlanningBase" Version="7.0.49" />
       <PackageReference Include="ClosedXML" Version="0.102.0" />
-      <PackageReference Include="Microting.TimePlanningBase" Version="7.0.45" />
+      <PackageReference Include="Microting.TimePlanningBase" Version="7.0.46" />
     </ItemGroup>
 
     <ItemGroup>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -657,7 +657,7 @@ namespace BackendConfiguration.Pn
                                     new()
                                     {
                                         LocaleName = LocaleNames.Ukrainian,
-                                        Name = "працівників",
+                                        Name = "Працівники",
                                         Language = LanguageNames.Ukrainian
                                     }
                                 }
@@ -685,7 +685,7 @@ namespace BackendConfiguration.Pn
                                 new()
                                 {
                                     LocaleName = LocaleNames.Ukrainian,
-                                    Name = "працівників",
+                                    Name = "Працівники",
                                     Language = LanguageNames.Ukrainian
                                 }
                             }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/TaskWizard/TaskWizardCreateModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/TaskWizard/TaskWizardCreateModel.cs
@@ -10,6 +10,7 @@ public class TaskWizardCreateModel
     public int Id { get; set; }
     public int PropertyId { get; set; }
     public int FolderId { get; set; }
+    public int? ItemPlanningTagId { get; set; }
     public List<int> TagIds { get; set; } = new();
     public List<CommonTranslationsModel> Translates { get; set; } = new();
     public int EformId { get; set; }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/TaskWizard/TaskWizardTaskModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/TaskWizard/TaskWizardTaskModel.cs
@@ -10,6 +10,7 @@ public class TaskWizardTaskModel
     public int Id { get; set; }
     public int PropertyId { get; set; }
     public int FolderId { get; set; }
+    public int? ItemPlanningTagId { get; set; }
     public List<int> Tags { get; set; } = new();
     public List<CommonTranslationsModel> Translations { get; set; } = new();
     public int EformId { get; set; }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskWizardService/BackendConfigurationTaskWizardService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskWizardService/BackendConfigurationTaskWizardService.cs
@@ -258,6 +258,7 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                     x.RepeatType,
                     x.Status,
                     x.PropertyId,
+                    x.ItemPlanningTagId,
                     TaskNames = x.AreaRule.AreaRuleTranslations
                         .Select(y => new CommonTranslationsModel()
                             { Id = y.Id, LanguageId = y.LanguageId, Name = y.Name })
@@ -302,6 +303,7 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                     RepeatEvery = (int)areaRule.RepeatEvery,
                     StartDate = (DateTime)areaRule.StartDate,
                     RepeatType = (RepeatType)areaRule.RepeatType,
+                    ItemPlanningTagId = areaRule.ItemPlanningTagId,
                     Status = areaRule.Status ? TaskWizardStatuses.Active : TaskWizardStatuses.NotActive,
                     Tags = planning.PlanningsTags
                         .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
@@ -432,6 +434,7 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                         RepeatEvery = createModel.RepeatEvery,
                         RepeatType = (int?)createModel.RepeatType,
                         PropertyId = createModel.PropertyId,
+                        ItemPlanningTagId = createModel.ItemPlanningTagId,
                         UpdatedByUserId = _userService.UserId,
                         CreatedByUserId = _userService.UserId,
                     }
@@ -496,6 +499,7 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
             areaRulePlanning.RepeatEvery = updateModel.RepeatEvery;
             areaRulePlanning.RepeatType = (int?)updateModel.RepeatType;
             areaRulePlanning.PropertyId = updateModel.PropertyId;
+            areaRulePlanning.ItemPlanningTagId = updateModel.ItemPlanningTagId;
             areaRulePlanning.UpdatedByUserId = _userService.UserId;
             await areaRulePlanning.Update(_backendConfigurationPnDbContext);
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/task-wizard/task-wizard-create.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/task-wizard/task-wizard-create.model.ts
@@ -4,6 +4,7 @@ import {RepeatTypeEnum, TaskWizardStatusesEnum} from '../../enums';
 export interface TaskWizardCreateModel {
   propertyId: number,
   folderId: number,
+  itemPlanningTagId: number,
   tagIds: number[],
   translates: CommonTranslationsModel[],
   eformId: number,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/task-wizard/task-wizard-task.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/task-wizard/task-wizard-task.model.ts
@@ -5,6 +5,7 @@ export interface TaskWizardTaskModel {
   id: number;
   propertyId: number;
   folderId: number;
+  itemPlanningTagId: number,
   tags: number[];
   translations: CommonTranslationsModel[];
   eformId: number;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-container/task-tracker-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-container/task-tracker-container.component.ts
@@ -174,6 +174,7 @@ export class TaskTrackerContainerComponent implements OnInit, OnDestroy {
             status: data.model.status,
             tagIds: data.model.tags,
             translates: data.model.translations,
+            itemPlanningTagId: data.model.itemPlanningTagId,
           });
           this.updateModal.componentInstance.typeahead.emit(data.model.eformName);
           this.updateModal.componentInstance.planningTagsModal = this.planningTagsModal;
@@ -215,6 +216,7 @@ export class TaskTrackerContainerComponent implements OnInit, OnDestroy {
               status: updateModel.status,
               tagIds: updateModel.tagIds,
               translates: data.model.translations,
+              itemPlanningTagId: data.model.itemPlanningTagId,
             }, this.updateModal);
           });
         }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-create-modal/task-wizard-create-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-create-modal/task-wizard-create-modal.component.html
@@ -29,7 +29,29 @@
       [disabled]="true"
     >
   </mat-form-field>
-
+  <mat-form-field>
+    <mat-label>{{ 'Table tag' | translate }}</mat-label>
+    <mtx-select
+      [items]="tags"
+      [bindValue]="'id'"
+      [bindLabel]="'name'"
+      id="createTableTags"
+      [value]="model.itemPlanningTagId"
+      (change)="changePlanningTagId($event)"
+      [clearable]="true"
+      [multiple]="false"
+    />
+    <button
+      matSuffix
+      mat-icon-button
+      color="primary"
+      id="planningManageTagsBtn1"
+      (click)="openTagsModal()"
+      matTooltip="{{ 'Manage tags' | translate }}"
+    >
+      <mat-icon>discount</mat-icon>
+    </button>
+  </mat-form-field>
   <mat-form-field>
     <mat-label>{{ 'Tags' | translate }}</mat-label>
     <mtx-select
@@ -46,7 +68,7 @@
       matSuffix
       mat-icon-button
       color="primary"
-      id="planningManageTagsBtn"
+      id="planningManageTagsBtn2"
       (click)="openTagsModal()"
       matTooltip="{{ 'Manage tags' | translate }}"
     >

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-create-modal/task-wizard-create-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-create-modal/task-wizard-create-modal.component.ts
@@ -65,9 +65,10 @@ export class TaskWizardCreateModalComponent implements OnInit, OnDestroy {
     propertyId: null,
     repeatEvery: null,
     repeatType: null,
-    sites: [],
+    itemPlanningTagId: null,
     startDate: null,
     status: TaskWizardStatusesEnum.Active,
+    sites: [],
     tagIds: [],
     translates: []
   };
@@ -168,6 +169,10 @@ export class TaskWizardCreateModalComponent implements OnInit, OnDestroy {
 
   changeTagIds(tags: SharedTagModel[]) {
     this.model.tagIds = tags.map(x => x.id);
+  }
+
+  changePlanningTagId(tag: SharedTagModel) {
+    this.model.itemPlanningTagId = tag.id;
   }
 
   /*updateLanguageModel(translationsModel: CommonTranslationsModel, index: number) {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-update-modal/task-wizard-update-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-update-modal/task-wizard-update-modal.component.html
@@ -30,6 +30,29 @@
     >
   </mat-form-field>
   <mat-form-field>
+    <mat-label>{{ 'Table tag' | translate }}</mat-label>
+    <mtx-select
+      [items]="tags"
+      [bindValue]="'id'"
+      [bindLabel]="'name'"
+      id="updateTableTags"
+      [value]="model.itemPlanningTagId"
+      (change)="changePlanningTagId($event)"
+      [clearable]="true"
+      [multiple]="false"
+    />
+    <button
+      matSuffix
+      mat-icon-button
+      color="primary"
+      id="planningManageTagsBtn1"
+      (click)="openTagsModal()"
+      matTooltip="{{ 'Manage tags' | translate }}"
+    >
+      <mat-icon>discount</mat-icon>
+    </button>
+  </mat-form-field>
+  <mat-form-field>
     <mat-label>{{ 'Tags' | translate }}</mat-label>
     <mtx-select
       [items]="tags"
@@ -45,7 +68,7 @@
       matSuffix
       mat-icon-button
       color="primary"
-      id="planningManageTagsBtn"
+      id="planningManageTagsBtn2"
       (click)="openTagsModal()"
       matTooltip="{{ 'Manage tags' | translate }}"
     >

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-update-modal/task-wizard-update-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-update-modal/task-wizard-update-modal.component.ts
@@ -66,9 +66,10 @@ export class TaskWizardUpdateModalComponent implements OnInit, OnDestroy {
     propertyId: null,
     repeatEvery: null,
     repeatType: null,
-    sites: [],
+    itemPlanningTagId: null,
     startDate: null,
     status: TaskWizardStatusesEnum.Active,
+    sites: [],
     tagIds: [],
     translates: []
   };
@@ -172,6 +173,10 @@ export class TaskWizardUpdateModalComponent implements OnInit, OnDestroy {
 
   changeTagIds(tags: SharedTagModel[]) {
     this.model.tagIds = tags.map(x => x.id);
+  }
+
+  changePlanningTagId(tag: SharedTagModel) {
+    this.model.itemPlanningTagId = tag.id;
   }
 
   /*updateLanguageModel(translationsModel: CommonTranslationsModel, index: number) {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-page/task-wizard-page.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-page/task-wizard-page.component.ts
@@ -161,6 +161,7 @@ export class TaskWizardPageComponent implements OnInit, OnDestroy, AfterViewInit
             status: data.model.status,
             tagIds: data.model.tags,
             translates: data.model.translations,
+            itemPlanningTagId: data.model.itemPlanningTagId,
           });
           this.updateModal.componentInstance.typeahead.emit(model.eform);
           this.updateModal.componentInstance.planningTagsModal = this.planningTagsModal;
@@ -202,6 +203,7 @@ export class TaskWizardPageComponent implements OnInit, OnDestroy, AfterViewInit
               status: updateModel.status,
               tagIds: updateModel.tagIds,
               translates: updateModel.translates,
+              itemPlanningTagId: updateModel.itemPlanningTagId,
             }, this.updateModal);
           });
         }
@@ -225,6 +227,7 @@ export class TaskWizardPageComponent implements OnInit, OnDestroy, AfterViewInit
             status: data.model.status,
             tagIds: data.model.tags,
             translates: data.model.translations,
+            itemPlanningTagId: data.model.itemPlanningTagId,
           };
           this.createModal.componentInstance.typeahead.emit(model.eform);
           this.createModal.componentInstance.planningTagsModal = this.planningTagsModal;


### PR DESCRIPTION
Added a new field called "itemPlanningTagId" to the TaskWizardCreateModel and TaskWizardTaskModel interfaces. This field is used to store the ID of a planning tag associated with a task. The "itemPlanningTagId" field was also added to the create and update modals in the TaskTrackerContainerComponent, TaskWizardCreateModalComponent, and TaskWizardUpdateModalComponent. Additionally, the "itemPlanningTagId" field was included in the data passed to the create and update modals in the TaskWizardPageComponent.