### PR TITLE
feat(grpc): add templates + compliance cases gRPC endpoints (Flutter)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -243,6 +243,8 @@
       <Protobuf Include="Protos\common.proto" GrpcServices="Server" ProtoRoot="Protos" />
       <Protobuf Include="Protos\calendar.proto" GrpcServices="Server" ProtoRoot="Protos" />
       <Protobuf Include="Protos\properties.proto" GrpcServices="Server" ProtoRoot="Protos" />
+      <Protobuf Include="Protos\templates.proto" GrpcServices="Server" ProtoRoot="Protos" />
+      <Protobuf Include="Protos\compliances.proto" GrpcServices="Server" ProtoRoot="Protos" />
     </ItemGroup>
 
 </Project>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -755,6 +755,8 @@ public class EformBackendConfigurationPlugin : IEformPlugin
         {
             endpoints.MapGrpcService<Services.GrpcServices.CalendarGrpcService>();
             endpoints.MapGrpcService<Services.GrpcServices.PropertiesGrpcService>();
+            endpoints.MapGrpcService<Services.GrpcServices.TemplatesGrpcService>();
+            endpoints.MapGrpcService<Services.GrpcServices.CompliancesGrpcService>();
         });
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/compliances.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/compliances.proto
@@ -1,0 +1,105 @@
+syntax = "proto3";
+
+package backend_configuration;
+
+option csharp_namespace = "BackendConfiguration.Pn.Grpc";
+
+service BackendConfigurationCompliancesGrpc {
+  rpc ReadComplianceCase(ReadComplianceCaseRequest) returns (ReadComplianceCaseResponse);
+  rpc UpdateComplianceCase(UpdateComplianceCaseRequest) returns (UpdateComplianceCaseResponse);
+}
+
+// ─── Read ───
+
+message ReadComplianceCaseRequest {
+  int32 sdk_site_id = 1;
+  int32 case_id = 2;
+  int32 template_id = 3;
+  int32 extra_id = 4;           // compliance DB ID for access check
+}
+
+message DataItemInfo {
+  int32 id = 1;
+  string label = 2;
+  string description = 3;
+  string field_type = 4;
+  string value = 5;
+  bool mandatory = 6;
+  bool read_only = 7;
+  string color = 8;
+  int32 display_order = 9;
+}
+
+message DataItemGroupInfo {
+  int32 id = 1;
+  string label = 2;
+  string description = 3;
+  string color = 4;
+  int32 display_order = 5;
+  repeated DataItemInfo data_items = 6;
+}
+
+message ReplyElementItem {
+  int32 id = 1;
+  string label = 2;
+  string status = 3;
+  repeated DataItemInfo data_items = 4;
+  repeated DataItemGroupInfo data_item_groups = 5;
+  repeated ReplyElementItem element_list = 6;
+}
+
+message ReadComplianceCaseResponse {
+  bool success = 1;
+  string message = 2;
+  int32 id = 3;
+  string label = 4;
+  string done_at = 5;
+  int32 done_by_id = 6;
+  int32 unit_id = 7;
+  repeated ReplyElementItem element_list = 8;
+}
+
+// ─── Update ───
+
+message CaseEditFieldValue {
+  int32 field_id = 1;
+  string value = 2;
+  string field_type = 3;
+}
+
+message CaseEditField {
+  string field_type = 1;
+  repeated CaseEditFieldValue field_values = 2;
+}
+
+message CaseEditGroupField {
+  int32 id = 1;
+  string label = 2;
+  string description = 3;
+  string color = 4;
+  int32 display_order = 5;
+  repeated CaseEditField fields = 6;
+}
+
+message CaseEditElement {
+  int32 id = 1;
+  string status = 2;
+  repeated CaseEditField fields = 3;
+  repeated CaseEditGroupField group_fields = 4;
+  repeated CaseEditElement element_list = 5;
+}
+
+message UpdateComplianceCaseRequest {
+  int32 sdk_site_id = 1;
+  int32 id = 2;
+  string label = 3;
+  string done_at = 4;
+  int32 extra_id = 5;
+  int32 site_id = 6;
+  repeated CaseEditElement element_list = 7;
+}
+
+message UpdateComplianceCaseResponse {
+  bool success = 1;
+  string message = 2;
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/templates.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/templates.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package backend_configuration;
+
+option csharp_namespace = "BackendConfiguration.Pn.Grpc";
+
+service BackendConfigurationTemplatesGrpc {
+  rpc GetTemplate(GetTemplateRequest) returns (GetTemplateResponse);
+}
+
+message GetTemplateRequest {
+  int32 sdk_site_id = 1;
+  int32 template_id = 2;
+  int32 language_id = 3;
+}
+
+message TemplateFieldDto {
+  int32 id = 1;
+  string label = 2;
+  string description = 3;
+  string field_type = 4;
+  int32 field_type_id = 5;
+  string color = 6;
+}
+
+message TemplateTagItem {
+  int32 id = 1;
+  string name = 2;
+}
+
+message TemplateItem {
+  int32 id = 1;
+  string created_at = 2;
+  string updated_at = 3;
+  string label = 4;
+  string description = 5;
+  int32 repeated = 6;
+  string folder_name = 7;
+  string workflow_state = 8;
+  bool has_cases = 9;
+  int32 display_index = 10;
+  int32 folder_id = 11;
+  bool jasper_export_enabled = 12;
+  bool docx_export_enabled = 13;
+  bool excel_export_enabled = 14;
+  string report_h1 = 15;
+  string report_h2 = 16;
+  string report_h3 = 17;
+  string report_h4 = 18;
+  string report_h5 = 19;
+  bool is_locked = 20;
+  bool is_editable = 21;
+  bool is_hidden = 22;
+  bool is_achievable = 23;
+  bool is_done_at_editable = 24;
+  repeated TemplateTagItem tags = 25;
+  TemplateFieldDto field1 = 26;
+  TemplateFieldDto field2 = 27;
+  TemplateFieldDto field3 = 28;
+  TemplateFieldDto field4 = 29;
+  TemplateFieldDto field5 = 30;
+  TemplateFieldDto field6 = 31;
+  TemplateFieldDto field7 = 32;
+  TemplateFieldDto field8 = 33;
+  TemplateFieldDto field9 = 34;
+  TemplateFieldDto field10 = 35;
+}
+
+message GetTemplateResponse {
+  bool success = 1;
+  string message = 2;
+  TemplateItem template = 3;
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/CompliancesGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/CompliancesGrpcService.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Grpc;
+using BackendConfiguration.Pn.Services.UserPropertyAccess;
+using Grpc.Core;
+using Microsoft.EntityFrameworkCore;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Models;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Helpers;
+using Microting.eFormApi.BasePn.Infrastructure.Models.Application.Case.CaseEdit;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data;
+
+namespace BackendConfiguration.Pn.Services.GrpcServices;
+
+public class CompliancesGrpcService(
+    IEFormCoreService coreHelper,
+    IBackendConfigurationUserPropertyAccess userPropertyAccess,
+    BackendConfigurationPnDbContext dbContext)
+    : BackendConfigurationCompliancesGrpc.BackendConfigurationCompliancesGrpcBase
+{
+    public override async Task<ReadComplianceCaseResponse> ReadComplianceCase(
+        ReadComplianceCaseRequest request,
+        ServerCallContext context)
+    {
+        if (request.ExtraId > 0)
+        {
+            var compliance = await dbContext.Compliances
+                .FirstOrDefaultAsync(x => x.Id == request.ExtraId)
+                .ConfigureAwait(false);
+
+            if (compliance != null &&
+                !await userPropertyAccess.HasAccessAsync(request.SdkSiteId, compliance.PropertyId)
+                    .ConfigureAwait(false))
+            {
+                throw new RpcException(new Status(StatusCode.PermissionDenied,
+                    "Caller has no PropertyWorker access to the compliance's property."));
+            }
+        }
+
+        var core = await coreHelper.GetCore().ConfigureAwait(false);
+        var sdkDbContext = core.DbContextHelper.GetDbContext();
+        var language = await sdkDbContext.Languages
+            .FirstAsync()
+            .ConfigureAwait(false);
+
+        ReplyElement theCase;
+        try
+        {
+            theCase = await core.CaseRead(request.CaseId, language).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            return new ReadComplianceCaseResponse { Success = false, Message = ex.Message };
+        }
+
+        if (theCase == null)
+        {
+            return new ReadComplianceCaseResponse { Success = false, Message = "Case not found" };
+        }
+
+        var response = new ReadComplianceCaseResponse
+        {
+            Success = true,
+            Message = string.Empty,
+            Id = theCase.Id,
+            Label = theCase.Label ?? string.Empty,
+            DoneAt = theCase.DoneAt.ToString("O", CultureInfo.InvariantCulture),
+            DoneById = theCase.DoneById,
+            UnitId = theCase.UnitId
+        };
+
+        foreach (var element in theCase.ElementList)
+        {
+            response.ElementList.Add(MapElement(element));
+        }
+
+        return response;
+    }
+
+    public override async Task<UpdateComplianceCaseResponse> UpdateComplianceCase(
+        UpdateComplianceCaseRequest request,
+        ServerCallContext context)
+    {
+        var compliance = await dbContext.Compliances
+            .SingleOrDefaultAsync(x => x.Id == request.ExtraId)
+            .ConfigureAwait(false);
+
+        if (compliance == null)
+        {
+            return new UpdateComplianceCaseResponse { Success = false, Message = "Compliance not found" };
+        }
+
+        if (!await userPropertyAccess.HasAccessAsync(request.SdkSiteId, compliance.PropertyId)
+                .ConfigureAwait(false))
+        {
+            throw new RpcException(new Status(StatusCode.PermissionDenied,
+                "Caller has no PropertyWorker access to the compliance's property."));
+        }
+
+        var replyRequest = new ReplyRequest
+        {
+            Id = request.Id,
+            Label = request.Label,
+            DoneAt = DateTime.TryParse(request.DoneAt, CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind, out var doneAt)
+                ? doneAt
+                : DateTime.UtcNow,
+            ExtraId = request.ExtraId,
+            SiteId = request.SiteId,
+            ElementList = request.ElementList.Select(MapCaseEditElement).ToList()
+        };
+
+        var checkListValueList = new List<string>();
+        var fieldValueList = new List<string>();
+        replyRequest.ElementList.ForEach(element =>
+        {
+            checkListValueList.AddRange(CaseUpdateHelper.GetCheckList(element));
+            fieldValueList.AddRange(CaseUpdateHelper.GetFieldList(element));
+        });
+
+        var core = await coreHelper.GetCore().ConfigureAwait(false);
+        var sdkDbContext = core.DbContextHelper.GetDbContext();
+        var language = await sdkDbContext.Languages.FirstAsync().ConfigureAwait(false);
+
+        try
+        {
+            await compliance.Delete(dbContext).ConfigureAwait(false);
+            await core.CaseUpdate(replyRequest.Id, fieldValueList, checkListValueList)
+                .ConfigureAwait(false);
+            await core.CaseUpdateFieldValues(replyRequest.Id, language).ConfigureAwait(false);
+
+            var foundCase = await sdkDbContext.Cases
+                .FirstOrDefaultAsync(x => x.Id == replyRequest.Id)
+                .ConfigureAwait(false);
+
+            if (foundCase != null)
+            {
+                var newDoneAt = new DateTime(
+                    replyRequest.DoneAt.Year, replyRequest.DoneAt.Month, replyRequest.DoneAt.Day,
+                    0, 0, 0, DateTimeKind.Utc);
+                foundCase.DoneAtUserModifiable = newDoneAt;
+                foundCase.DoneAt = newDoneAt;
+                foundCase.SiteId = replyRequest.SiteId;
+                foundCase.Status = 100;
+                foundCase.WorkflowState = Constants.WorkflowStates.Created;
+                await foundCase.Update(sdkDbContext).ConfigureAwait(false);
+            }
+
+            return new UpdateComplianceCaseResponse { Success = true, Message = string.Empty };
+        }
+        catch (Exception ex)
+        {
+            return new UpdateComplianceCaseResponse { Success = false, Message = ex.Message };
+        }
+    }
+
+    private static ReplyElementItem MapElement(Element element)
+    {
+        var item = new ReplyElementItem
+        {
+            Id = element.Id,
+            Label = element.Label ?? string.Empty
+        };
+
+        switch (element)
+        {
+            case CheckListValue clv:
+                item.Status = clv.Status ?? string.Empty;
+                MapDataItems(clv.DataItemList, item.DataItems);
+                MapDataItemGroups(clv.DataItemGroupList, item.DataItemGroups);
+                break;
+            case DataElement de:
+                MapDataItems(de.DataItemList, item.DataItems);
+                MapDataItemGroups(de.DataItemGroupList, item.DataItemGroups);
+                break;
+            case GroupElement ge:
+                foreach (var child in ge.ElementList)
+                {
+                    item.ElementList.Add(MapElement(child));
+                }
+                break;
+        }
+
+        return item;
+    }
+
+    private static void MapDataItems(
+        List<DataItem> source,
+        Google.Protobuf.Collections.RepeatedField<DataItemInfo> target)
+    {
+        if (source == null) return;
+        foreach (var di in source)
+        {
+            target.Add(new DataItemInfo
+            {
+                Id = di.Id,
+                Label = di.Label ?? string.Empty,
+                Description = di.Description?.InderValue ?? string.Empty,
+                FieldType = di.GetType().Name,
+                Value = ExtractValue(di),
+                Mandatory = di.Mandatory,
+                ReadOnly = di.ReadOnly,
+                Color = di.Color ?? string.Empty,
+                DisplayOrder = di.DisplayOrder
+            });
+        }
+    }
+
+    private static void MapDataItemGroups(
+        List<DataItemGroup> source,
+        Google.Protobuf.Collections.RepeatedField<DataItemGroupInfo> target)
+    {
+        if (source == null) return;
+        foreach (var group in source)
+        {
+            var g = new DataItemGroupInfo
+            {
+                Id = int.TryParse(group.Id, out var gid) ? gid : 0,
+                Label = group.Label ?? string.Empty,
+                Description = group.Description ?? string.Empty,
+                Color = group.Color ?? string.Empty,
+                DisplayOrder = group.DisplayOrder
+            };
+            MapDataItems(group.DataItemList, g.DataItems);
+            target.Add(g);
+        }
+    }
+
+    private static string ExtractValue(DataItem di)
+    {
+        return di switch
+        {
+            Date d => d.DefaultValue ?? string.Empty,
+            Number n => n.DefaultValue.ToString(CultureInfo.InvariantCulture),
+            NumberStepper ns => ns.DefaultValue.ToString(CultureInfo.InvariantCulture),
+            Text t => t.Value ?? string.Empty,
+            Comment c => c.Value ?? string.Empty,
+            CheckBox cb => cb.DefaultValue ? "1" : "0",
+            SingleSelect => string.Empty,
+            MultiSelect => string.Empty,
+            _ => string.Empty
+        };
+    }
+
+    private static CaseEditRequest MapCaseEditElement(CaseEditElement proto)
+    {
+        return new CaseEditRequest
+        {
+            Id = proto.Id,
+            Status = proto.Status,
+            Fields = proto.Fields.Select(f => new CaseEditRequestField
+            {
+                FieldType = f.FieldType,
+                FieldValues = f.FieldValues.Select(fv => new CaseEditRequestFieldValue
+                {
+                    FieldId = fv.FieldId,
+                    Value = fv.Value,
+                    FieldType = fv.FieldType
+                }).ToList()
+            }).ToList(),
+            GroupFields = proto.GroupFields.Select(gf => new CaseEditRequestGroupField
+            {
+                Id = gf.Id,
+                Label = gf.Label,
+                Description = gf.Description,
+                Color = gf.Color,
+                DisplayOrder = gf.DisplayOrder,
+                Fields = gf.Fields.Select(f => new CaseEditRequestField
+                {
+                    FieldType = f.FieldType,
+                    FieldValues = f.FieldValues.Select(fv => new CaseEditRequestFieldValue
+                    {
+                        FieldId = fv.FieldId,
+                        Value = fv.Value,
+                        FieldType = fv.FieldType
+                    }).ToList()
+                }).ToList()
+            }).ToList(),
+            ElementList = proto.ElementList.Select(MapCaseEditElement).ToList()
+        };
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/TemplatesGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/TemplatesGrpcService.cs
@@ -1,0 +1,97 @@
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Grpc;
+using Grpc.Core;
+using Microsoft.EntityFrameworkCore;
+using Microting.eFormApi.BasePn.Abstractions;
+
+namespace BackendConfiguration.Pn.Services.GrpcServices;
+
+public class TemplatesGrpcService(IEFormCoreService coreHelper)
+    : BackendConfigurationTemplatesGrpc.BackendConfigurationTemplatesGrpcBase
+{
+    public override async Task<GetTemplateResponse> GetTemplate(
+        GetTemplateRequest request,
+        ServerCallContext context)
+    {
+        var core = await coreHelper.GetCore().ConfigureAwait(false);
+        var sdkDbContext = core.DbContextHelper.GetDbContext();
+        var language = await sdkDbContext.Languages
+            .FirstOrDefaultAsync(x => x.Id == request.LanguageId)
+            .ConfigureAwait(false);
+
+        if (language == null)
+        {
+            return new GetTemplateResponse { Success = false, Message = "Language not found" };
+        }
+
+        var dto = await core.TemplateItemRead(request.TemplateId, language).ConfigureAwait(false);
+        if (dto == null)
+        {
+            return new GetTemplateResponse { Success = false, Message = "Template not found" };
+        }
+
+        var item = new TemplateItem
+        {
+            Id = dto.Id,
+            CreatedAt = dto.CreatedAt?.ToString("O", CultureInfo.InvariantCulture) ?? string.Empty,
+            UpdatedAt = dto.UpdatedAt?.ToString("O", CultureInfo.InvariantCulture) ?? string.Empty,
+            Label = dto.Label ?? string.Empty,
+            Description = dto.Description ?? string.Empty,
+            Repeated = dto.Repeated,
+            FolderName = dto.FolderName ?? string.Empty,
+            WorkflowState = dto.WorkflowState ?? string.Empty,
+            HasCases = dto.HasCases,
+            DisplayIndex = dto.DisplayIndex ?? 0,
+            FolderId = dto.FolderId ?? 0,
+            JasperExportEnabled = dto.JasperExportEnabled,
+            DocxExportEnabled = dto.DocxExportEnabled,
+            ExcelExportEnabled = dto.ExcelExportEnabled,
+            ReportH1 = dto.ReportH1 ?? string.Empty,
+            ReportH2 = dto.ReportH2 ?? string.Empty,
+            ReportH3 = dto.ReportH3 ?? string.Empty,
+            ReportH4 = dto.ReportH4 ?? string.Empty,
+            ReportH5 = dto.ReportH5 ?? string.Empty,
+            IsLocked = dto.IsLocked,
+            IsEditable = dto.IsEditable,
+            IsHidden = dto.IsHidden,
+            IsAchievable = dto.IsAchievable,
+            IsDoneAtEditable = dto.IsDoneAtEditable
+        };
+
+        if (dto.Tags != null)
+        {
+            foreach (var tag in dto.Tags)
+            {
+                item.Tags.Add(new TemplateTagItem { Id = tag.Key, Name = tag.Value ?? string.Empty });
+            }
+        }
+
+        item.Field1 = MapFieldDto(dto.Field1);
+        item.Field2 = MapFieldDto(dto.Field2);
+        item.Field3 = MapFieldDto(dto.Field3);
+        item.Field4 = MapFieldDto(dto.Field4);
+        item.Field5 = MapFieldDto(dto.Field5);
+        item.Field6 = MapFieldDto(dto.Field6);
+        item.Field7 = MapFieldDto(dto.Field7);
+        item.Field8 = MapFieldDto(dto.Field8);
+        item.Field9 = MapFieldDto(dto.Field9);
+        item.Field10 = MapFieldDto(dto.Field10);
+
+        return new GetTemplateResponse { Success = true, Message = string.Empty, Template = item };
+    }
+
+    private static TemplateFieldDto MapFieldDto(Microting.eForm.Dto.FieldDto src)
+    {
+        if (src == null) return null;
+        return new TemplateFieldDto
+        {
+            Id = src.Id,
+            Label = src.Label ?? string.Empty,
+            Description = src.Description ?? string.Empty,
+            FieldType = src.FieldType ?? string.Empty,
+            FieldTypeId = src.FieldTypeId
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Adds 3 new gRPC RPCs to the existing backend-configuration gRPC layer for the Flutter mobile client:

- **`BackendConfigurationTemplatesGrpc.GetTemplate`** — returns flat `Template_Dto` metadata (label, Field1-10, tags, export flags) via `core.TemplateItemRead()`
- **`BackendConfigurationCompliancesGrpc.ReadComplianceCase`** — returns the case element tree (DataItems, DataItemGroups, nested elements) via `core.CaseRead()`
- **`BackendConfigurationCompliancesGrpc.UpdateComplianceCase`** — accepts the edit tree, runs `CaseUpdateHelper` to extract field/checklist values, calls `core.CaseUpdate()`, updates case DoneAt/SiteId/Status, deletes the compliance record

### Access control
Compliance endpoints resolve `PropertyId` from the `Compliances` table and call `HasAccessAsync(sdkSiteId, propertyId)`. Templates have no property scoping (matches REST behavior).

### Design note
Both services call the SDK core directly via `IEFormCoreService.GetCore()` rather than the existing service layer, because the existing `BackendConfigurationCompliancesService` depends on `IUserService` (HTTP context) which is unavailable in the gRPC call path from Flutter.

No existing code modified — only new files + additive wiring changes.

## Test plan

- [ ] `dotnet build` succeeds (proto compilation + C# compilation)
- [ ] Existing Playwright CI shards still pass (no REST regressions)
- [ ] (Follow-up) Flutter app calls `GetTemplate`, `ReadComplianceCase`, `UpdateComplianceCase` with valid device tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)