### PR TITLE
feat(opgaver): mirror eform_id proto add + populate from CalendarTaskResponseModel

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/opgaver.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/opgaver.proto
@@ -108,6 +108,8 @@ message Opgave {
   google.protobuf.Timestamp updated_at = 11;
   string comment = 12;
   repeated Attachment attachments = 13;
+  // eform template id this opgave is backed by; clients use this to look up template-specific field structure
+  int32 eform_id = 14;
 }
 
 message Attachment {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/OpgaverGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/OpgaverGrpcService.cs
@@ -225,7 +225,8 @@ public class OpgaverGrpcService(
                 Completed = task.Completed,
                 CompletedBy = string.Empty,
                 DescriptionHtml = task.DescriptionHtml ?? string.Empty,
-                Comment = comment
+                Comment = comment,
+                EformId = task.EformId ?? 0
                 // updated_at: Timestamp default (zero) — no source field in CalendarTaskResponseModel.
             };
 
@@ -605,7 +606,8 @@ public class OpgaverGrpcService(
                 Completed = task.Completed,
                 CompletedBy = string.Empty,
                 DescriptionHtml = task.DescriptionHtml ?? string.Empty,
-                Comment = comment
+                Comment = comment,
+                EformId = task.EformId ?? 0
             };
 
             PopulateAttachments(opgave, envelope);


### PR DESCRIPTION
## Summary

- Mirrors the flutter-eform proto change (`int32 eform_id = 14;` on the `Opgave` message) in this plugin's local copy of `opgaver.proto`
- Populates `Opgave.EformId` from the existing `CalendarTaskResponseModel.EformId` (already populated by `BackendConfigurationCalendarService` — same mapping pattern used by `CalendarGrpcService.cs:79`)
- Updated at both Opgave-construction sites: `ListOpgaver` (read path) and `LoadOpgaverAsync` (used by `StreamOpgaveChanges`) so the streaming wire shape stays consistent with the list response
- `task.EformId` is nullable on the model so we coerce with `?? 0`. Clients should treat `eform_id == 0` as "unknown / not yet linked to a template" (proto3 default)

## Companion PR

https://github.com/microting/flutter-eform/pull/721

## Test plan

- [x] `dotnet build BackendConfiguration.Pn.csproj` — 0 errors (39 pre-existing warnings)
- [ ] CI green
- [ ] After merge, capture a fresh contract-harness golden showing `eformId: 1129` (or similar) on a real Opgave from `/microting.opgaver.Opgaver/ListOpgaver`

🤖 Generated with [Claude Code](https://claude.com/claude-code)