### PR TITLE
feat(opgaver): multi-tavle filter on ListOpgaver + StreamOpgaveChanges

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/opgaver.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/opgaver.proto
@@ -123,7 +123,7 @@ message ListTavlerResponse { repeated Tavle tavler = 1; }
 
 message ListOpgaverRequest {
   string ejendom_id = 1;
-  string tavle_id = 2;
+  repeated string tavle_ids = 2;
   string from_date_key = 3;
   string to_date_key = 4;
 }
@@ -141,7 +141,7 @@ message ListTaskTrackerResponse { repeated Opgave opgaver = 1; }
 
 message StreamOpgaveChangesRequest {
   string ejendom_id = 1;
-  string tavle_id = 2;
+  repeated string tavle_ids = 2;
 }
 
 message OpgaveChange {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/OpgaverGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/OpgaverGrpcService.cs
@@ -199,7 +199,7 @@ public class OpgaverGrpcService(
             PropertyId = propertyId,
             WeekStart = request.FromDateKey ?? string.Empty,
             WeekEnd = request.ToDateKey ?? string.Empty,
-            BoardIds = TryParseBoardIds(request.TavleId),
+            BoardIds = TryParseBoardIds(request.TavleIds),
             TagNames = [],
             SiteIds = [],
             ActionableOnly = true
@@ -777,7 +777,7 @@ public class OpgaverGrpcService(
                 "Caller has no PropertyWorker access to the requested property."));
         }
 
-        var boardFilter = TryParseBoardIds(request.TavleId);
+        var boardFilter = TryParseBoardIds(request.TavleIds);
         var ct = context.CancellationToken;
 
         // Watch window is recomputed on every poll so the day-roll-over case
@@ -2931,20 +2931,54 @@ public class OpgaverGrpcService(
             "ejendom_id must be a numeric property id."));
     }
 
-    private static System.Collections.Generic.List<int> TryParseBoardIds(string raw)
+    /// <summary>
+    /// Parse the repeated <c>tavle_ids</c> wire field into a deduplicated list
+    /// of numeric SDK board ids suitable for the
+    /// <c>CalendarTaskRequestModel.BoardIds</c> filter.
+    /// <para>
+    /// Behavior:
+    /// <list type="bullet">
+    /// <item><description>Empty / null input → empty list (means "no board filter,
+    /// show all boards" downstream in <c>BackendConfigurationCalendarService.ShouldIncludeTask</c>).</description></item>
+    /// <item><description>Each entry is trimmed via <see cref="string.IsNullOrWhiteSpace(string?)"/>;
+    /// blank entries are skipped silently.</description></item>
+    /// <item><description>Each remaining entry is parsed with
+    /// <see cref="int.TryParse(string?, NumberStyles, IFormatProvider?, out int)"/>;
+    /// successful parses are collected, non-numeric entries are skipped (per-entry,
+    /// not all-or-nothing). If every entry is non-numeric the result is an empty list,
+    /// which still means "show all" — matching the prior single-string behavior of
+    /// "non-numeric → empty filter".</description></item>
+    /// <item><description>Duplicate ids are collapsed so the downstream LINQ
+    /// <c>Contains</c> filter does not see redundant values.</description></item>
+    /// </list>
+    /// </para>
+    /// Pure: no side effects, no I/O, deterministic for a given input sequence.
+    /// </summary>
+    private static System.Collections.Generic.List<int> TryParseBoardIds(
+        System.Collections.Generic.IEnumerable<string> raws)
     {
-        if (string.IsNullOrWhiteSpace(raw))
+        if (raws is null)
         {
             return [];
         }
 
-        if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+        var seen = new System.Collections.Generic.HashSet<int>();
+        var result = new System.Collections.Generic.List<int>();
+        foreach (var raw in raws)
         {
-            return [id];
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                continue;
+            }
+
+            if (int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id)
+                && seen.Add(id))
+            {
+                result.Add(id);
+            }
         }
 
-        // Non-numeric tavle_id is treated as "no board filter" rather than a hard failure.
-        return [];
+        return result;
     }
 
     /// <summary>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/OpgaverGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/OpgaverGrpcService.cs
