### PR TITLE
feat(opgaver): rename gRPC surface from microting.opgaver.Opgaver to backend_configuration.Events

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -246,7 +246,7 @@
       <Protobuf Include="Protos\templates.proto" GrpcServices="Server" ProtoRoot="Protos" />
       <Protobuf Include="Protos\compliances.proto" GrpcServices="Server" ProtoRoot="Protos" />
       <Protobuf Include="Protos\documents.proto" GrpcServices="None" ProtoRoot="Protos" />
-      <Protobuf Include="Protos\opgaver.proto" GrpcServices="Server" ProtoRoot="Protos" />
+      <Protobuf Include="Protos\events.proto" GrpcServices="Server" ProtoRoot="Protos" />
     </ItemGroup>
 
 </Project>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -787,7 +787,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
             endpoints.MapGrpcService<Services.GrpcServices.PropertiesGrpcService>();
             endpoints.MapGrpcService<Services.GrpcServices.TemplatesGrpcService>();
             endpoints.MapGrpcService<Services.GrpcServices.CompliancesGrpcService>();
-            endpoints.MapGrpcService<Services.GrpcServices.OpgaverGrpcService>();
+            endpoints.MapGrpcService<Services.GrpcServices.EventsGrpcService>();
         });
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskRequestModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskRequestModel.cs
@@ -15,7 +15,7 @@ public class CalendarTaskRequestModel
     /// When true, the calendar emits only *actionable* compliance rows for the requested
     /// week — i.e. compliances whose backing SDK Case still exists, is not soft-deleted,
     /// and is not yet completed (Status != 100). This is intended for the mobile-worker
-    /// gRPC path (<c>OpgaverGrpcService</c>) where non-actionable rows have no write
+    /// gRPC path (<c>EventsGrpcService</c>) where non-actionable rows have no write
     /// handler to bind to and would just clutter the worker's view.
     ///
     /// Default <c>false</c> preserves the historical behavior used by the angular admin

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
@@ -1,21 +1,16 @@
 syntax = "proto3";
 
-// NOTE: Intentional mixed Danish/English in this file.
-//
-// This proto is mid-migration per
+// Mid-migration: opgave -> event per
 // docs/superpowers/specs/2026-05-11-opgave-to-event-migration.md.
-// The current phase renames the "opgave" noun (and its compounds) to
-// "event" — service, package, the Opgave/OpgaveChange/CompleteOpgave*
-// messages, and the matching RPC method names.
 //
-// The "Ejendom", "Tavle", and "rode" domain nouns deliberately STAY
-// Danish in this PR; their rename is tracked in follow-up phases of the
-// same migration spec. Likewise, the proto FIELD names inside renamed
-// messages (e.g. `repeated Event opgaver = 1;`, `Event opgave = 1;`)
-// keep their original wire identifiers so the C# handler's generated
-// property accessors (`response.Opgaver.Add(...)`,
-// `new CompleteEventResponse { Opgave = ... }`) stay unchanged — this
-// is intentional "smallest-viable diff" per the plan.
+// This phase renames the "opgave" noun only: service, package, message
+// types (Opgave/OpgaveChange/CompleteOpgave* -> Event/...), and RPC
+// method names. The Ejendom/Tavle/rode nouns and all field names (e.g.
+// `repeated Event opgaver = 1;`) deliberately stay as-is — keeping the
+// wire identifiers preserves the generated C# accessors
+// (`response.Opgaver.Add(...)`, `new CompleteEventResponse { Opgave =
+// ... }`) and limits this PR to the smallest viable diff. Follow-up
+// phases handle those renames.
 
 package backend_configuration;
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
@@ -1,19 +1,36 @@
 syntax = "proto3";
 
-package microting.opgaver;
+// NOTE: Intentional mixed Danish/English in this file.
+//
+// This proto is mid-migration per
+// docs/superpowers/specs/2026-05-11-opgave-to-event-migration.md.
+// The current phase renames the "opgave" noun (and its compounds) to
+// "event" — service, package, the Opgave/OpgaveChange/CompleteOpgave*
+// messages, and the matching RPC method names.
+//
+// The "Ejendom", "Tavle", and "rode" domain nouns deliberately STAY
+// Danish in this PR; their rename is tracked in follow-up phases of the
+// same migration spec. Likewise, the proto FIELD names inside renamed
+// messages (e.g. `repeated Event opgaver = 1;`, `Event opgave = 1;`)
+// keep their original wire identifiers so the C# handler's generated
+// property accessors (`response.Opgaver.Add(...)`,
+// `new CompleteEventResponse { Opgave = ... }`) stay unchanged — this
+// is intentional "smallest-viable diff" per the plan.
 
