### PR TITLE
feat(events): server-side thumbnail generation on UploadPhoto

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -2338,9 +2338,15 @@ public class EventsGrpcService(
                 await core.PutFileToS3Storage(originalMs, fileName).ConfigureAwait(false);
             }
 
-            // Thumbnail generation for raster images, SDK parity.
-            var fileExt = Path.GetExtension(uploadedData.FileName).ToLowerInvariant();
-            if (fileExt is ".jpg" or ".jpeg" or ".png")
+            // Thumbnail generation for raster images, SDK parity. Best-effort:
+            // any failure here is logged but does NOT throw, so the FieldValue /
+            // envelope writes below still run. The original photo is already on
+            // S3 + UploadedData row persisted, so a thumbnail failure means
+            // consumers fall back to the original (acceptable degradation) — far
+            // better than orphaning the row by short-circuiting the rest of the
+            // handler. (uploadedData.Extension is normalized to "jpg"/"png" by
+            // the earlier content-type switch, so we only check those two.)
+            if (uploadedData.Extension is "jpg" or "png")
             {
                 var smallFilename = $"{uploadedData.Id}_300_{uploadedData.Checksum}.{uploadedData.Extension}";
                 var bigFilename = $"{uploadedData.Id}_700_{uploadedData.Checksum}.{uploadedData.Extension}";
@@ -2349,8 +2355,9 @@ public class EventsGrpcService(
                 {
                     using var image = new MagickImage(photoBytes);
                     image.AutoOrient();
+                    if (image.Width == 0 || image.Height == 0) return;
                     var ratio = image.Height / (decimal)image.Width;
-                    var newHeight = (uint)Math.Round(ratio * targetWidth);
+                    var newHeight = Math.Max(1u, (uint)Math.Round(ratio * targetWidth));
                     image.Resize(targetWidth, newHeight);
                     image.Crop(targetWidth, newHeight);    // SDK parity — Resize may round; Crop pins exact dims
                     using var resizedMs = new MemoryStream();
@@ -2359,8 +2366,17 @@ public class EventsGrpcService(
                     await core.PutFileToS3Storage(resizedMs, targetFilename).ConfigureAwait(false);
                 }
 
-                await WriteResizedAsync(300, smallFilename).ConfigureAwait(false);
-                await WriteResizedAsync(700, bigFilename).ConfigureAwait(false);
+                try
+                {
+                    await WriteResizedAsync(300, smallFilename).ConfigureAwait(false);
+                    await WriteResizedAsync(700, bigFilename).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "Thumbnail generation failed for UploadedData {Id}; original photo persisted, consumers will fall back to it",
+                        uploadedData.Id);
+                }
             }
 
             // 6. Mirror angular's FieldValues row insert.

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -15,6 +15,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService;
 using BackendConfiguration.Pn.Services.UserPropertyAccess;
 using Google.Protobuf;
 using Grpc.Core;
+using ImageMagick;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microting.eForm.Infrastructure.Constants;
@@ -2324,7 +2325,43 @@ public class EventsGrpcService(
             uploadedData.FileName = fileName;
             await uploadedData.Update(sdkDbContext).ConfigureAwait(false);
 
-            await core.PutFileToS3Storage(ms, fileName).ConfigureAwait(false);
+            // Materialise bytes once: AWS SDK v4 sets AutoCloseStream=true on
+            // PutObjectRequest, so each PutFileToS3Storage call disposes the
+            // stream it receives. We re-use the bytes for the original + both
+            // thumbnails by handing each upload a fresh MemoryStream over the
+            // same byte[] (mirrors BackendConfigurationTaskManagementService.cs:530-534).
+            ms.Position = 0;
+            var photoBytes = ms.ToArray();
+
+            using (var originalMs = new MemoryStream(photoBytes))
+            {
+                await core.PutFileToS3Storage(originalMs, fileName).ConfigureAwait(false);
+            }
+
+            // Thumbnail generation for raster images, SDK parity.
+            var fileExt = Path.GetExtension(uploadedData.FileName).ToLowerInvariant();
+            if (fileExt is ".jpg" or ".jpeg" or ".png")
+            {
+                var smallFilename = $"{uploadedData.Id}_300_{uploadedData.Checksum}.{uploadedData.Extension}";
+                var bigFilename = $"{uploadedData.Id}_700_{uploadedData.Checksum}.{uploadedData.Extension}";
+
+                async Task WriteResizedAsync(uint targetWidth, string targetFilename)
+                {
+                    using var image = new MagickImage(photoBytes);
+                    image.AutoOrient();
+                    var ratio = image.Height / (decimal)image.Width;
+                    var newHeight = (uint)Math.Round(ratio * targetWidth);
+                    image.Resize(targetWidth, newHeight);
+                    image.Crop(targetWidth, newHeight);    // SDK parity — Resize may round; Crop pins exact dims
+                    using var resizedMs = new MemoryStream();
+                    await image.WriteAsync(resizedMs).ConfigureAwait(false);
+                    resizedMs.Position = 0;
+                    await core.PutFileToS3Storage(resizedMs, targetFilename).ConfigureAwait(false);
+                }
+
+                await WriteResizedAsync(300, smallFilename).ConfigureAwait(false);
+                await WriteResizedAsync(700, bigFilename).ConfigureAwait(false);
+            }
 
             // 6. Mirror angular's FieldValues row insert.
             // EFormFilesController.AddNewImage at line 306-316 creates a NEW

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -593,7 +593,7 @@ public class EventsGrpcService(
             case Date d:
                 field.Value = d.DefaultValue ?? string.Empty;
                 break;
-            case Number n:
+            case Microting.eForm.Infrastructure.Models.Number n:
                 field.Value = n.DefaultValue.ToString(CultureInfo.InvariantCulture);
                 break;
             case NumberStepper ns:


### PR DESCRIPTION
## Summary

Server-side thumbnail generation on the plugin's gRPC \`UploadPhoto\` handler. Mirrors the SDK's \`Core.cs DownloadUploadedData\` thumbnail logic (lines 6118-6436) so consumers expecting \`{Id}_300_{Checksum}.{Extension}\` / \`{Id}_700_{Checksum}.{Extension}\` S3 keys actually find them for photos uploaded via the flutter mobile gRPC route. Without this, the existing reports + task-tracker views + workflow case views 404 on mobile-uploaded photos.

Closest in-plugin precedent (used as template): \`BackendConfigurationTaskManagementService.cs:500-582\` (\`WorkOrderCases\` upload, exact same MemoryStream → ImageMagick → S3 shape).

## What the handler now does

After the original \`PutFileToS3Storage(ms, fileName)\`, before the FieldValue/envelope writes:

1. Gate on \`Path.GetExtension(uploadedData.FileName).ToLowerInvariant() is ".jpg" or ".jpeg" or ".png"\` — only raster images get thumbnails.
2. Materialize \`photoBytes = ms.ToArray()\` once (necessary because AWS SDK v4 disposes the input stream on \`PutObjectAsync\`).
3. \`WriteResizedAsync(300, smallFilename)\` and \`WriteResizedAsync(700, bigFilename)\` produce aspect-preserving thumbnails:
   - \`AutoOrient()\` normalises EXIF rotation (covers all 8 orientations; SDK's manual switch handled 3/6/8 only).
   - \`Resize(width, height)\` with computed \`height = round(originalH/originalW * width)\`.
   - \`Crop(width, height)\` immediately after — SDK / TaskManagementService precedent; pins exact dimensions when Resize rounds.
   - Writes the renamed MagickImage to a fresh MemoryStream and \`PutFileToS3Storage\`.

## Carve-outs preserved

- **UploadedData.Extension column** stays no-leading-dot (\`"jpg"\` / \`"png"\`) per the parity-harness fix documented in the comment block at lines 2152-2157. Thumbnail key templates inline the dot: \`$"{Id}_300_{Checksum}.{Extension}"\`.
- **No new DB rows** for thumbnails — they're S3-only artifacts discoverable by filename convention, matching SDK behavior.
- **No change** to the FieldValue / OpgaverCustomEnvelope write path; thumbnails inject between the original PUT and the field write.

## Verification

- [x] \`dotnet clean && dotnet build\` from \`eFormAPI.Web\` — 0 errors (10 pre-existing warnings)
- [x] Backend restarts cleanly on \`:5000\`+\`:5001\`, no plugin-load exceptions
- [x] Embedded copy at \`eform-angular-frontend/eFormAPI/Plugins/BackendConfiguration.Pn/\` synced (\`diff -q\` silent)
- [x] Dual-subagent gate green after one fixup round (caught: stream-lifecycle ObjectDisposedException bug from \`AutoCloseStream=true\`; Extension column convention divergence from the parity-harness fix; Crop omission diverging from SDK byte parity; 300/700 duplication)

## Test plan

- [ ] Upload a photo from the flutter app to the local backend
- [ ] Confirm in S3 (or local file storage) that 3 keys exist: \`{Id}_<hash>.jpg\`, \`{Id}_300_<hash>.jpg\`, \`{Id}_700_<hash>.jpg\`
- [ ] Open the case report / task tracker that uses \`{Id}_700_{Checksum}{Extension}\` URLs and verify the thumbnail loads

## Magick.NET version

\`Magick.NET-Q16-AnyCPU 14.13.0\` (same version the SDK + TaskManagementService already use; transitively in the resolved graph — no new top-level reference needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)