### PR TITLE
fix(calendar): symmetric gutter on event boxes within day columns

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.html
@@ -4,8 +4,8 @@
   [class.resizing]="resizing"
   [style.top.px]="topPx"
   [style.height.px]="heightPx"
-  [style.left.%]="leftPercent"
-  [style.width.%]="widthPercent"
+  [style.left]="leftStyle"
+  [style.width]="widthStyle"
   [style.background-color]="task.color"
   cdkDrag
   [cdkDragData]="task"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
@@ -1,6 +1,7 @@
 .task-block {
   user-select: none;
   position: absolute;
+  box-sizing: border-box;
   border-radius: var(--radius-sm, 4px);
   overflow: hidden;
   cursor: pointer;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.ts
@@ -56,12 +56,17 @@ export class CalendarTaskBlockComponent {
     return Math.max(dur * this.hourHeight - 4, 20);
   }
 
-  get leftPercent(): number {
-    return (this.task._colIndex / this.task._colCount) * 100;
+  // 4px horizontal gutter inside the sub-column. Using calc(% ± px) keeps
+  // the gap visually constant across viewport widths; with N overlapping
+  // events this gives 4px outside + 8px between adjacent events.
+  get leftStyle(): string {
+    const colWidth = 100 / this.task._colCount;
+    return `calc(${this.task._colIndex * colWidth}% + 4px)`;
   }
 
-  get widthPercent(): number {
-    return (1 / this.task._colCount) * 100 - 1;
+  get widthStyle(): string {
+    const colWidth = 100 / this.task._colCount;
+    return `calc(${colWidth}% - 8px)`;
   }
 
   // Live time labels — show the preview values during a resize so the user


### PR DESCRIPTION
## Summary
- Calendar event boxes (week view) were bleeding past the right edge of their day column with effectively zero gutter on the left. Now they sit with a symmetric 4 px gutter inside the column, and with N overlapping events there's an 8 px gap between adjacent events.
- Replaces percent-only positioning (`left: 0%; width: 99%`) with `calc()` strings that combine a percent-based sub-column with a fixed pixel gutter, and adds `box-sizing: border-box` so the 2 px white border can't push the visible edge past the computed width.
- Design spec: [`docs/superpowers/specs/2026-05-13-calendar-event-box-gutter-design.md`](https://github.com/microting/eform-angular-frontend/blob/master/docs/superpowers/specs/2026-05-13-calendar-event-box-gutter-design.md) (workspace-level repo).

## Test plan
- [ ] Open `/plugins/backend-configuration-pn/calendar` week view; confirm a single event sits symmetrically inside its day column (4 px on each side).
- [ ] Confirm no event crosses the right column divider at viewport widths 1280 / 1440 / 1920 px.
- [ ] Stage two overlapping events on the same day; confirm 8 px gap between them and 4 px from outer column edges.
- [ ] Drag an event to another day — drag-drop still works.
- [ ] Drag the top edge / bottom edge to resize — both still work.
- [ ] Hover an event — lift / z-index unchanged.
- [ ] Toggle completion — still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)