-option csharp_namespace = "BackendConfiguration.Pn.Grpc.Opgaver";
+package backend_configuration;
+
+option csharp_namespace = "BackendConfiguration.Pn.Grpc.Events";
 
 import "google/protobuf/timestamp.proto";
 import "documents.proto";
 
-service Opgaver {
+service Events {
   rpc ListEjendomme(ListEjendommeRequest) returns (ListEjendommeResponse);
   rpc ListTavler(ListTavlerRequest) returns (ListTavlerResponse);
-  rpc ListOpgaver(ListOpgaverRequest) returns (ListOpgaverResponse);
+  rpc ListEvents(ListOpgaverRequest) returns (ListOpgaverResponse);
   rpc ListTaskTracker(ListTaskTrackerRequest) returns (ListTaskTrackerResponse);
-  rpc StreamOpgaveChanges(StreamOpgaveChangesRequest) returns (stream OpgaveChange);
-  rpc CompleteOpgave(CompleteOpgaveRequest) returns (CompleteOpgaveResponse);
+  rpc StreamEventChanges(StreamOpgaveChangesRequest) returns (stream EventChange);
+  rpc CompleteEvent(CompleteEventRequest) returns (CompleteEventResponse);
   rpc SetComment(SetCommentRequest) returns (SetCommentResponse);
   rpc UploadPhoto(stream UploadPhotoChunk) returns (UploadPhotoResponse);
   rpc RemovePhoto(RemovePhotoRequest) returns (RemovePhotoResponse);
@@ -31,16 +48,16 @@ message UploadPhotoMeta {
   int32 slot = 2;
   string content_type = 3;
   int64 client_ts_unix = 4;
-  // Server-assigned PK of the Compliance row this opgave was emitted from
+  // Server-assigned PK of the Compliance row this event was emitted from
   // (see Index handler). 0 means "unknown" — legacy clients that pre-date
   // this field; server falls back to the site-filtered fuzzy lookup in
   // that case so in-flight outbox payloads keep draining.
   int64 compliance_id = 5;
-  // Server-assigned PK of the SDK Case row backing this opgave. 0 = legacy.
+  // Server-assigned PK of the SDK Case row backing this event. 0 = legacy.
   int64 microting_sdk_case_id = 6;
-  // SDK Field.Id — matches FormField.id from ListOpgaver. The server
+  // SDK Field.Id — matches FormField.id from ListEvents. The server
   // creates the FieldValue row with this Field.Id so multi-Picture-field
-  // opgaver bind each photo to the correct field. 0 = legacy clients
+  // events bind each photo to the correct field. 0 = legacy clients
   // that pre-date this field; server falls back to BFS-first-Picture
   // discovery (matches the prior single-Picture assumption).
   int32 field_id = 7;
@@ -59,7 +76,7 @@ message RemovePhotoRequest {
 }
 message RemovePhotoResponse {}
 
-message CompleteOpgaveRequest {
+message CompleteEventRequest {
   string opgave_id = 1;
   bool completed = 2;
   string completed_by = 3;
@@ -80,9 +97,9 @@ message CompleteOpgaveRequest {
   // OpgaverComment body verbatim, matching SetComment semantics.
   string comment = 8;
 }
-message CompleteOpgaveResponse { Opgave opgave = 1; }
+message CompleteEventResponse { Event opgave = 1; }
 
-// One field-value write bundled into CompleteOpgaveRequest.field_values.
+// One field-value write bundled into CompleteEventRequest.field_values.
 // Mirrors the per-RPC SetFieldValueRequest pair (field_id + value) so the
 // server-side handler can reuse the same lookup + canonicalization helpers.
 message FieldValueWrite {
@@ -102,7 +119,7 @@ message SetCommentRequest {
   int64 compliance_id = 4;
   int64 microting_sdk_case_id = 5;
 }
-message SetCommentResponse { Opgave opgave = 1; }
+message SetCommentResponse { Event opgave = 1; }
 
 message SetFieldValueRequest {
   string opgave_id = 1;
@@ -113,7 +130,7 @@ message SetFieldValueRequest {
   int64 compliance_id = 5;
   int64 microting_sdk_case_id = 6;
 }
-message SetFieldValueResponse { Opgave opgave = 1; }
+message SetFieldValueResponse { Event opgave = 1; }
 
 message ListEjendommeRequest {}
 message ListEjendommeResponse { repeated Ejendom ejendomme = 1; }
@@ -127,26 +144,26 @@ message ListOpgaverRequest {
   string from_date_key = 3;
   string to_date_key = 4;
 }
-message ListOpgaverResponse { repeated Opgave opgaver = 1; }
+message ListOpgaverResponse { repeated Event opgaver = 1; }
 
 // Full property-scoped compliance list for the mobile worker's "task
 // tracker" view (mirror of the angular admin's BackendConfigurationTaskTrackerHelper.Index).
 // No deadline window — actionable + missed + completed rotations are all
 // returned, with per-row status carried on the existing `completed` field
-// and the new `task_is_expired` field (see Opgave below).
+// and the new `task_is_expired` field (see Event below).
 message ListTaskTrackerRequest {
   int32 property_id = 1;
 }
-message ListTaskTrackerResponse { repeated Opgave opgaver = 1; }
+message ListTaskTrackerResponse { repeated Event opgaver = 1; }
 
 message StreamOpgaveChangesRequest {
   string ejendom_id = 1;
   repeated string tavle_ids = 2;
 }
 
-message OpgaveChange {
+message EventChange {
   oneof kind {
-    Opgave upserted = 1;
+    Event upserted = 1;
     string removed_id = 2;
   }
 }
@@ -163,7 +180,7 @@ message Tavle {
   string color_hex = 4;
 }
 
-message Opgave {
+message Event {
   string id = 1;
   string ejendom_id = 2;
   string tavle_id = 3;
@@ -177,25 +194,25 @@ message Opgave {
   google.protobuf.Timestamp updated_at = 11;
   string comment = 12;
   repeated Attachment attachments = 13;
-  // eform template id this opgave is backed by; clients use this to look up template-specific field structure
+  // eform template id this event is backed by; clients use this to look up template-specific field structure
   int32 eform_id = 14;
   // Form-field structure + current values for the eForm template backing
-  // this opgave. Empty when no Case exists yet (recurrence-only tasks).
+  // this event. Empty when no Case exists yet (recurrence-only tasks).
   repeated FormField fields = 15;
-  // Server-assigned PK of the Compliance row this opgave was emitted from.
+  // Server-assigned PK of the Compliance row this event was emitted from.
   // Round-tripped through the Flutter Drift cache and back on every write
   // so the server can resolve compliance + sdk case deterministically
   // (no fuzzy OrderBy(Deadline).First() lookup). 0 = recurrence-only task
   // with no backing compliance yet (or legacy server pre-dating this field).
   int64 compliance_id = 16;
-  // Server-assigned PK of the SDK Case row backing this opgave. 0 means
+  // Server-assigned PK of the SDK Case row backing this event. 0 means
   // "no backing case" (recurrence-only) or a legacy server.
   int64 microting_sdk_case_id = 17;
-  // True when the opgave's deadline has passed AND the underlying case is
+  // True when the event's deadline has passed AND the underlying case is
   // either retracted (Case.WorkflowState=Removed AND Status=77) or simply
   // past its deadline without being completed (Case.Deadline < UtcNow AND
   // Status != 100). Surfaced primarily by ListTaskTracker so flutter can
-  // render missed rotations in red. The calendar-week view (ListOpgaver)
+  // render missed rotations in red. The calendar-week view (ListEvents)
   // pre-filters non-actionable rows out and so emits this as false; default
   // proto3 zero-value remains backwards-compatible with older clients.
   bool task_is_expired = 18;
@@ -206,7 +223,7 @@ message Attachment {
   string name = 2;
 }
 
-// Field of the eForm template that backs an Opgave.
+// Field of the eForm template that backs an Event.
 // Carries both the template definition (label, type, options) and the
 // worker's current answer (value).
 message FormField {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -66,7 +66,7 @@ public class BackendConfigurationCalendarService(
             //   CalendarGrpcService): emit ALL non-removed compliances in the week, including
             //   missed deadlines and already-completed ones. Bit-identical to pre-c2637800.
             //
-            // * ActionableOnly == true (mobile worker via OpgaverGrpcService): emit only
+            // * ActionableOnly == true (mobile worker via EventsGrpcService): emit only
             //   compliances whose backing SDK Case still exists, is not soft-deleted, and is
             //   not yet completed (Status != 100). Non-actionable compliance rows must NOT be
             //   emitted to the worker because the corresponding write handlers ("complete",

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -8,7 +8,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using BackendConfiguration.Pn.Grpc.Documents;
-using BackendConfiguration.Pn.Grpc.Opgaver;
+using BackendConfiguration.Pn.Grpc.Events;
 using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService;
@@ -99,7 +99,7 @@ namespace BackendConfiguration.Pn.Services.GrpcServices;
 ///     stale.</description></item>
 /// </list>
 /// </summary>
-public class OpgaverGrpcService(
+public class EventsGrpcService(
     IBackendConfigurationCalendarService calendarService,
     IBackendConfigurationPropertiesService propertiesService,
     IBackendConfigurationUserPropertyAccess userPropertyAccess,
@@ -107,8 +107,8 @@ public class OpgaverGrpcService(
     IEFormCoreService coreHelper,
     BackendConfigurationPnDbContext dbContext,
     ItemsPlanningPnDbContext itemsPlanningPnDbContext,
-    ILogger<OpgaverGrpcService> logger)
-    : Opgaver.OpgaverBase
+    ILogger<EventsGrpcService> logger)
+    : Events.EventsBase
 {
     public override async Task<ListEjendommeResponse> ListEjendomme(
         ListEjendommeRequest request,
@@ -181,7 +181,7 @@ public class OpgaverGrpcService(
         return response;
     }
 
-    public override async Task<ListOpgaverResponse> ListOpgaver(
+    public override async Task<ListOpgaverResponse> ListEvents(
         ListOpgaverRequest request,
         ServerCallContext context)
     {
@@ -234,7 +234,7 @@ public class OpgaverGrpcService(
 
             var comment = envelope?.OpgaverComment?.Text ?? string.Empty;
 
-            var opgave = new Opgave
+            var opgave = new Event
             {
                 Id = task.Id.ToString(CultureInfo.InvariantCulture),
                 EjendomId = task.PropertyId.ToString(CultureInfo.InvariantCulture),
@@ -325,7 +325,7 @@ public class OpgaverGrpcService(
             envelopeByTaskId.TryGetValue(task.Id, out var envelope);
             var comment = envelope?.OpgaverComment?.Text ?? string.Empty;
 
-            var opgave = new Opgave
+            var opgave = new Event
             {
                 Id = task.Id.ToString(CultureInfo.InvariantCulture),
                 EjendomId = task.PropertyId.ToString(CultureInfo.InvariantCulture),
@@ -374,7 +374,7 @@ public class OpgaverGrpcService(
     /// can index them stably; entries with missing or invalid metadata
     /// are skipped silently.
     /// </summary>
-    private static void PopulateAttachments(Opgave opgave, OpgaverCustomEnvelope? envelope)
+    private static void PopulateAttachments(Event opgave, OpgaverCustomEnvelope? envelope)
     {
         if (envelope?.OpgaverPhotos == null)
         {
@@ -762,9 +762,9 @@ public class OpgaverGrpcService(
     /// server holds no shared subscription registry. v2 with event-bus push
     /// will introduce one.
     /// </summary>
-    public override async Task StreamOpgaveChanges(
+    public override async Task StreamEventChanges(
         StreamOpgaveChangesRequest request,
-        IServerStreamWriter<OpgaveChange> responseStream,
+        IServerStreamWriter<EventChange> responseStream,
         ServerCallContext context)
     {
         var propertyId = ParsePropertyId(request.EjendomId);
@@ -798,7 +798,7 @@ public class OpgaverGrpcService(
             foreach (var op in initial)
             {
                 ct.ThrowIfCancellationRequested();
-                await responseStream.WriteAsync(new OpgaveChange { Upserted = op }, ct)
+                await responseStream.WriteAsync(new EventChange { Upserted = op }, ct)
                     .ConfigureAwait(false);
                 if (int.TryParse(op.Id, NumberStyles.Integer, CultureInfo.InvariantCulture,
                         out var opgaveId))
@@ -850,7 +850,7 @@ public class OpgaverGrpcService(
                     if (!seen.TryGetValue(opgaveId, out var prevHash) || prevHash != hash)
                     {
                         ct.ThrowIfCancellationRequested();
-                        await responseStream.WriteAsync(new OpgaveChange { Upserted = op }, ct)
+                        await responseStream.WriteAsync(new EventChange { Upserted = op }, ct)
                             .ConfigureAwait(false);
                         seen[opgaveId] = hash;
                     }
@@ -861,7 +861,7 @@ public class OpgaverGrpcService(
                 foreach (var id in removed)
                 {
                     ct.ThrowIfCancellationRequested();
-                    await responseStream.WriteAsync(new OpgaveChange
+                    await responseStream.WriteAsync(new EventChange
                         {
                             RemovedId = id.ToString(CultureInfo.InvariantCulture)
                         }, ct).ConfigureAwait(false);
@@ -928,7 +928,7 @@ public class OpgaverGrpcService(
     /// is forwarded to the EF compliance + occurrence queries verbatim, so a
     /// month-wide window is supported in a single call.
     /// </summary>
-    private async Task<List<Opgave>> LoadOpgaverAsync(
+    private async Task<List<Event>> LoadOpgaverAsync(
         int propertyId,
         List<int> boardFilter,
         DateTime windowStart,
@@ -946,7 +946,7 @@ public class OpgaverGrpcService(
         };
 
         var result = await calendarService.GetTasksForWeek(model).ConfigureAwait(false);
-        var output = new List<Opgave>();
+        var output = new List<Event>();
 
         if (!result.Success || result.Model == null)
         {
@@ -964,7 +964,7 @@ public class OpgaverGrpcService(
             envelopeByTaskId.TryGetValue(task.Id, out var envelope);
             var comment = envelope?.OpgaverComment?.Text ?? string.Empty;
 
-            var opgave = new Opgave
+            var opgave = new Event
             {
                 Id = task.Id.ToString(CultureInfo.InvariantCulture),
                 EjendomId = task.PropertyId.ToString(CultureInfo.InvariantCulture),
@@ -1007,14 +1007,14 @@ public class OpgaverGrpcService(
     /// memory footprint small (~44 base64 chars) — the dictionary may hold
     /// a few hundred entries per subscriber.
     /// </summary>
-    private static string ComputeStateHash(Opgave op)
+    private static string ComputeStateHash(Event op)
     {
         var bytes = SHA256.HashData(op.ToByteArray());
         return Convert.ToBase64String(bytes);
     }
 
-    public override async Task<CompleteOpgaveResponse> CompleteOpgave(
-        CompleteOpgaveRequest request,
+    public override async Task<CompleteEventResponse> CompleteEvent(
+        CompleteEventRequest request,
         ServerCallContext context)
     {
         var opgaveId = ParseOpgaveId(request.OpgaveId);
@@ -1428,8 +1428,8 @@ public class OpgaverGrpcService(
             if (!string.IsNullOrEmpty(request.Comment))
             {
                 var existingEnvelope = TryParseEnvelope(foundCase.Custom);
-                var nextEnvelope = existingEnvelope ?? new OpgaverCustomEnvelope();
-                nextEnvelope.OpgaverComment = new OpgaverCommentBody
+                var nextEnvelope = existingEnvelope ?? new EventrCustomEnvelope();
+                nextEnvelope.OpgaverComment = new EventrCommentBody
                 {
                     Text = request.Comment,
                     TsUnix = ToUnixSeconds(commentAtUtc),
@@ -1549,7 +1549,7 @@ public class OpgaverGrpcService(
             ? refreshed.Model.FirstOrDefault(t => t.Id == opgaveId)
             : null;
 
-        Opgave opgave;
+        Event opgave;
         if (refreshedTask != null)
         {
             // Reuse the same envelope + eForm field-structure helpers as
@@ -1568,7 +1568,7 @@ public class OpgaverGrpcService(
             envelopeByTaskId.TryGetValue(refreshedTask.Id, out var envelope);
             var comment = envelope?.OpgaverComment?.Text ?? string.Empty;
 
-            opgave = new Opgave
+            opgave = new Event
             {
                 Id = refreshedTask.Id.ToString(CultureInfo.InvariantCulture),
                 EjendomId = refreshedTask.PropertyId.ToString(CultureInfo.InvariantCulture),
@@ -1600,7 +1600,7 @@ public class OpgaverGrpcService(
             // reconcile local state against the new server truth. Empty
             // Fields / Attachments are correct here: the row is no longer
             // actionable and the client should drop it.
-            opgave = new Opgave
+            opgave = new Event
             {
                 Id = opgaveId.ToString(CultureInfo.InvariantCulture),
                 EjendomId = arp.PropertyId.ToString(CultureInfo.InvariantCulture),
@@ -1616,7 +1616,7 @@ public class OpgaverGrpcService(
             };
         }
 
-        return new CompleteOpgaveResponse { Opgave = opgave };
+        return new CompleteEventResponse { Opgave = opgave };
     }
 
     /// <summary>
@@ -1641,8 +1641,8 @@ public class OpgaverGrpcService(
     ///     calendar query says about that row today. No DB writes.</description></item>
     /// </list>
     /// </summary>
-    private async Task<CompleteOpgaveResponse> BuildIdempotentCompleteOpgaveResponse(
-        int opgaveId, CompleteOpgaveRequest request)
+    private async Task<CompleteEventResponse> BuildIdempotentCompleteOpgaveResponse(
+        int opgaveId, CompleteEventRequest request)
     {
         var arp = await dbContext.AreaRulePlannings
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed || x.WorkflowState == null)
@@ -1711,9 +1711,9 @@ public class OpgaverGrpcService(
             // No live compliance row — the row was already completed (or never
             // had one). Return Completed=true so the flutter client drops it
             // from Drift via the empty/zero-id "no longer actionable" path.
-            return new CompleteOpgaveResponse
+            return new CompleteEventResponse
             {
-                Opgave = new Opgave
+                Opgave = new Event
                 {
                     Id = opgaveId.ToString(CultureInfo.InvariantCulture),
                     EjendomId = arp.PropertyId.ToString(CultureInfo.InvariantCulture),
@@ -1751,7 +1751,7 @@ public class OpgaverGrpcService(
             ? refreshed.Model.FirstOrDefault(t => t.Id == opgaveId)
             : null;
 
-        Opgave opgave;
+        Event opgave;
         if (refreshedTask != null)
         {
             // Mirror the main CompleteOpgave path: reuse the envelope +
@@ -1770,7 +1770,7 @@ public class OpgaverGrpcService(
             envelopeByTaskId.TryGetValue(refreshedTask.Id, out var envelope);
             var comment = envelope?.OpgaverComment?.Text ?? string.Empty;
 
-            opgave = new Opgave
+            opgave = new Event
             {
                 Id = refreshedTask.Id.ToString(CultureInfo.InvariantCulture),
                 EjendomId = refreshedTask.PropertyId.ToString(CultureInfo.InvariantCulture),
@@ -1800,7 +1800,7 @@ public class OpgaverGrpcService(
             // Compliance alive but calendar query didn't surface the row
             // (e.g. ActionableOnly filtered it out). Treat the same as
             // "no longer actionable" so the client drops it.
-            opgave = new Opgave
+            opgave = new Event
             {
                 Id = opgaveId.ToString(CultureInfo.InvariantCulture),
                 EjendomId = arp.PropertyId.ToString(CultureInfo.InvariantCulture),
@@ -1816,7 +1816,7 @@ public class OpgaverGrpcService(
             };
         }
 
-        return new CompleteOpgaveResponse { Opgave = opgave };
+        return new CompleteEventResponse { Opgave = opgave };
     }
 
     /// <summary>
@@ -2008,10 +2008,10 @@ public class OpgaverGrpcService(
         // legacy CompliancesGrpcService.ReadComplianceCase passthrough sees
         // an empty string instead of "{...}".
         var existingEnvelope = TryParseEnvelope(foundCase.Custom);
-        var nextEnvelope = existingEnvelope ?? new OpgaverCustomEnvelope();
+        var nextEnvelope = existingEnvelope ?? new EventrCustomEnvelope();
         nextEnvelope.OpgaverComment = string.IsNullOrEmpty(trimmed)
             ? null
-            : new OpgaverCommentBody
+            : new EventrCommentBody
             {
                 Text = trimmed,
                 TsUnix = ToUnixSeconds(commentAtUtc)
@@ -2043,7 +2043,7 @@ public class OpgaverGrpcService(
         // need a follow-up read. GetTasksForWeek does not currently surface
         // Case.Custom, so populating opgave.comment here is the only path.
         var opgave = refreshedTask != null
-            ? new Opgave
+            ? new Event
             {
                 Id = refreshedTask.Id.ToString(CultureInfo.InvariantCulture),
                 EjendomId = refreshedTask.PropertyId.ToString(CultureInfo.InvariantCulture),
@@ -2391,7 +2391,7 @@ public class OpgaverGrpcService(
                 ? DateTimeOffset.FromUnixTimeSeconds(meta.ClientTsUnix).UtcDateTime
                 : DateTime.UtcNow;
 
-            var envelope = TryParseEnvelope(foundCase.Custom) ?? new OpgaverCustomEnvelope();
+            var envelope = TryParseEnvelope(foundCase.Custom) ?? new EventrCustomEnvelope();
             envelope.OpgaverPhotos ??= new List<OpgaverPhotoBody>();
 
             var existing = envelope.OpgaverPhotos.FirstOrDefault(p => p.Slot == meta.Slot);
@@ -2410,7 +2410,7 @@ public class OpgaverGrpcService(
                 envelope.OpgaverPhotos.Remove(existing);
             }
 
-            envelope.OpgaverPhotos.Add(new OpgaverPhotoBody
+            envelope.OpgaverPhotos.Add(new EventrPhotoBody
             {
                 Slot = meta.Slot,
                 UploadedDataId = uploadedData.Id,
@@ -2559,10 +2559,10 @@ public class OpgaverGrpcService(
         return new RemovePhotoResponse();
     }
 
-    private static Opgave SynthesiseMinimalOpgave(
+    private static Event SynthesiseMinimalOpgave(
         int opgaveId, int propertyId, DateTime commentAtUtc, string trimmed)
     {
-        return new Opgave
+        return new Event
         {
             Id = opgaveId.ToString(CultureInfo.InvariantCulture),
             EjendomId = propertyId.ToString(CultureInfo.InvariantCulture),
@@ -2856,10 +2856,10 @@ public class OpgaverGrpcService(
             ? refreshed.Model.FirstOrDefault(t => t.Id == opgaveId)
             : null;
 
-        Opgave opgave;
+        Event opgave;
         if (refreshedTask != null)
         {
-            opgave = new Opgave
+            opgave = new Event
             {
                 Id = refreshedTask.Id.ToString(CultureInfo.InvariantCulture),
                 EjendomId = refreshedTask.PropertyId.ToString(CultureInfo.InvariantCulture),
@@ -2892,7 +2892,7 @@ public class OpgaverGrpcService(
         else
         {
             // Task fell out of the window after update — synthesise minimal Opgave.
-            opgave = new Opgave
+            opgave = new Event
             {
                 Id = opgaveId.ToString(CultureInfo.InvariantCulture),
                 EjendomId = arp.PropertyId.ToString(CultureInfo.InvariantCulture),

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -1428,8 +1428,8 @@ public class EventsGrpcService(
             if (!string.IsNullOrEmpty(request.Comment))
             {
                 var existingEnvelope = TryParseEnvelope(foundCase.Custom);
-                var nextEnvelope = existingEnvelope ?? new EventrCustomEnvelope();
-                nextEnvelope.OpgaverComment = new EventrCommentBody
+                var nextEnvelope = existingEnvelope ?? new OpgaverCustomEnvelope();
+                nextEnvelope.OpgaverComment = new OpgaverCommentBody
                 {
                     Text = request.Comment,
                     TsUnix = ToUnixSeconds(commentAtUtc),
@@ -2008,10 +2008,10 @@ public class EventsGrpcService(
         // legacy CompliancesGrpcService.ReadComplianceCase passthrough sees
         // an empty string instead of "{...}".
         var existingEnvelope = TryParseEnvelope(foundCase.Custom);
-        var nextEnvelope = existingEnvelope ?? new EventrCustomEnvelope();
+        var nextEnvelope = existingEnvelope ?? new OpgaverCustomEnvelope();
         nextEnvelope.OpgaverComment = string.IsNullOrEmpty(trimmed)
             ? null
-            : new EventrCommentBody
+            : new OpgaverCommentBody
             {
                 Text = trimmed,
                 TsUnix = ToUnixSeconds(commentAtUtc)
@@ -2391,7 +2391,7 @@ public class EventsGrpcService(
                 ? DateTimeOffset.FromUnixTimeSeconds(meta.ClientTsUnix).UtcDateTime
                 : DateTime.UtcNow;
 
-            var envelope = TryParseEnvelope(foundCase.Custom) ?? new EventrCustomEnvelope();
+            var envelope = TryParseEnvelope(foundCase.Custom) ?? new OpgaverCustomEnvelope();
             envelope.OpgaverPhotos ??= new List<OpgaverPhotoBody>();
 
             var existing = envelope.OpgaverPhotos.FirstOrDefault(p => p.Slot == meta.Slot);
@@ -2410,7 +2410,7 @@ public class EventsGrpcService(
                 envelope.OpgaverPhotos.Remove(existing);
             }
 
-            envelope.OpgaverPhotos.Add(new EventrPhotoBody
+            envelope.OpgaverPhotos.Add(new OpgaverPhotoBody
             {
                 Slot = meta.Slot,
                 UploadedDataId = uploadedData.Id,


### PR DESCRIPTION
## Summary
Plugin side of the opgave→event Danish→English migration per [`docs/superpowers/specs/2026-05-11-opgave-to-event-migration.md`](https://github.com/microting/flutter-eform/blob/master/docs/superpowers/specs/2026-05-11-opgave-to-event-migration.md).

**Renamed wire surface:**
- Proto file: `opgaver.proto` → `events.proto`
- Package: `microting.opgaver` → `backend_configuration`
- Service: `Opgaver` → `Events`
- `csharp_namespace`: `BackendConfiguration.Pn.Grpc.Opgaver` → `…Grpc.Events`
- Messages: `Opgave` → `Event`, `OpgaveChange` → `EventChange`, `CompleteOpgaveRequest/Response` → `CompleteEventRequest/Response`
- RPC methods: `ListOpgaver` → `ListEvents`, `StreamOpgaveChanges` → `StreamEventChanges`, `CompleteOpgave` → `CompleteEvent`

**C# handler:**
- File: `OpgaverGrpcService.cs` → `EventsGrpcService.cs` (via `git mv`)
- Class: `OpgaverGrpcService` → `EventsGrpcService`
- Base: `Opgaver.OpgaverBase` → `Events.EventsBase`
- `MapGrpcService<EventsGrpcService>()` at `EformBackendConfigurationPlugin.cs:790`
- csproj `<Protobuf Include="…events.proto"/>` updated
- 2 stale comment refs updated

## Smallest-viable-diff carve-out
Intentionally **stays Danish** in this PR — tracked for follow-up phases:
- Proto field names (`opgave_id`, `tavle_id`, `ejendom_id`, `opgaver`, `rode`-prefixed) — keeps generated C# accessors stable, no handler property cascade.
- `Ejendom`, `Tavle` messages.
- Helper method names (`LoadOpgaverAsync`, `BuildIdempotentCompleteOpgaveResponse`, `SynthesiseMinimalOpgave`, `ParseOpgaveId`).
- Private JSON envelope classes (`OpgaverCustomEnvelope`, `OpgaverCommentBody`, `OpgaverPhotoBody`).
- Private C# locals.
- RPCs unrelated to opgave noun (`UploadPhoto`, `RemovePhoto`, `SetComment`, `SetFieldValue`, `ListTaskTracker`, `ListEjendomme`, `ListTavler`).

Mixed-language proto flagged with a top-of-file comment for future readers.

## Lockstep
**Merge order: this PR (toward \`stable\`) FIRST**, then deploy the new backend image, then merge the flutter-eform consumer PR (forthcoming) which regenerates Dart stubs against the renamed proto. The Helm chart already routes BOTH `/microting.opgaver.Opgaver/*` (legacy) and `/backend_configuration.Events/*` (new) to the same backend service.

## Verification
- Pre-commit dual-subagent gate clean. Code-reviewer caught 6 `Eventr*` typos from the original mechanical rename (overshot into the carved-out JSON envelope classes) → restored to `Opgaver*` in commit `66e9721e`. Code-simplifier trimmed the top-of-file migration comment in `events.proto`.
- `dotnet clean && dotnet build` against the embedded copy: 0 errors, only pre-existing CS8632/NU1510 warnings.

## Known follow-ups (not in this PR)
- Proto field rename phase (still Danish wire fields).
- Helper method + private envelope class English rename.
- `Ejendom→Property`, `Tavle→Board`, `rode→Overdue` migrations (own PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)