### PR TITLE
chore: tokenize SCSS hardcoded values for M3 consolidation

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.scss
@@ -9,7 +9,7 @@
     min-width: 240px;
     transition: width 0.2s, min-width 0.2s;
     overflow-y: auto;
-    border-right: 1px solid #e0e0e0;
+    border-right: 1px solid var(--border, #e0e0e0);
   }
 
   &.sidebar-closed app-calendar-sidebar {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-day-column/calendar-day-column.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-day-column/calendar-day-column.component.scss
@@ -46,7 +46,7 @@
       left: 0;
       right: 0;
       height: 2px;
-      background: #ea4335;
+      background: var(--error, #ea4335);
       z-index: 10;
       pointer-events: none;
 
@@ -58,7 +58,7 @@
         width: 10px;
         height: 10px;
         border-radius: 50%;
-        background: #ea4335;
+        background: var(--error, #ea4335);
       }
     }
   }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.scss
@@ -26,7 +26,7 @@
   .week-badge {
     padding: 4px 10px;
     border-radius: 10px;
-    background: #e3f2fd;
+    background: var(--surface-info-light, #e3f2fd);
     color: #1976d2;
     font-size: 0.8rem;
     font-weight: 600;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.scss
@@ -17,7 +17,7 @@
       font-size: 0.9rem;
       color: #444;
       padding: 4px 0;
-      border-bottom: 2px solid #e0e0e0;
+      border-bottom: 2px solid var(--border, #e0e0e0);
       margin-bottom: 8px;
       text-transform: capitalize;
     }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-sidebar/calendar-sidebar.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-sidebar/calendar-sidebar.component.scss
@@ -194,7 +194,7 @@
     }
 
     &.selected {
-      outline: 2px solid #333;
+      outline: 2px solid var(--text-header, #333);
       outline-offset: 2px;
     }
   }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
@@ -1,7 +1,7 @@
 .task-block {
   user-select: none;
   position: absolute;
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 4px);
   overflow: hidden;
   cursor: pointer;
   padding: 2px 4px;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
@@ -8,8 +8,8 @@
 
 .all-day-row {
   display: flex;
-  border-bottom: 1px solid #e0e0e0;
-  background: #fafafa;
+  border-bottom: 1px solid var(--border, #e0e0e0);
+  background: var(--surface-muted, #fafafa);
   min-height: 32px;
 
   .all-day-label {
@@ -34,7 +34,7 @@
     flex-direction: column;
     gap: 2px;
     padding: 2px 4px;
-    border-left: 1px solid #e0e0e0;
+    border-left: 1px solid var(--border, #e0e0e0);
 
     &.today-col {
       background: rgba(26, 115, 232, 0.04);
@@ -101,7 +101,7 @@
     position: sticky;
     left: 0;
     z-index: 2;
-    background: white;
+    background: var(--bg, #FFFFFF);
   }
 }
 
@@ -151,7 +151,7 @@
 // Static faded overlay at the original task position — stays put while dragging, like Google Calendar
 .drag-source-slot {
   position: absolute;
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 4px);
   opacity: 0.25;
   pointer-events: none;
   z-index: 1;
@@ -166,7 +166,7 @@
 // top/left/width are set via [style] bindings; width comes from the measured column rect
 .drag-ghost-task {
   position: absolute;
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 4px);
   padding: 2px 4px;
   opacity: 0.55;
   pointer-events: none;
@@ -195,7 +195,7 @@
   left: 0;
   right: 0;
   border: 2px solid #1a73e8;
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 4px);
   background: rgba(26, 115, 232, 0.08);
   z-index: 5;
   pointer-events: none;
@@ -206,7 +206,7 @@
   left: 0;
   right: 0;
   height: 2px;
-  background: #ea4335;
+  background: var(--error, #ea4335);
   z-index: 10;
   pointer-events: none;
 
@@ -218,12 +218,12 @@
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background: #ea4335;
+    background: var(--error, #ea4335);
   }
 }
 
 .past-slot {
-  background-color: #f5f5f5;
+  background-color: var(--surface-muted, #f5f5f5);
   cursor: not-allowed;
   opacity: 0.6;
 }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
@@ -1,7 +1,7 @@
 // Popover card wrapper — used when rendered via CDK Overlay
 .gcal-popover-card {
-  background: white;
-  border-radius: 8px;
+  background: var(--bg, #FFFFFF);
+  border-radius: var(--radius-md, 8px);
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
   max-height: calc(100vh - 16px);
   display: flex;
@@ -189,7 +189,7 @@
   background: rgba(0, 0, 0, 0.08);
   color: #5f6368;
   padding: 1px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 4px);
   text-transform: uppercase;
   letter-spacing: 0.3px;
 }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.scss
@@ -1,7 +1,7 @@
 // Popover card — used when rendered via CDK Overlay
 .gcal-popover-card {
-  background: white;
-  border-radius: 8px;
+  background: var(--bg, #FFFFFF);
+  border-radius: var(--radius-md, 8px);
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
   min-width: 320px;
   max-width: 420px;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-table/files-table.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-table/files-table.component.scss
@@ -18,10 +18,10 @@ mtx-grid {
 
 @keyframes highlightFade {
   0% {
-    background-color: #b3d3ea;
+    background-color: var(--surface-powder, #b3d3ea);
   }
   70% {
-    background-color: #b3d3ea;
+    background-color: var(--surface-powder, #b3d3ea);
   }
   100% {
     background-color: transparent;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.scss
@@ -18,13 +18,13 @@
 .day-row {
   margin-bottom: 24px;
   padding: 16px;
-  border: 1px solid #e0e0e0;
-  border-radius: 4px;
+  border: 1px solid var(--border, #e0e0e0);
+  border-radius: var(--radius-sm, 4px);
 }
 
 .day-row h5 {
   margin-bottom: 12px;
-  color: #333;
+  color: var(--text-header, #333);
 }
 
 .time-inputs {
@@ -45,32 +45,32 @@
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #6b7280;
+  color: var(--text-tertiary, #6b7280);
   font-weight: 700;
-  border-bottom: 1px solid #edeff3;
+  border-bottom: 1px solid var(--border, #edeff3);
   padding-bottom: 6px;
   margin: 22px 4px 12px;
 }
 
 .checkbox-description {
   display: block;
-  color: #6b7280;
+  color: var(--text-tertiary, #6b7280);
   font-size: 11px;
   line-height: 1.4;
   margin-top: 2px;
 }
 
 .muted-note {
-  color: #9ca3af;
+  color: var(--text-quaternary, #9ca3af);
   font-size: 10px;
   display: block;
   margin-top: 4px;
 }
 
 .mobile-axis {
-  background: #f9fafb;
+  background: var(--surface-subtle, #f9fafb);
   border: 1px solid #e5e7eb;
-  border-radius: 8px;
+  border-radius: var(--radius-md, 8px);
   padding: 12px 16px;
   margin: 10px 4px;
 }
@@ -101,14 +101,14 @@
 .sub-option {
   margin: 8px 0 4px 28px;
   padding: 8px 12px;
-  background: #ffffff;
+  background: var(--bg, #FFFFFF);
   border: 1px dashed #d1d5db;
   border-radius: 5px;
 }
 
 .cutoff-badge {
   display: inline-block;
-  background: #fef3c7;
+  background: var(--surface-warning-light, #fef3c7);
   color: #92400e;
   font-size: 10px;
   font-weight: 600;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-qr-modal/property-worker-qr-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-qr-modal/property-worker-qr-modal.component.scss
@@ -12,7 +12,7 @@
 }
 
 .qr-canvas {
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
+  border: 1px solid var(--border, #e0e0e0);
+  border-radius: var(--radius-md, 8px);
 }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-table/property-worker-table.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-table/property-worker-table.component.scss
@@ -1,9 +1,9 @@
 @keyframes highlightFade {
   0% {
-    background-color: #b3d3ea;
+    background-color: var(--surface-powder, #b3d3ea);
   }
   70% {
-    background-color: #b3d3ea;
+    background-color: var(--surface-powder, #b3d3ea);
   }
   100% {
     background-color: transparent;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/reports/components/report-table/report-table.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/reports/components/report-table/report-table.component.scss
@@ -1,18 +1,18 @@
 .highlighted {
-  background-color: #b3d3ea !important;
+  background-color: var(--surface-powder, #b3d3ea) !important;
   transition: background-color 0.3s ease;
-  color: #0F1316 !important;
+  color: var(--text-header, #0F1316) !important;
 
   span {
-    color: #0F1316 !important;
+    color: var(--text-header, #0F1316) !important;
   }
 
   td.mat-table-sticky-right {
-    background-color: #b3d3ea !important;
+    background-color: var(--surface-powder, #b3d3ea) !important;
 
     #actionMenu {
       .mat-icon {
-        color: #0F1316 !important;
+        color: var(--text-header, #0F1316) !important;
       }
     }
 
@@ -20,20 +20,20 @@
 }
 
 :host ::ng-deep tr.highlighted > td {
-  background-color: #b3d3ea !important;
+  background-color: var(--surface-powder, #b3d3ea) !important;
   transition: background-color 0.3s ease;
-  color: #0F1316 !important;
+  color: var(--text-header, #0F1316) !important;
 
   span {
-    color: #0F1316 !important;
+    color: var(--text-header, #0F1316) !important;
   }
 
   td.mat-table-sticky-right {
-    background-color: #b3d3ea !important;
+    background-color: var(--surface-powder, #b3d3ea) !important;
 
     #actionMenu {
       .mat-icon {
-        color: #0F1316 !important;
+        color: var(--text-header, #0F1316) !important;
       }
     }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-management/components/task-management-table/task-management-table.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-management/components/task-management-table/task-management-table.component.scss
@@ -1,9 +1,9 @@
 @keyframes highlightFade {
   0% {
-    background-color: #b3d3ea;
+    background-color: var(--surface-powder, #b3d3ea);
   }
   70% {
-    background-color: #b3d3ea;
+    background-color: var(--surface-powder, #b3d3ea);
   }
   100% {
     background-color: transparent;


### PR DESCRIPTION
## Summary
- Replace hardcoded color and border values with CSS custom property tokens
- Calendar-specific colors left as plugin-specific values
- Part of platform-wide M3 token consolidation

## Test plan
- [ ] Verify calendar views render correctly
- [ ] Verify task management tables display properly
- [ ] Verify modals and property worker pages unchanged visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)