### PR TITLE
chore(events.proto): mark migration post-complete (comment-only)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-// Mid-migration: opgave -> event, tavle -> board, ejendom -> property per
+// Post-migration: opgave -> event, tavle -> board, ejendom -> property per
 // docs/superpowers/specs/2026-05-11-opgave-to-event-migration.md.
 // Wire field names (`opgaver`, `tavler`, `tavle_id`, `tavle_ids`,
 // `ejendom_id`, `ejendomme`) stay as-is so generated accessors don't churn;
-// only message types and RPC method names move. Rode rename lands in Phase 4.
+// only message types and RPC method names move.
 
 package backend_configuration;
 


### PR DESCRIPTION
## Summary

Comment-only cleanup now that all 4 noun phases of the opgave→event migration are merged on \`stable\` (Phase 1 #802, Phase 2 #803+#804 promotion, Phase 3 #805) and on flutter-eform \`master\`.

Two edits to \`events.proto\` header:
- "Mid-migration" → "Post-migration"
- Drop trailing sentence "Rode rename lands in Phase 4." (rode is a Flutter-side filter concept; no plugin gRPC types named with it, confirmed by Phase 4 plugin inventory)

No wire / message-type / RPC-method changes. \`response.Ejendomme.Add\`/\`request.TavleIds\`/etc. accessors all unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)