### PR TITLE
feat(grpc): user-scoped gRPC layer for calendar + properties (Flutter)

### DIFF
--- a/docs/superpowers/specs/2026-04-15-calendar-grpc-layer-design.md
+++ b/docs/superpowers/specs/2026-04-15-calendar-grpc-layer-design.md
@@ -1,0 +1,265 @@
+# Backend-Configuration gRPC Layer for Calendar + Properties (Flutter)
+
+## Context
+
+The Flutter mobile app needs to consume 3 existing backend-configuration REST
+endpoints over gRPC so it can use generated models and streaming-friendly
+transport instead of JSON. The endpoints must also enforce a property-worker
+scoping rule: a user (identified by SDK site id) can only see properties they
+are assigned to via `PropertyWorker`, and can only query tasks/boards for those
+properties.
+
+Endpoints to expose:
+
+1. `POST /api/backend-configuration-pn/calendar/tasks/week`
+2. `GET /api/backend-configuration-pn/properties/dictionary?fullNames=false`
+3. `GET /api/backend-configuration-pn/calendar/boards/{propertyId}`
+
+The pattern to mirror is the existing gRPC layer in
+`eform-angular-timeplanning-plugin` (server-side only, C# + `.proto`, consumed
+by the same Flutter client).
+
+User decisions (captured):
+- **Server-side only** (no Angular client work). Flutter consumes it.
+- **Keep `propertyId` on tasks/week and boards**; server rejects with
+  `PERMISSION_DENIED` when the caller's site id has no `PropertyWorker` row for
+  that property.
+- **Properties dictionary** naturally returns only the caller's accessible
+  properties (no `propertyId` input).
+
+## Files to modify
+
+All paths are relative to
+`/home/rene/Documents/workspace/microting/eform-backendconfiguration-plugin/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/`.
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `Protos/common.proto` | Shared messages: `OperationResult`, `Empty`. Matches timeplanning's `common.proto`. |
+| `Protos/calendar.proto` | `BackendConfigurationCalendarService` with `GetTasksForWeek` + `GetBoards` RPCs, plus their request/response/item messages. |
+| `Protos/properties.proto` | `BackendConfigurationPropertiesService` with `GetCommonDictionary` RPC and its messages. |
+| `Services/GrpcServices/CalendarGrpcService.cs` | Server implementation of `BackendConfigurationCalendarService.BackendConfigurationCalendarServiceBase`. Injects `IBackendConfigurationCalendarService` + the new access-check helper. |
+| `Services/GrpcServices/PropertiesGrpcService.cs` | Server implementation of `BackendConfigurationPropertiesService.BackendConfigurationPropertiesServiceBase`. Injects `IBackendConfigurationPropertiesService` + the helper. |
+| `Services/UserPropertyAccess/IBackendConfigurationUserPropertyAccess.cs` | Interface for the access helper. |
+| `Services/UserPropertyAccess/BackendConfigurationUserPropertyAccess.cs` | Implementation — given `sdkSiteId`, returns `List<int>` of property ids where the caller has a non-removed `PropertyWorker` row, and a `HasAccessAsync(sdkSiteId, propertyId)` check. |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `BackendConfiguration.Pn.csproj` | Add `Grpc.AspNetCore 2.76.0`, `Google.Protobuf 3.34.1`, and `<Protobuf Include="Protos/*.proto" GrpcServices="Server" ProtoRoot="Protos" />` items. Match versions used in `TimePlanning.Pn.csproj` (lines 35, 39-47, 50). |
+| `EformBackendConfigurationPlugin.cs` | In `ConfigureServices`: `services.AddGrpc();` plus DI registrations for `IBackendConfigurationUserPropertyAccess` and the 2 gRPC services. In `Configure` (or the endpoint mapper used by the host): `endpoints.MapGrpcService<CalendarGrpcService>();` and `endpoints.MapGrpcService<PropertiesGrpcService>();`. Mirror `EformTimePlanningPlugin.cs` lines 95 and 215-224. |
+
+## Proto design (high level)
+
+### `common.proto`
+```proto
+syntax = "proto3";
+package backend_configuration;
+option csharp_namespace = "BackendConfiguration.Pn.Grpc";
+
+message OperationResult { bool success = 1; string message = 2; }
+message Empty {}
+```
+
+### `properties.proto` — replaces `GET /properties/dictionary`
+```proto
+service BackendConfigurationPropertiesService {
+  rpc GetCommonDictionary(GetCommonDictionaryRequest) returns (GetCommonDictionaryResponse);
+}
+
+message GetCommonDictionaryRequest {
+  int32 sdk_site_id = 1;
+  bool full_names = 2;
+}
+
+message CommonDictionaryItem {
+  int32 id = 1;
+  string name = 2;
+  string description = 3;
+}
+
+message GetCommonDictionaryResponse {
+  bool success = 1;
+  string message = 2;
+  repeated CommonDictionaryItem items = 3;
+}
+```
+
+### `calendar.proto` — replaces tasks/week + boards
+```proto
+service BackendConfigurationCalendarService {
+  rpc GetTasksForWeek(GetTasksForWeekRequest) returns (GetTasksForWeekResponse);
+  rpc GetBoards(GetBoardsRequest) returns (GetBoardsResponse);
+}
+
+message GetTasksForWeekRequest {
+  int32 sdk_site_id = 1;
+  int32 property_id = 2;
+  string week_start = 3;               // ISO-8601 yyyy-MM-dd
+  string week_end = 4;                 // ISO-8601 yyyy-MM-dd
+  repeated int32 board_ids = 5;
+  repeated string tag_names = 6;
+  repeated int32 site_ids = 7;         // optional assignee filter
+}
+
+message CalendarTaskItem {             // mirrors CalendarTaskResponseModel
+  int32 id = 1;
+  string title = 2;
+  int32 start_hour = 3;
+  int32 duration = 4;
+  string task_date = 5;                // ISO-8601
+  repeated string tags = 6;
+  repeated int32 assignee_ids = 7;
+  int32 board_id = 8;
+  string color = 9;
+  string repeat_type = 10;
+  int32 repeat_every = 11;
+  bool completed = 12;
+  int32 property_id = 13;
+  int32 compliance_id = 14;
+  bool is_from_compliance = 15;
+  string deadline = 16;                // ISO-8601 (nullable via empty string)
+  string next_execution_time = 17;     // ISO-8601
+  int32 planning_id = 18;
+  bool is_all_day = 19;
+  int32 exception_id = 20;
+}
+
+message GetTasksForWeekResponse {
+  bool success = 1;
+  string message = 2;
+  repeated CalendarTaskItem tasks = 3;
+}
+
+message GetBoardsRequest {
+  int32 sdk_site_id = 1;
+  int32 property_id = 2;
+}
+
+message CalendarBoardItem {            // mirrors CalendarBoardModel
+  int32 id = 1;
+  string name = 2;
+  string color = 3;
+  int32 property_id = 4;
+}
+
+message GetBoardsResponse {
+  bool success = 1;
+  string message = 2;
+  repeated CalendarBoardItem boards = 3;
+}
+```
+
+Field ordering in `CalendarTaskItem` must match the REST DTO at
+`Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs`. Same for
+`CalendarBoardItem` vs `CalendarBoardModel.cs`. Keep field numbers stable once
+shipped (never renumber).
+
+## User-scoping helper — `BackendConfigurationUserPropertyAccess`
+
+Reuses the existing query pattern found in
+`Services/BackendConfigurationAreaRulePlanningsService/BackendConfigurationAreaRulePlanningsService.cs`
+lines 144-147 and
+`Services/BackendConfigurationAssignmentWorkerService/BackendConfigurationAssignmentWorkerService.cs`
+lines 486-489:
+
+```csharp
+var propertyIds = await _dbContext.PropertyWorkers
+    .Where(x => x.WorkerId == sdkSiteId
+             && x.WorkflowState != Constants.WorkflowStates.Removed)
+    .Select(x => x.PropertyId)
+    .ToListAsync();
+```
+
+Interface:
+```csharp
+public interface IBackendConfigurationUserPropertyAccess
+{
+    Task<List<int>> GetAccessiblePropertyIdsAsync(int sdkSiteId);
+    Task<bool> HasAccessAsync(int sdkSiteId, int propertyId);
+}
+```
+
+Registered as `Transient`. The `sdkSiteId` comes from the gRPC request message
+(same pattern as timeplanning's `request.SdkSiteId` in
+`TimePlanningWorkingHoursGrpcService.cs` line 20). This is consistent with how
+the Flutter app already authenticates in timeplanning.
+
+## gRPC service method wiring
+
+### `PropertiesGrpcService.GetCommonDictionary`
+1. Call `IBackendConfigurationPropertiesService.GetCommonDictionary(request.FullNames)` — existing method at `Services/BackendConfigurationPropertiesService/BackendConfigurationPropertiesService.cs` lines 482-504.
+2. Intersect the returned list with `GetAccessiblePropertyIdsAsync(request.SdkSiteId)` (match on `CommonDictionaryModel.Id`).
+3. Map to `CommonDictionaryItem` and return.
+
+### `CalendarGrpcService.GetTasksForWeek`
+1. If `!await HasAccessAsync(request.SdkSiteId, request.PropertyId)` → throw `RpcException(new Status(StatusCode.PermissionDenied, "No access to property"))`.
+2. Build a `CalendarTaskRequestModel` from the request fields (parse `week_start` / `week_end` with `DateTime.ParseExact(..., "yyyy-MM-dd", CultureInfo.InvariantCulture)`; empty string → null for optional assignee filter).
+3. Call `IBackendConfigurationCalendarService.GetTasksForWeek(model)` — existing method at `Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs` lines 34-361.
+4. On `OperationDataResult.Success`, project each `CalendarTaskResponseModel` to `CalendarTaskItem` (use empty strings for null DateTimes).
+5. On failure, return a response with `success = false` + `message = result.Message`.
+
+### `CalendarGrpcService.GetBoards`
+1. Access check as above.
+2. Call `IBackendConfigurationCalendarService.GetBoards(request.PropertyId)` — existing method at `Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs` lines 846-891.
+3. Project `List<CalendarBoardModel>` → `repeated CalendarBoardItem`.
+
+All 3 methods follow the timeplanning "thin wrapper" pattern: `GrpcService →
+existing business service → convert DTOs`. No new business logic.
+
+## Registration (EformBackendConfigurationPlugin.cs)
+
+Mirror `EformTimePlanningPlugin.cs`:
+
+**In `ConfigureServices`** (next to other `services.AddTransient<...>` calls):
+```csharp
+services.AddGrpc();
+services.AddTransient<IBackendConfigurationUserPropertyAccess, BackendConfigurationUserPropertyAccess>();
+// No separate DI needed for the gRPC service classes — AddGrpc + MapGrpcService handles them.
+```
+
+**In `Configure`** (alongside existing endpoint wiring):
+```csharp
+endpoints.MapGrpcService<CalendarGrpcService>();
+endpoints.MapGrpcService<PropertiesGrpcService>();
+```
+
+## Naming conventions to follow (from timeplanning)
+
+- Proto package: `backend_configuration` (snake_case).
+- C# namespace: `BackendConfiguration.Pn.Grpc`.
+- Service names in proto: `BackendConfigurationCalendarService`, `BackendConfigurationPropertiesService`.
+- Implementation class suffix: `GrpcService` (e.g. `CalendarGrpcService`).
+- Field names in proto: `snake_case`; messages: `PascalCase`.
+
+## Verification
+
+1. **Build** — from the plugin root: `dotnet build BackendConfiguration.Pn.sln`. Expect protoc to generate C# stubs under `obj/Debug/net*/Protos/` with no errors.
+2. **Unit test**: add a focused test for `BackendConfigurationUserPropertyAccess.GetAccessiblePropertyIdsAsync` seeding 2 properties + 1 PropertyWorker row for site 7; call with `sdkSiteId=7` and assert exactly 1 property id returned, then call with `sdkSiteId=99` and assert empty list.
+3. **Manual gRPC smoke** — start the eFormAPI host, use `grpcurl` against `localhost:<port>`:
+   ```
+   grpcurl -plaintext -d '{"sdk_site_id":<known>,"full_names":false}' \
+     localhost:<port> backend_configuration.BackendConfigurationPropertiesService/GetCommonDictionary
+   ```
+   Expect only properties that seed `PropertyWorker` with the same site id.
+4. **Access-denied check** — call `GetBoards` with a `property_id` the site is not assigned to; expect `Code: PermissionDenied`.
+5. **Parity check against REST** — for an accessible property, call the gRPC `GetTasksForWeek` and the REST `POST /calendar/tasks/week` with equivalent payloads; response task counts and fields must match.
+
+## Out of scope
+
+- Angular frontend changes (separate effort; REST remains for the web client).
+- Any new business logic in calendar/properties services (just wrapping).
+- Proto changes for endpoints we're not exposing (tags, employees, teams, etc.) — follow-up if Flutter needs them.
+- Authentication/token changes — inherits the same ASP.NET Core middleware that timeplanning's gRPC services already rely on.
+
+## Build sequence
+
+1. Create the 3 proto files.
+2. Add the two `PackageReference`s and `Protobuf` items to the csproj; `dotnet build` to verify stubs generate.
+3. Create the access-helper interface + implementation + unit test.
+4. Create the two `GrpcService` implementations.
+5. Wire `services.AddGrpc()`, DI for the helper, and `MapGrpcService<>()` in `EformBackendConfigurationPlugin.cs`.
+6. Manual smoke with `grpcurl` (step 3 + 4 of Verification).
+7. Commit on a new feat branch `feat/calendar-grpc` off `stable`; PR to `stable`.

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/BackendConfiguration.Pn.Test.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/BackendConfiguration.Pn.Test.csproj
@@ -18,6 +18,7 @@
       <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
       <PackageReference Include="Testcontainers" Version="4.11.0" />
       <PackageReference Include="Testcontainers.MariaDb" Version="4.11.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/UserPropertyAccess/BackendConfigurationUserPropertyAccessTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/UserPropertyAccess/BackendConfigurationUserPropertyAccessTests.cs
