### PR TITLE
Fix incorrect button ID in task wizard edit spec

### DIFF
--- a/eform-client/cypress/e2e/plugins/backend-configuration-pn/c/task-wizard.edit.spec.cy.ts
+++ b/eform-client/cypress/e2e/plugins/backend-configuration-pn/c/task-wizard.edit.spec.cy.ts
@@ -149,7 +149,7 @@ describe('Area rules type 1', () => {
     selectValueInNgSelectorNoSelector(`${property2.cvrNumber} - ${property2.chrNumber} - ${property2.name}`);
     cy.wait('@getFolders', { timeout: 60000 });
     cy.wait(1000);
-    cy.get('app-task-wizard-update-modal button#createFolder').click();// must be #updateFolder
+    cy.get('app-task-wizard-update-modal button#updateFolder').click();
     cy.wait(500);
     cy.get('.mat-tree-node > .mat-focus-indicator > .mat-button-wrapper > .mat-icon').click();
     cy.wait(500);


### PR DESCRIPTION
The commit fixes an issue where the wrong button ID was being used in the task wizard edit spec. The incorrect ID was replaced with the correct one to ensure proper functionality.
