### PR TITLE
Fix: compliance tasks not marked completed based on deadline

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -364,7 +364,7 @@ public class BackendConfigurationCalendarService(
                     Color = calConfig?.Color,
                     RepeatType = arp?.RepeatType ?? 0,
                     RepeatEvery = arp?.RepeatEvery ?? 1,
-                    Completed = compliance.Deadline < DateTime.UtcNow,
+                    Completed = false,
                     PropertyId = compliance.PropertyId,
                     ComplianceId = compliance.Id,
                     IsFromCompliance = true,


### PR DESCRIPTION
## Summary
- Compliance tasks returned by `GetTasksForWeek` were incorrectly marked `Completed = true` when `Deadline < DateTime.UtcNow`
- A non-removed Compliance is by definition pending work — completion deletes the record (sets WorkflowState = Removed)
- Changed to `Completed = false` to match the task-tracker REST endpoint behavior

## Test plan
- [ ] Verify `GetTasksForWeek` returns `completed=false` for past compliance tasks
- [ ] Verify mobile app shows correct røde opgaver count matching web task-tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)