### PR TITLE
fix(opgaver-grpc): emit canonical FieldType (Text/Number/...), not Field

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/OpgaverGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/OpgaverGrpcService.cs
@@ -466,7 +466,7 @@ public class OpgaverGrpcService(
             Id = di.Id,
             Label = di.Label ?? string.Empty,
             Description = di.Description?.InderValue ?? string.Empty,
-            FieldType = di.GetType().Name,
+            FieldType = di is Field sdkField ? sdkField.FieldType : di.GetType().Name,
             Required = di.Mandatory
         };
 
@@ -507,6 +507,18 @@ public class OpgaverGrpcService(
                 break;
             case EntitySelect el:
                 field.Value = el.DefaultValue.ToString(CultureInfo.InvariantCulture);
+                break;
+            case Field f:
+                // SDK runtime wrapper (returned by CaseRead) — carries the actual answer value
+                // and the canonical FieldType string (e.g. "Text", "Number", "CheckBox", ...).
+                if (f.KeyValuePairList?.Count > 0)
+                {
+                    AppendKeyValuePairOptions(f.KeyValuePairList, field);
+                }
+                else
+                {
+                    field.Value = f.FieldValue ?? string.Empty;
+                }
                 break;
             default:
                 field.Value = string.Empty;


### PR DESCRIPTION
## Summary

- `LoadFieldsByTaskIdAsync` used `di.GetType().Name` on SDK `DataItem` instances returned by `core.CaseRead()`. These instances are `Field` wrappers (answer containers), not template subclasses like `Text`/`Number`, so `GetType().Name` always returned `"Field"`.
- Flutter renderer had no handler for `"Field"` and fell through to `(not yet supported: Field)` for every eForm field on the device.
- Fix: when `di` is a `Field` instance, use `f.FieldType` (the SDK's canonical string: `"Text"`, `"Number"`, `"CheckBox"`, `"SingleSelect"`, `"MultiSelect"`, `"Date"`, `"Comment"`, `"Picture"`, etc.) instead of `GetType().Name`.
- Also adds a `case Field` arm to the value-extraction switch to properly populate `FieldValue` and `KeyValuePairList` from the answer data.

## Test plan
- [ ] Load a task with eForm fields in the Flutter device app — confirm fields render with their correct type label instead of "(not yet supported: Field)"
- [ ] Verify Text, Number, CheckBox, SingleSelect, MultiSelect, Date, Comment, Picture field types all emit correct canonical names
- [ ] No regression on existing JSON endpoints (not touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)