### PR TITLE
feat(events): Phase 3 — rename gRPC ejendom types to property

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
@@ -1,11 +1,10 @@
 syntax = "proto3";
 
-// Mid-migration: opgave -> event, tavle -> board per
+// Mid-migration: opgave -> event, tavle -> board, ejendom -> property per
 // docs/superpowers/specs/2026-05-11-opgave-to-event-migration.md.
 // Wire field names (`opgaver`, `tavler`, `tavle_id`, `tavle_ids`,
-// `ejendom_id`) stay as-is so generated accessors don't churn; only
-// message types and RPC method names move. Ejendom and rode renames
-// land in follow-up phases.
+// `ejendom_id`, `ejendomme`) stay as-is so generated accessors don't churn;
+// only message types and RPC method names move. Rode rename lands in Phase 4.
 
 package backend_configuration;
 
@@ -15,7 +14,7 @@ import "google/protobuf/timestamp.proto";
 import "documents.proto";
 
 service Events {
-  rpc ListEjendomme(ListEjendommeRequest) returns (ListEjendommeResponse);
+  rpc ListProperties(ListPropertiesRequest) returns (ListPropertiesResponse);
   rpc ListBoards(ListBoardsRequest) returns (ListBoardsResponse);
   rpc ListEvents(ListOpgaverRequest) returns (ListOpgaverResponse);
   rpc ListTaskTracker(ListTaskTrackerRequest) returns (ListTaskTrackerResponse);
@@ -122,8 +121,8 @@ message SetFieldValueRequest {
 }
 message SetFieldValueResponse { Event opgave = 1; }
 
-message ListEjendommeRequest {}
-message ListEjendommeResponse { repeated Ejendom ejendomme = 1; }
+message ListPropertiesRequest {}
+message ListPropertiesResponse { repeated Property ejendomme = 1; }
 
 message ListBoardsRequest { string ejendom_id = 1; }
 message ListBoardsResponse { repeated Board tavler = 1; }
@@ -158,7 +157,7 @@ message EventChange {
   }
 }
 
-message Ejendom {
+message Property {
   string id = 1;
   string name = 2;
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -135,7 +135,12 @@ public class EventsGrpcService(
                 continue;
             }
 
-            response.Ejendomme.Add(new Property
+            // Fully-qualify the gRPC Property to disambiguate from
+            // EformBackendConfigurationBase.*.Entities.Property which the
+            // outer `using` import also pulls into scope (the Tavle→Board
+            // rename in Phase 2 didn't hit this because the base package
+            // has no Board entity).
+            response.Ejendomme.Add(new BackendConfiguration.Pn.Grpc.Events.Property
             {
                 Id = item.Id.Value.ToString(CultureInfo.InvariantCulture),
                 Name = item.Name ?? string.Empty

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -32,7 +32,7 @@ namespace BackendConfiguration.Pn.Services.GrpcServices;
 
 /// <summary>
 /// gRPC adapter for the mobile "Opgaver" feature.
-/// Read-only RPCs (ListEjendomme / ListBoards / ListOpgaver) reuse the existing
+/// Read-only RPCs (ListProperties / ListBoards / ListEvents) reuse the existing
 /// Properties + Calendar service paths and reshape the result into the
 /// microting.opgaver wire contract. CompleteOpgave performs the SDK-case
 /// completion inline (mirroring CompliancesGrpcService.UpdateComplianceCase,
@@ -110,8 +110,8 @@ public class EventsGrpcService(
     ILogger<EventsGrpcService> logger)
     : Events.EventsBase
 {
-    public override async Task<ListEjendommeResponse> ListEjendomme(
-        ListEjendommeRequest request,
+    public override async Task<ListPropertiesResponse> ListProperties(
+        ListPropertiesRequest request,
         ServerCallContext context)
     {
         var sdkSiteId = await siteResolver.GetSdkSiteIdAsync();
@@ -121,7 +121,7 @@ public class EventsGrpcService(
         // fullNames: false matches the historical mobile call (short name only).
         var result = await propertiesService.GetCommonDictionary(false);
 
-        var response = new ListEjendommeResponse();
+        var response = new ListPropertiesResponse();
 
         if (!result.Success || result.Model == null)
         {
@@ -135,7 +135,7 @@ public class EventsGrpcService(
                 continue;
             }
 
-            response.Ejendomme.Add(new Ejendom
+            response.Ejendomme.Add(new Property
             {
                 Id = item.Id.Value.ToString(CultureInfo.InvariantCulture),
                 Name = item.Name ?? string.Empty


### PR DESCRIPTION
## Summary

Phase 3 of the opgave→event migration: rename gRPC message types and RPC method names from Ejendom to Property on the plugin side. Mirrors Phase 1 + Phase 2 pattern — wire field names stay so generated C# accessors don't churn.

**Base:** \`stable\` (correcting the Phase 2 oversight that targeted \`master\` and required a follow-up promotion PR #804).

**Spec:** \`docs/superpowers/specs/2026-05-11-opgave-to-event-migration.md\` (Phase 3 subsection).

### Renamed (gRPC type / RPC method)
- \`rpc ListEjendomme(ListEjendommeRequest) returns (ListEjendommeResponse)\` → \`rpc ListProperties(ListPropertiesRequest) returns (ListPropertiesResponse)\`
- \`message Ejendom\` → \`message Property\`
- \`message ListEjendommeRequest\`/\`Response\` → \`ListPropertiesRequest\`/\`Response\`
- \`EventsGrpcService.ListEjendomme(...)\` handler → \`ListProperties(...)\`
- Top-of-file proto comment trimmed (Phase 2 re-gate pattern)

### Stayed Danish (CARVE_WIRE_FIELD)
- Wire field names: \`ejendomme\` (response repeated field on \`ListPropertiesResponse\`), \`ejendom_id\` (5 sites)
- 16 generated C# accessors (\`request.EjendomId\` reads x3, \`event.EjendomId = ...\` setters x13) untouched
- \`response.Ejendomme.Add(new Property { ... })\` kept (generated from carved wire field)

### Verification
- [x] \`dotnet clean && dotnet build\` from \`eFormAPI.Web/\` — 0 errors
- [x] Backend restarted, Kestrel binds \`:5000\` + \`:5001\` cleanly, no plugin-load exceptions
- [x] Embedded copy at \`eform-angular-frontend/eFormAPI/Plugins/BackendConfiguration.Pn/\` synced
- [x] Dual-subagent gate green after one fixup round (proto comment trimmed)

### Coordinated rollout
- Flutter Phase 3 PR coming next; will reference this PR's commit
- This PR targets \`stable\` so production deploy parity is automatic on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)