@@ -2933,37 +2933,20 @@ public class OpgaverGrpcService(
 
     /// <summary>
     /// Parse the repeated <c>tavle_ids</c> wire field into a deduplicated list
-    /// of numeric SDK board ids suitable for the
-    /// <c>CalendarTaskRequestModel.BoardIds</c> filter.
-    /// <para>
-    /// Behavior:
-    /// <list type="bullet">
-    /// <item><description>Empty / null input → empty list (means "no board filter,
-    /// show all boards" downstream in <c>BackendConfigurationCalendarService.ShouldIncludeTask</c>).</description></item>
-    /// <item><description>Each entry is trimmed via <see cref="string.IsNullOrWhiteSpace(string?)"/>;
-    /// blank entries are skipped silently.</description></item>
-    /// <item><description>Each remaining entry is parsed with
-    /// <see cref="int.TryParse(string?, NumberStyles, IFormatProvider?, out int)"/>;
-    /// successful parses are collected, non-numeric entries are skipped (per-entry,
-    /// not all-or-nothing). If every entry is non-numeric the result is an empty list,
-    /// which still means "show all" — matching the prior single-string behavior of
-    /// "non-numeric → empty filter".</description></item>
-    /// <item><description>Duplicate ids are collapsed so the downstream LINQ
-    /// <c>Contains</c> filter does not see redundant values.</description></item>
-    /// </list>
-    /// </para>
-    /// Pure: no side effects, no I/O, deterministic for a given input sequence.
+    /// of numeric SDK board ids for <c>CalendarTaskRequestModel.BoardIds</c>.
+    /// Blank and non-numeric entries are skipped per-entry (not all-or-nothing);
+    /// an empty result means "no board filter, show all" downstream in
+    /// <c>BackendConfigurationCalendarService.ShouldIncludeTask</c>.
     /// </summary>
-    private static System.Collections.Generic.List<int> TryParseBoardIds(
-        System.Collections.Generic.IEnumerable<string> raws)
+    private static List<int> TryParseBoardIds(IEnumerable<string> raws)
     {
         if (raws is null)
         {
             return [];
         }
 
-        var seen = new System.Collections.Generic.HashSet<int>();
-        var result = new System.Collections.Generic.List<int>();
+        var seen = new HashSet<int>();
+        var result = new List<int>();
         foreach (var raw in raws)
         {
             if (string.IsNullOrWhiteSpace(raw))


### PR DESCRIPTION
## Summary
- Replaces `string tavle_id = 2;` with `repeated string tavle_ids = 2;` on `ListOpgaverRequest` and `StreamOpgaveChangesRequest` in `opgaver.proto`. Same field number, type change. Hard cutover — flutter is the only consumer.
- C# handler `OpgaverGrpcService.TryParseBoardIds(string)` refactored to `TryParseBoardIds(IEnumerable<string>)` with per-entry skip-on-blank-or-non-numeric semantics + insertion-order-preserving HashSet dedup. Empty result still means "show all".
- The two consumers (`ListOpgaver` line 202, `StreamOpgaveChanges` line 780) feed the parsed list into the existing `CalendarTaskRequestModel.BoardIds` which `BackendConfigurationCalendarService.ShouldIncludeTask` already filters on (1809-1813) — **no business-logic changes**, only proto + glue.
- Auth gate untouched (property-level `HasAccessAsync`); EF schema untouched.

## Why
Today the mobile home-page filter renders `Checkbox` widgets for tavler that visually read as multi-select, but the data model is single-select — checking a second board silently overwrites the first. This PR is the wire side of widening the model to `Set<String>` end-to-end. The flutter side is in a follow-up PR (linked below) that **must merge in lockstep** with this one (a flutter client carrying the new repeated field cannot talk to a `tavle_id`-only server, and vice versa).

## Verification
- Pre-commit dual-subagent gate (code-review + code-simplifier) clean. Reviewer recommended ship-it; simplifier dropped fully-qualified namespaces + tightened the XML doc.
- `dotnet clean && dotnet build` against the embedded copy (`/home/rene/Documents/workspace/microting/eform-angular-frontend/eFormAPI/Plugins/BackendConfiguration.Pn/`): 0 errors, only pre-existing CS8632/NU1510 warnings.
- Backend running locally on the new DLL.
- The flutter-side feature PR will smoke-test end-to-end on device with a multi-tavler selection asserting only the chosen boards' opgaver render.

## Known follow-ups (not in this PR)
- No unit tests on `TryParseBoardIds` or the two RPCs. Worth a backlog item: table test covering `null`, `[]`, `[""]`, `[" "]`, `["abc"]`, `["1","1","2"]`, `["1","abc","2"]`.

## Lockstep
- **Merge order: this PR (toward `stable`) FIRST**, then deploy the new backend, then merge the flutter-eform consumer PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)