### PR TITLE
Add eform_id and sdk_case_id to calendar task proto

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
@@ -26,5 +26,6 @@ public class CalendarTaskResponseModel
     public bool IsAllDay { get; set; }
     public int? ExceptionId { get; set; }
     public int? EformId { get; set; }
+    public int? SdkCaseId { get; set; }
     public int? ItemPlanningTagId { get; set; }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/calendar.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/calendar.proto
@@ -39,6 +39,8 @@ message CalendarTaskItem {
   int32 planning_id = 18;              // 0 when null
   bool is_all_day = 19;
   int32 exception_id = 20;             // 0 when null
+  int32 eform_id = 21;
+  int32 sdk_case_id = 22;
 }
 
 message GetTasksForWeekResponse {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -372,6 +372,7 @@ public class BackendConfigurationCalendarService(
                     PlanningId = compliance.PlanningId,
                     IsAllDay = compIsAllDay,
                     EformId = arp?.AreaRule?.EformId,
+                    SdkCaseId = compliance.MicrotingSdkCaseId,
                     ItemPlanningTagId = arp?.ItemPlanningTagId
                 };
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/CalendarGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/CalendarGrpcService.cs
@@ -75,7 +75,9 @@ public class CalendarGrpcService(
                 NextExecutionTime = task.NextExecutionTime?.ToString(IsoDateTime, CultureInfo.InvariantCulture) ?? string.Empty,
                 PlanningId = task.PlanningId ?? 0,
                 IsAllDay = task.IsAllDay,
-                ExceptionId = task.ExceptionId ?? 0
+                ExceptionId = task.ExceptionId ?? 0,
+                EformId = task.EformId ?? 0,
+                SdkCaseId = task.SdkCaseId ?? 0
             });
         }
 


### PR DESCRIPTION
## Summary
- Extend `CalendarTaskItem` proto with `eform_id` (field 21) and `sdk_case_id` (field 22)
- Add `SdkCaseId` property to `CalendarTaskResponseModel`
- Map `EformId` and `SdkCaseId` in `CalendarGrpcService`
- Map `compliance.MicrotingSdkCaseId` for compliance-sourced tasks

## Test plan
- [ ] Verify `GetTasksForWeek` returns `eform_id` and `sdk_case_id` for compliance tasks
- [ ] Verify non-compliance tasks have `sdk_case_id = 0`
- [ ] Verify `ReadComplianceCase` can be called with the returned IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)