### PR TITLE
feat(opgaver): gRPC service skeleton + ListEjendomme/ListTavler/ListOpgaver

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -245,6 +245,8 @@
       <Protobuf Include="Protos\properties.proto" GrpcServices="Server" ProtoRoot="Protos" />
       <Protobuf Include="Protos\templates.proto" GrpcServices="Server" ProtoRoot="Protos" />
       <Protobuf Include="Protos\compliances.proto" GrpcServices="Server" ProtoRoot="Protos" />
+      <Protobuf Include="Protos\documents.proto" GrpcServices="None" ProtoRoot="Protos" />
+      <Protobuf Include="Protos\opgaver.proto" GrpcServices="Server" ProtoRoot="Protos" />
     </ItemGroup>
 
 </Project>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -746,6 +746,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
             endpoints.MapGrpcService<Services.GrpcServices.PropertiesGrpcService>();
             endpoints.MapGrpcService<Services.GrpcServices.TemplatesGrpcService>();
             endpoints.MapGrpcService<Services.GrpcServices.CompliancesGrpcService>();
+            endpoints.MapGrpcService<Services.GrpcServices.OpgaverGrpcService>();
         });
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/documents.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/documents.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+package microting.documents;
+
+option csharp_namespace = "BackendConfiguration.Pn.Grpc.Documents";
+
+service Documents {
+  rpc GetAttachment(GetAttachmentRequest) returns (GetAttachmentResponse);
+}
+
+message GetAttachmentRequest {
+  string opgave_id = 1;
+  AttachmentSource source = 2;
+  int32 index = 3;
+}
+
+enum AttachmentSource {
+  ATTACHMENT_SOURCE_UNSPECIFIED = 0;
+  GDRIVE = 1;
+  ONEDRIVE = 2;
+}
+
+message GetAttachmentResponse {
+  string content_type = 1;
+  string filename = 2;
+  oneof payload {
+    bytes data = 3;
+    string redirect_url = 4;
+  }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/opgaver.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/opgaver.proto
@@ -1,0 +1,116 @@
+syntax = "proto3";
+
+package microting.opgaver;
+
+option csharp_namespace = "BackendConfiguration.Pn.Grpc.Opgaver";
+
+import "google/protobuf/timestamp.proto";
+import "documents.proto";
+
+service Opgaver {
+  rpc ListEjendomme(ListEjendommeRequest) returns (ListEjendommeResponse);
+  rpc ListTavler(ListTavlerRequest) returns (ListTavlerResponse);
+  rpc ListOpgaver(ListOpgaverRequest) returns (ListOpgaverResponse);
+  rpc StreamOpgaveChanges(StreamOpgaveChangesRequest) returns (stream OpgaveChange);
+  rpc CompleteOpgave(CompleteOpgaveRequest) returns (CompleteOpgaveResponse);
+  rpc SetComment(SetCommentRequest) returns (SetCommentResponse);
+  rpc UploadPhoto(stream UploadPhotoChunk) returns (UploadPhotoResponse);
+  rpc RemovePhoto(RemovePhotoRequest) returns (RemovePhotoResponse);
+}
+
+message UploadPhotoChunk {
+  oneof kind {
+    UploadPhotoMeta meta = 1;
+    bytes chunk = 2;
+  }
+}
+message UploadPhotoMeta {
+  string opgave_id = 1;
+  int32 slot = 2;
+  string content_type = 3;
+  int64 client_ts_unix = 4;
+}
+message UploadPhotoResponse {
+  string storage_id = 1;
+}
+
+message RemovePhotoRequest {
+  string opgave_id = 1;
+  int32 slot = 2;
+  int64 client_ts_unix = 3;
+}
+message RemovePhotoResponse {}
+
+message CompleteOpgaveRequest {
+  string opgave_id = 1;
+  bool completed = 2;
+  string completed_by = 3;
+  int64 client_ts_unix = 4;
+}
+message CompleteOpgaveResponse { Opgave opgave = 1; }
+
+message SetCommentRequest {
+  string opgave_id = 1;
+  string text = 2;
+  int64 client_ts_unix = 3;
+}
+message SetCommentResponse { Opgave opgave = 1; }
+
+message ListEjendommeRequest {}
+message ListEjendommeResponse { repeated Ejendom ejendomme = 1; }
+
+message ListTavlerRequest { string ejendom_id = 1; }
+message ListTavlerResponse { repeated Tavle tavler = 1; }
+
+message ListOpgaverRequest {
+  string ejendom_id = 1;
+  string tavle_id = 2;
+  string from_date_key = 3;
+  string to_date_key = 4;
+}
+message ListOpgaverResponse { repeated Opgave opgaver = 1; }
+
+message StreamOpgaveChangesRequest {
+  string ejendom_id = 1;
+  string tavle_id = 2;
+}
+
+message OpgaveChange {
+  oneof kind {
+    Opgave upserted = 1;
+    string removed_id = 2;
+  }
+}
+
+message Ejendom {
+  string id = 1;
+  string name = 2;
+}
+
+message Tavle {
+  string id = 1;
+  string ejendom_id = 2;
+  string name = 3;
+  string color_hex = 4;
+}
+
+message Opgave {
+  string id = 1;
+  string ejendom_id = 2;
+  string tavle_id = 3;
+  string plan_day_key = 4;
+  string planned_at = 5;
+  string task_text = 6;
+  string calendar_color = 7;
+  bool completed = 8;
+  string completed_by = 9;
+  string description_html = 10;
+  google.protobuf.Timestamp updated_at = 11;
+  string comment = 12;
+  repeated Attachment attachments = 13;
+}
+
+message Attachment {
+  microting.documents.AttachmentSource source = 1;
+  string name = 2;
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/OpgaverGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/OpgaverGrpcService.cs
@@ -1,0 +1,180 @@
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Grpc.Opgaver;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService;
+using BackendConfiguration.Pn.Services.UserPropertyAccess;
+using Grpc.Core;
+
+namespace BackendConfiguration.Pn.Services.GrpcServices;
+
+/// <summary>
+/// gRPC adapter for the mobile "Opgaver" feature.
+/// Read-only RPCs (ListEjendomme / ListTavler / ListOpgaver) reuse the existing
+/// Properties + Calendar service paths and reshape the result into the
+/// microting.opgaver wire contract. Write RPCs (CompleteOpgave, SetComment,
+/// UploadPhoto, RemovePhoto, StreamOpgaveChanges) are intentionally not
+/// overridden — the generated base returns UNIMPLEMENTED, which is the correct
+/// v1 behaviour. Follow-up PRs in the stack will fill them in.
+/// </summary>
+public class OpgaverGrpcService(
+    IBackendConfigurationCalendarService calendarService,
+    IBackendConfigurationPropertiesService propertiesService,
+    IBackendConfigurationUserPropertyAccess userPropertyAccess,
+    IGrpcSiteResolver siteResolver)
+    : Opgaver.OpgaverBase
+{
+    public override async Task<ListEjendommeResponse> ListEjendomme(
+        ListEjendommeRequest request,
+        ServerCallContext context)
+    {
+        var sdkSiteId = await siteResolver.GetSdkSiteIdAsync();
+        var accessibleIds = (await userPropertyAccess
+            .GetAccessiblePropertyIdsAsync(sdkSiteId)).ToHashSet();
+
+        // fullNames: false matches the historical mobile call (short name only).
+        var result = await propertiesService.GetCommonDictionary(false);
+
+        var response = new ListEjendommeResponse();
+
+        if (!result.Success || result.Model == null)
+        {
+            return response;
+        }
+
+        foreach (var item in result.Model)
+        {
+            if (item.Id is null || !accessibleIds.Contains(item.Id.Value))
+            {
+                continue;
+            }
+
+            response.Ejendomme.Add(new Ejendom
+            {
+                Id = item.Id.Value.ToString(CultureInfo.InvariantCulture),
+                Name = item.Name ?? string.Empty
+            });
+        }
+
+        return response;
+    }
+
+    public override async Task<ListTavlerResponse> ListTavler(
+        ListTavlerRequest request,
+        ServerCallContext context)
+    {
+        var propertyId = ParsePropertyId(request.EjendomId);
+
+        var sdkSiteId = await siteResolver.GetSdkSiteIdAsync();
+        if (!await userPropertyAccess.HasAccessAsync(sdkSiteId, propertyId))
+        {
+            throw new RpcException(new Status(StatusCode.PermissionDenied,
+                "Caller has no PropertyWorker access to the requested property."));
+        }
+
+        var result = await calendarService.GetBoards(propertyId);
+
+        var response = new ListTavlerResponse();
+
+        if (!result.Success || result.Model == null)
+        {
+            return response;
+        }
+
+        foreach (var board in result.Model)
+        {
+            response.Tavler.Add(new Tavle
+            {
+                Id = board.Id.ToString(CultureInfo.InvariantCulture),
+                EjendomId = board.PropertyId.ToString(CultureInfo.InvariantCulture),
+                Name = board.Name ?? string.Empty,
+                ColorHex = board.Color ?? string.Empty
+            });
+        }
+
+        return response;
+    }
+
+    public override async Task<ListOpgaverResponse> ListOpgaver(
+        ListOpgaverRequest request,
+        ServerCallContext context)
+    {
+        var propertyId = ParsePropertyId(request.EjendomId);
+
+        var sdkSiteId = await siteResolver.GetSdkSiteIdAsync();
+        if (!await userPropertyAccess.HasAccessAsync(sdkSiteId, propertyId))
+        {
+            throw new RpcException(new Status(StatusCode.PermissionDenied,
+                "Caller has no PropertyWorker access to the requested property."));
+        }
+
+        var model = new CalendarTaskRequestModel
+        {
+            PropertyId = propertyId,
+            WeekStart = request.FromDateKey ?? string.Empty,
+            WeekEnd = request.ToDateKey ?? string.Empty,
+            BoardIds = TryParseBoardIds(request.TavleId),
+            TagNames = [],
+            SiteIds = []
+        };
+
+        var result = await calendarService.GetTasksForWeek(model);
+
+        var response = new ListOpgaverResponse();
+
+        if (!result.Success || result.Model == null)
+        {
+            return response;
+        }
+
+        foreach (var task in result.Model)
+        {
+            response.Opgaver.Add(new Opgave
+            {
+                Id = task.Id.ToString(CultureInfo.InvariantCulture),
+                EjendomId = task.PropertyId.ToString(CultureInfo.InvariantCulture),
+                TavleId = task.BoardId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+                PlanDayKey = task.TaskDate ?? string.Empty,
+                PlannedAt = string.Empty,
+                TaskText = task.Title ?? string.Empty,
+                CalendarColor = task.Color ?? string.Empty,
+                Completed = task.Completed,
+                CompletedBy = string.Empty,
+                DescriptionHtml = task.DescriptionHtml ?? string.Empty,
+                Comment = string.Empty
+                // updated_at: Timestamp default (zero) — no source field in CalendarTaskResponseModel.
+                // attachments: empty — populated in a later PR via the Documents/attachments flow.
+            });
+        }
+
+        return response;
+    }
+
+    private static int ParsePropertyId(string raw)
+    {
+        if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+        {
+            return id;
+        }
+        throw new RpcException(new Status(StatusCode.InvalidArgument,
+            "ejendom_id must be a numeric property id."));
+    }
+
+    private static System.Collections.Generic.List<int> TryParseBoardIds(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return [];
+        }
+
+        if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+        {
+            return [id];
+        }
+
+        // Non-numeric tavle_id is treated as "no board filter" rather than a hard failure.
+        return [];
+    }
+}


### PR DESCRIPTION
## Summary

PR 1 of a stack adding the mobile "Opgaver" gRPC contract to this plugin.

- New protos: `Protos/opgaver.proto` (8 RPCs declared) + `Protos/documents.proto` (message types only — `GrpcServices="None"`).
- New service: `Services/GrpcServices/OpgaverGrpcService.cs` implementing 3 read RPCs.
- Service registered in `EformBackendConfigurationPlugin.Configure` alongside the existing gRPC services.

### Implemented in this PR

| RPC | Reuses | Access check |
|---|---|---|
| `ListEjendomme` | `PropertiesService.GetCommonDictionary` filtered by `userPropertyAccess.GetAccessiblePropertyIdsAsync` | per-property filter (mirrors `PropertiesGrpcService`) |
| `ListTavler` | `CalendarService.GetBoards(propertyId)` | `userPropertyAccess.HasAccessAsync` (RpcException PermissionDenied) |
| `ListOpgaver` | `CalendarService.GetTasksForWeek(propertyId, range, boardIds=[tavle_id])` | `userPropertyAccess.HasAccessAsync` |

### Intentionally NOT implemented (return UNIMPLEMENTED via generated base)

`StreamOpgaveChanges`, `CompleteOpgave`, `SetComment`, `UploadPhoto`, `RemovePhoto` — to be filled in by follow-up PRs in the stack.

## Mapping notes / known gaps

- `Opgave.planned_at`, `Opgave.completed_by`, `Opgave.comment`, `Opgave.updated_at`, `Opgave.attachments` have no source field on `CalendarTaskResponseModel` yet, so they are emitted as proto3 defaults. The write-side PRs will add the persistence + read-back wiring (the harness goldens already accept defaults for these on the read path).
- `ejendom_id` / `tavle_id` are int-on-the-wire but proto declares them as `string` (matches `flutter-eform`'s data model). The service parses on the way in (InvalidArgument on bad input) and stringifies on the way out. Non-numeric / empty `tavle_id` on `ListOpgaver` is treated as "no board filter" rather than an error.
- `documents.proto` is included with `GrpcServices="None"` because `Opgave.attachments` references `microting.documents.AttachmentSource`; the Documents service itself is not hosted by this plugin in v1.
- No new EF entities, no migrations.

## Discovery + companion fix

Discovered via the `flutter-eform` contract-test harness. Companion fix in `eform-angular-frontend` PR #7870 ensures UNIMPLEMENTED returns cleanly instead of HTTP 500 when the grpc-web matcher policy sees an unrouted sub-method on a registered service.

## Test plan

- [x] `dotnet build BackendConfiguration.Pn/BackendConfiguration.Pn.csproj` — 0 errors locally.
- [ ] CI green on this branch.
- [ ] Goldens for `ListEjendomme` / `ListTavler` / `ListOpgaver` rerun against this branch via the flutter-eform harness (next PR in the stack).