@@ -1,0 +1,88 @@
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Services.UserPropertyAccess;
+using Microsoft.EntityFrameworkCore;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using NUnit.Framework;
+
+namespace BackendConfiguration.Pn.Test.UserPropertyAccess;
+
+[TestFixture]
+public class BackendConfigurationUserPropertyAccessTests
+{
+    private BackendConfigurationPnDbContext NewContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<BackendConfigurationPnDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .EnableSensitiveDataLogging()
+            .Options;
+        return new BackendConfigurationPnDbContext(options);
+    }
+
+    [Test]
+    public async Task GetAccessiblePropertyIdsAsync_returns_only_properties_where_site_has_active_property_worker()
+    {
+        await using var ctx = NewContext(nameof(GetAccessiblePropertyIdsAsync_returns_only_properties_where_site_has_active_property_worker));
+        ctx.PropertyWorkers.Add(new PropertyWorker { WorkerId = 7, PropertyId = 100, WorkflowState = Constants.WorkflowStates.Created });
+        ctx.PropertyWorkers.Add(new PropertyWorker { WorkerId = 7, PropertyId = 101, WorkflowState = Constants.WorkflowStates.Removed });
+        ctx.PropertyWorkers.Add(new PropertyWorker { WorkerId = 99, PropertyId = 102, WorkflowState = Constants.WorkflowStates.Created });
+        await ctx.SaveChangesAsync();
+
+        var sut = new BackendConfigurationUserPropertyAccess(ctx);
+
+        var ids = await sut.GetAccessiblePropertyIdsAsync(7);
+
+        Assert.That(ids, Is.EquivalentTo(new[] { 100 }));
+    }
+
+    [Test]
+    public async Task GetAccessiblePropertyIdsAsync_returns_empty_for_unknown_site()
+    {
+        await using var ctx = NewContext(nameof(GetAccessiblePropertyIdsAsync_returns_empty_for_unknown_site));
+        ctx.PropertyWorkers.Add(new PropertyWorker { WorkerId = 7, PropertyId = 100, WorkflowState = Constants.WorkflowStates.Created });
+        await ctx.SaveChangesAsync();
+
+        var sut = new BackendConfigurationUserPropertyAccess(ctx);
+
+        var ids = await sut.GetAccessiblePropertyIdsAsync(42);
+
+        Assert.That(ids, Is.Empty);
+    }
+
+    [Test]
+    public async Task HasAccessAsync_true_when_active_property_worker_exists()
+    {
+        await using var ctx = NewContext(nameof(HasAccessAsync_true_when_active_property_worker_exists));
+        ctx.PropertyWorkers.Add(new PropertyWorker { WorkerId = 7, PropertyId = 100, WorkflowState = Constants.WorkflowStates.Created });
+        await ctx.SaveChangesAsync();
+
+        var sut = new BackendConfigurationUserPropertyAccess(ctx);
+
+        Assert.That(await sut.HasAccessAsync(7, 100), Is.True);
+    }
+
+    [Test]
+    public async Task HasAccessAsync_false_for_removed_property_worker()
+    {
+        await using var ctx = NewContext(nameof(HasAccessAsync_false_for_removed_property_worker));
+        ctx.PropertyWorkers.Add(new PropertyWorker { WorkerId = 7, PropertyId = 100, WorkflowState = Constants.WorkflowStates.Removed });
+        await ctx.SaveChangesAsync();
+
+        var sut = new BackendConfigurationUserPropertyAccess(ctx);
+
+        Assert.That(await sut.HasAccessAsync(7, 100), Is.False);
+    }
+
+    [Test]
+    public async Task HasAccessAsync_false_for_different_property()
+    {
+        await using var ctx = NewContext(nameof(HasAccessAsync_false_for_different_property));
+        ctx.PropertyWorkers.Add(new PropertyWorker { WorkerId = 7, PropertyId = 100, WorkflowState = Constants.WorkflowStates.Created });
+        await ctx.SaveChangesAsync();
+
+        var sut = new BackendConfigurationUserPropertyAccess(ctx);
+
+        Assert.That(await sut.HasAccessAsync(7, 999), Is.False);
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -217,24 +217,35 @@
   <ItemGroup>
     <PackageReference Include="ChemicalsBase" Version="10.0.4" />
     <PackageReference Include="Google.Apis.Sheets.v4" Version="1.73.0.4061" />
+    <PackageReference Include="Google.Protobuf" Version="3.34.1" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageReference Include="HtmlToOpenXml.dll" Version="3.3.1" />
     <PackageReference Include="Ical.Net" Version="5.2.1" />
-    <PackageReference Include="Microting.eForm" Version="10.0.17" />
-    <PackageReference Include="Microting.EformAngularFrontendBase" Version="10.0.22" />
-    <PackageReference Include="Microting.eFormApi.BasePn" Version="10.0.18" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
-    <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.23" />
-    <PackageReference Include="Microting.eFormCaseTemplateBase" Version="10.0.18" />
-    <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.18" />
-    <PackageReference Include="Microting.TimePlanningBase" Version="10.0.36" />
     <PackageReference Include="QuestPDF" Version="2026.2.4" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.2" />
     <PackageReference Include="Sentry" Version="6.3.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Protobuf Include="Protos\common.proto" GrpcServices="Server" ProtoRoot="Protos" />
+    <Protobuf Include="Protos\calendar.proto" GrpcServices="Server" ProtoRoot="Protos" />
+    <Protobuf Include="Protos\properties.proto" GrpcServices="Server" ProtoRoot="Protos" />
+  </ItemGroup>
+
     <ItemGroup>
       <EmbeddedResource Include="Resources\localization.json" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\..\..\eform-backendconfiguration-base\Microting.EformBackendConfigurationBase\Microting.EformBackendConfigurationBase.csproj" />
+      <ProjectReference Include="..\..\..\..\..\eform-angular-frontend-base\Microting.EformAngularFrontendBase\Microting.EformAngularFrontendBase.csproj" />
+      <ProjectReference Include="..\..\..\..\..\eform-items-planning-base\Microting.ItemsPlanningBase\Microting.ItemsPlanningBase.csproj" />
+      <ProjectReference Include="..\..\..\..\..\eform-timeplanning-base\Microting.TimePlanningBase\Microting.TimePlanningBase.csproj" />
+      <ProjectReference Include="..\..\..\..\..\eform-casetemplate-base\Microting.eFormCaseTemplateBase\Microting.eFormCaseTemplateBase.csproj" />
+      <ProjectReference Include="..\..\..\..\..\eFormApi.BasePn\eFormApi.BasePn\eFormApi.BasePn.csproj" />
+      <ProjectReference Include="..\..\..\..\..\eform-sdk\eFormCore\Microting.eForm.csproj" />
     </ItemGroup>
 
 </Project>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -221,17 +221,18 @@
     <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageReference Include="HtmlToOpenXml.dll" Version="3.3.1" />
     <PackageReference Include="Ical.Net" Version="5.2.1" />
+    <PackageReference Include="Microting.eForm" Version="10.0.17" />
+    <PackageReference Include="Microting.EformAngularFrontendBase" Version="10.0.22" />
+    <PackageReference Include="Microting.eFormApi.BasePn" Version="10.0.18" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
+    <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.23" />
+    <PackageReference Include="Microting.eFormCaseTemplateBase" Version="10.0.18" />
+    <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.18" />
+    <PackageReference Include="Microting.TimePlanningBase" Version="10.0.36" />
     <PackageReference Include="QuestPDF" Version="2026.2.4" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.2" />
     <PackageReference Include="Sentry" Version="6.3.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Protobuf Include="Protos\common.proto" GrpcServices="Server" ProtoRoot="Protos" />
-    <Protobuf Include="Protos\calendar.proto" GrpcServices="Server" ProtoRoot="Protos" />
-    <Protobuf Include="Protos\properties.proto" GrpcServices="Server" ProtoRoot="Protos" />
   </ItemGroup>
 
     <ItemGroup>
@@ -239,13 +240,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\..\eform-backendconfiguration-base\Microting.EformBackendConfigurationBase\Microting.EformBackendConfigurationBase.csproj" />
-      <ProjectReference Include="..\..\..\..\..\eform-angular-frontend-base\Microting.EformAngularFrontendBase\Microting.EformAngularFrontendBase.csproj" />
-      <ProjectReference Include="..\..\..\..\..\eform-items-planning-base\Microting.ItemsPlanningBase\Microting.ItemsPlanningBase.csproj" />
-      <ProjectReference Include="..\..\..\..\..\eform-timeplanning-base\Microting.TimePlanningBase\Microting.TimePlanningBase.csproj" />
-      <ProjectReference Include="..\..\..\..\..\eform-casetemplate-base\Microting.eFormCaseTemplateBase\Microting.eFormCaseTemplateBase.csproj" />
-      <ProjectReference Include="..\..\..\..\..\eFormApi.BasePn\eFormApi.BasePn\eFormApi.BasePn.csproj" />
-      <ProjectReference Include="..\..\..\..\..\eform-sdk\eFormCore\Microting.eForm.csproj" />
+      <Protobuf Include="Protos\common.proto" GrpcServices="Server" ProtoRoot="Protos" />
+      <Protobuf Include="Protos\calendar.proto" GrpcServices="Server" ProtoRoot="Protos" />
+      <Protobuf Include="Protos\properties.proto" GrpcServices="Server" ProtoRoot="Protos" />
     </ItemGroup>
 
 </Project>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -108,6 +108,9 @@ public class EformBackendConfigurationPlugin : IEformPlugin
 
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddGrpc();
+        services.AddTransient<Services.UserPropertyAccess.IBackendConfigurationUserPropertyAccess,
+            Services.UserPropertyAccess.BackendConfigurationUserPropertyAccess>();
         services.AddTransient<IBackendConfigurationAreaRulePlanningsService, BackendConfigurationAreaRulePlanningsService>();
         services.AddTransient<IBackendConfigurationAssignmentWorkerService, BackendConfigurationAssignmentWorkerService>();
         services.AddTransient<IBackendConfigurationTaskManagementService, BackendConfigurationTaskManagementService>();
@@ -746,6 +749,13 @@ public class EformBackendConfigurationPlugin : IEformPlugin
         using var scope = serviceProvider.CreateScope();
         var backfillService = scope.ServiceProvider.GetRequiredService<WorkorderCaseGroupIdBackfillService>();
         backfillService.RunIfNeededAsync().GetAwaiter().GetResult();
+
+        appBuilder.UseRouting();
+        appBuilder.UseEndpoints(endpoints =>
+        {
+            endpoints.MapGrpcService<Services.GrpcServices.CalendarGrpcService>();
+            endpoints.MapGrpcService<Services.GrpcServices.PropertiesGrpcService>();
+        });
     }
 
     public List<PluginMenuItemModel> GetNavigationMenu(IServiceProvider serviceProvider)

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/calendar.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/calendar.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package backend_configuration;
+
+option csharp_namespace = "BackendConfiguration.Pn.Grpc";
+
+service BackendConfigurationCalendarGrpc {
+  rpc GetTasksForWeek(GetTasksForWeekRequest) returns (GetTasksForWeekResponse);
+  rpc GetBoards(GetBoardsRequest) returns (GetBoardsResponse);
+}
+
+message GetTasksForWeekRequest {
+  int32 sdk_site_id = 1;
+  int32 property_id = 2;
+  string week_start = 3;               // yyyy-MM-dd
+  string week_end = 4;                 // yyyy-MM-dd
+  repeated int32 board_ids = 5;
+  repeated string tag_names = 6;
+  repeated int32 site_ids = 7;
+}
+
+message CalendarTaskItem {
+  int32 id = 1;
+  string title = 2;
+  double start_hour = 3;
+  double duration = 4;
+  string task_date = 5;
+  repeated string tags = 6;
+  repeated int32 assignee_ids = 7;
+  int32 board_id = 8;                  // 0 when null
+  string color = 9;
+  int32 repeat_type = 10;
+  int32 repeat_every = 11;
+  bool completed = 12;
+  int32 property_id = 13;
+  int32 compliance_id = 14;            // 0 when null
+  bool is_from_compliance = 15;
+  string deadline = 16;                // ISO-8601, empty when null
+  string next_execution_time = 17;     // ISO-8601, empty when null
+  int32 planning_id = 18;              // 0 when null
+  bool is_all_day = 19;
+  int32 exception_id = 20;             // 0 when null
+}
+
+message GetTasksForWeekResponse {
+  bool success = 1;
+  string message = 2;
+  repeated CalendarTaskItem tasks = 3;
+}
+
+message GetBoardsRequest {
+  int32 sdk_site_id = 1;
+  int32 property_id = 2;
+}
+
+message CalendarBoardItem {
+  int32 id = 1;
+  string name = 2;
+  string color = 3;
+  int32 property_id = 4;
+}
+
+message GetBoardsResponse {
+  bool success = 1;
+  string message = 2;
+  repeated CalendarBoardItem boards = 3;
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/common.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/common.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package backend_configuration;
+
+option csharp_namespace = "BackendConfiguration.Pn.Grpc";
+
+message OperationResult {
+  bool success = 1;
+  string message = 2;
+}
+
+message Empty {}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/properties.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/properties.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package backend_configuration;
+
+option csharp_namespace = "BackendConfiguration.Pn.Grpc";
+
+service BackendConfigurationPropertiesGrpc {
+  rpc GetCommonDictionary(GetCommonDictionaryRequest) returns (GetCommonDictionaryResponse);
+}
+
+message GetCommonDictionaryRequest {
+  int32 sdk_site_id = 1;
+  bool full_names = 2;
+}
+
+message CommonDictionaryItem {
+  int32 id = 1;
+  string name = 2;
+  string description = 3;
+}
+
+message GetCommonDictionaryResponse {
+  bool success = 1;
+  string message = 2;
+  repeated CommonDictionaryItem items = 3;
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/CalendarGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/CalendarGrpcService.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Grpc;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.UserPropertyAccess;
+using Grpc.Core;
+
+namespace BackendConfiguration.Pn.Services.GrpcServices;
+
+public class CalendarGrpcService(
+    IBackendConfigurationCalendarService calendarService,
+    IBackendConfigurationUserPropertyAccess userPropertyAccess)
+    : BackendConfigurationCalendarGrpc.BackendConfigurationCalendarGrpcBase
+{
+    private const string IsoDate = "yyyy-MM-dd";
+    private const string IsoDateTime = "yyyy-MM-ddTHH:mm:ss.fffZ";
+
+    public override async Task<GetTasksForWeekResponse> GetTasksForWeek(
+        GetTasksForWeekRequest request,
+        ServerCallContext context)
+    {
+        if (!await userPropertyAccess.HasAccessAsync(request.SdkSiteId, request.PropertyId))
+        {
+            throw new RpcException(new Status(StatusCode.PermissionDenied,
+                "Caller has no PropertyWorker access to the requested property."));
+        }
+
+        var model = new CalendarTaskRequestModel
+        {
+            PropertyId = request.PropertyId,
+            WeekStart = request.WeekStart,
+            WeekEnd = request.WeekEnd,
+            BoardIds = request.BoardIds.ToList(),
+            TagNames = request.TagNames.ToList(),
+            SiteIds = request.SiteIds.ToList()
+        };
+
+        var result = await calendarService.GetTasksForWeek(model);
+
+        var response = new GetTasksForWeekResponse
+        {
+            Success = result.Success,
+            Message = result.Message ?? string.Empty
+        };
+
+        if (!result.Success || result.Model == null)
+        {
+            return response;
+        }
+
+        foreach (var task in result.Model)
+        {
+            response.Tasks.Add(new CalendarTaskItem
+            {
+                Id = task.Id,
+                Title = task.Title ?? string.Empty,
+                StartHour = task.StartHour,
+                Duration = task.Duration,
+                TaskDate = task.TaskDate ?? string.Empty,
+                Tags = { task.Tags ?? [] },
+                AssigneeIds = { task.AssigneeIds ?? [] },
+                BoardId = task.BoardId ?? 0,
+                Color = task.Color ?? string.Empty,
+                RepeatType = task.RepeatType,
+                RepeatEvery = task.RepeatEvery,
+                Completed = task.Completed,
+                PropertyId = task.PropertyId,
+                ComplianceId = task.ComplianceId ?? 0,
+                IsFromCompliance = task.IsFromCompliance,
+                Deadline = task.Deadline?.ToString(IsoDateTime, CultureInfo.InvariantCulture) ?? string.Empty,
+                NextExecutionTime = task.NextExecutionTime?.ToString(IsoDateTime, CultureInfo.InvariantCulture) ?? string.Empty,
+                PlanningId = task.PlanningId ?? 0,
+                IsAllDay = task.IsAllDay,
+                ExceptionId = task.ExceptionId ?? 0
+            });
+        }
+
+        return response;
+    }
+
+    public override async Task<GetBoardsResponse> GetBoards(
+        GetBoardsRequest request,
+        ServerCallContext context)
+    {
+        if (!await userPropertyAccess.HasAccessAsync(request.SdkSiteId, request.PropertyId))
+        {
+            throw new RpcException(new Status(StatusCode.PermissionDenied,
+                "Caller has no PropertyWorker access to the requested property."));
+        }
+
+        var result = await calendarService.GetBoards(request.PropertyId);
+
+        var response = new GetBoardsResponse
+        {
+            Success = result.Success,
+            Message = result.Message ?? string.Empty
+        };
+
+        if (!result.Success || result.Model == null)
+        {
+            return response;
+        }
+
+        foreach (var board in result.Model)
+        {
+            response.Boards.Add(new CalendarBoardItem
+            {
+                Id = board.Id,
+                Name = board.Name ?? string.Empty,
+                Color = board.Color ?? string.Empty,
+                PropertyId = board.PropertyId
+            });
+        }
+
+        return response;
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/PropertiesGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/PropertiesGrpcService.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Grpc;
+using BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService;
+using BackendConfiguration.Pn.Services.UserPropertyAccess;
+using Grpc.Core;
+
+namespace BackendConfiguration.Pn.Services.GrpcServices;
+
+public class PropertiesGrpcService(
+    IBackendConfigurationPropertiesService propertiesService,
+    IBackendConfigurationUserPropertyAccess userPropertyAccess)
+    : BackendConfigurationPropertiesGrpc.BackendConfigurationPropertiesGrpcBase
+{
+    public override async Task<GetCommonDictionaryResponse> GetCommonDictionary(
+        GetCommonDictionaryRequest request,
+        ServerCallContext context)
+    {
+        var accessibleIds = (await userPropertyAccess
+            .GetAccessiblePropertyIdsAsync(request.SdkSiteId)).ToHashSet();
+
+        var result = await propertiesService.GetCommonDictionary(request.FullNames);
+
+        var response = new GetCommonDictionaryResponse
+        {
+            Success = result.Success,
+            Message = result.Message ?? string.Empty
+        };
+
+        if (!result.Success || result.Model == null)
+        {
+            return response;
+        }
+
+        foreach (var item in result.Model)
+        {
+            if (item.Id is null || !accessibleIds.Contains(item.Id.Value))
+            {
+                continue;
+            }
+
+            response.Items.Add(new CommonDictionaryItem
+            {
+                Id = item.Id.Value,
+                Name = item.Name ?? string.Empty,
+                Description = item.Description ?? string.Empty
+            });
+        }
+
+        return response;
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/UserPropertyAccess/BackendConfigurationUserPropertyAccess.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/UserPropertyAccess/BackendConfigurationUserPropertyAccess.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data;
+
+namespace BackendConfiguration.Pn.Services.UserPropertyAccess;
+
+public class BackendConfigurationUserPropertyAccess(BackendConfigurationPnDbContext dbContext)
+    : IBackendConfigurationUserPropertyAccess
+{
+    public Task<List<int>> GetAccessiblePropertyIdsAsync(int sdkSiteId)
+    {
+        return dbContext.PropertyWorkers
+            .Where(x => x.WorkerId == sdkSiteId
+                        && x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Select(x => x.PropertyId)
+            .Distinct()
+            .ToListAsync();
+    }
+
+    public Task<bool> HasAccessAsync(int sdkSiteId, int propertyId)
+    {
+        return dbContext.PropertyWorkers
+            .AnyAsync(x => x.WorkerId == sdkSiteId
+                           && x.PropertyId == propertyId
+                           && x.WorkflowState != Constants.WorkflowStates.Removed);
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/UserPropertyAccess/IBackendConfigurationUserPropertyAccess.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/UserPropertyAccess/IBackendConfigurationUserPropertyAccess.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BackendConfiguration.Pn.Services.UserPropertyAccess;
+
+public interface IBackendConfigurationUserPropertyAccess
+{
+    Task<List<int>> GetAccessiblePropertyIdsAsync(int sdkSiteId);
+    Task<bool> HasAccessAsync(int sdkSiteId, int propertyId);
+}


### PR DESCRIPTION
## Summary

Add server-side gRPC endpoints for the Flutter mobile client, mirroring the
pattern already in \`eform-angular-timeplanning-plugin\`. The 3 REST endpoints
used by the calendar UI are exposed over gRPC with a property-worker access
filter so a caller can only see data for properties they are assigned to.

### Services
- \`BackendConfigurationCalendarGrpc\`: \`GetTasksForWeek\`, \`GetBoards\`
- \`BackendConfigurationPropertiesGrpc\`: \`GetCommonDictionary\`

### Access control
New \`IBackendConfigurationUserPropertyAccess\` helper filters the properties
dictionary and rejects calendar/board requests with \`PermissionDenied\` when
the caller's \`sdk_site_id\` has no active \`PropertyWorker\` row for the
requested \`property_id\`. Uses the same pattern as
\`BackendConfigurationAreaRulePlanningsService\` and
\`BackendConfigurationAssignmentWorkerService\`.

### Wiring
- \`Protos/{common,calendar,properties}.proto\` (\`Server\`-only codegen)
- \`Grpc.AspNetCore 2.76.0\`, \`Google.Protobuf 3.34.1\` added to csproj
- \`services.AddGrpc()\` + DI for the helper in \`ConfigureServices\`
- \`UseRouting\` + \`MapGrpcService<>\` in \`Configure\` (after migrations)

### Tests
5 unit tests for the access helper using in-memory EF:
- Returns only non-removed PropertyWorkers
- Returns empty for unknown site
- \`HasAccessAsync\` true / false for removed / different property

No existing business logic or REST endpoints modified.

## Test plan

- [ ] \`dotnet build\` succeeds
- [ ] \`dotnet test --filter BackendConfigurationUserPropertyAccessTests\` — 5/5 pass
- [ ] Existing Playwright shards still pass (no regressions in REST layer)
- [ ] (Follow-up, not in this PR) Flutter app can connect and call the RPCs with a valid device token

🤖 Generated with [Claude Code](https://claude.com/claude-code)