### PR TITLE
test(events): integration tests for EventDeployService

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
@@ -29,6 +29,7 @@ using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.EventDeployService;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
 using Microting.eForm.Infrastructure.Data.Entities;
@@ -229,18 +230,42 @@ public class EventDeployServiceTest : TestBaseSetup
         var coreHelper = Substitute.For<IEFormCoreService>();
         coreHelper.GetCore().Returns(Task.FromResult(core));
 
+        // Use a capturing TestLogger so we can prove the idempotence guard
+        // (EventDeployService.cs:184-195) short-circuited. Asserting only
+        // Count==1 is tautological: if the guard silently broke,
+        // execution would fall through to the planning lookup at line 200,
+        // find nothing for planningId=500, log a "planning ... not found"
+        // warning at line 208, hit `continue` at line 211, and STILL leave
+        // Compliance count at 1. By asserting that NEITHER the
+        // planning-not-found NOR areaRulePlanning-not-found warnings were
+        // emitted, we pin that the guard fired before either downstream
+        // null-fallthrough.
+        var logger = new TestLogger<EventDeployService>();
         var service = new EventDeployService(
             BackendConfigurationPnDbContext!,
             ItemsPlanningPnDbContext!,
             coreHelper,
             calendar,
-            NullLogger<EventDeployService>.Instance);
+            logger);
 
         // Act
         await service.EnsureDeployedAsync(
             PropertyId, BoardIds, "2026-05-14", "2026-05-20", site.Id, CancellationToken.None);
 
-        // Assert — still exactly 1 Compliance row, no duplicate from the deploy pass.
+        // Assert — guard fired (no downstream null-fallthrough warnings)
+        // AND no duplicate Compliance row was created.
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                logger.Entries.Any(e => e.Message.Contains("planning") && e.Message.Contains("not found")),
+                Is.False,
+                "Guard should have short-circuited before the planning lookup at EventDeployService.cs:200-212.");
+            Assert.That(
+                logger.Entries.Any(e => e.Message.Contains("areaRulePlanning") && e.Message.Contains("not found")),
+                Is.False,
+                "Guard should have short-circuited before the areaRulePlanning lookup at EventDeployService.cs:214-227.");
+        });
+
         var complianceCount = await BackendConfigurationPnDbContext.Compliances.CountAsync();
         Assert.That(complianceCount, Is.EqualTo(1));
     }
@@ -309,24 +334,19 @@ public class EventDeployServiceTest : TestBaseSetup
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        // Act + Assert — either the cancellation token cascades into an
-        // OperationCanceledException (preferred) or the call returns
-        // without writing. Both shapes honour the contract.
-        var beforeCount = await BackendConfigurationPnDbContext!.Compliances.CountAsync();
+        // Act + Assert — the future-day rotation passes the candidate
+        // filter, so the pipeline reaches the SDK Sites EF query at
+        // EventDeployService.cs:145 which is passed the cancelled token
+        // and is GUARANTEED to throw OperationCanceledException (or its
+        // TaskCanceledException subclass). A previous swallowing try/catch
+        // would have masked a regression that accidentally drops the token
+        // (e.g. passes CancellationToken.None to the EF call).
+        Assert.ThrowsAsync<OperationCanceledException>(
+            () => service.EnsureDeployedAsync(
+                PropertyId, BoardIds, "2026-05-14", "2026-05-20", SdkSiteId, cts.Token));
 
-        try
-        {
-            await service.EnsureDeployedAsync(
-                PropertyId, BoardIds, "2026-05-14", "2026-05-20", SdkSiteId, cts.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected path — the EF query in the foreach loop (or the
-            // sdkSite lookup) sees the cancelled token and throws.
-        }
-
-        var afterCount = await BackendConfigurationPnDbContext.Compliances.CountAsync();
-        Assert.That(afterCount, Is.EqualTo(beforeCount),
+        var afterCount = await BackendConfigurationPnDbContext!.Compliances.CountAsync();
+        Assert.That(afterCount, Is.EqualTo(0),
             "Cancellation must not produce any Compliance writes.");
     }
 
@@ -346,4 +366,34 @@ public class EventDeployServiceTest : TestBaseSetup
     // column-name quirk (PlanningCaseSiteId = PlanningCase.Id; see
     // EventDeployService.cs:392-395).
     // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Captures every <see cref="ILogger.Log"/> invocation into an in-memory
+    /// list so tests can pin "this log line was (or wasn't) emitted". Used
+    /// by the idempotence-guard test to distinguish "guard fired" from
+    /// "guard missed but a downstream null-fallthrough produced the same
+    /// observable Compliance count". Asserting on
+    /// <see cref="ILogger"/> via NSubstitute against the underlying
+    /// <c>Log(LogLevel, EventId, TState, Exception?, Func&lt;TState,Exception?,string&gt;)</c>
+    /// overload is brittle because <c>TState</c> is the runtime
+    /// <c>FormattedLogValues</c> struct; a plain capture is more robust.
+    /// </summary>
+    private sealed class TestLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
@@ -61,6 +61,66 @@ public class EventDeployServiceTest : TestBaseSetup
     private const int SdkSiteId = 1;
     private static readonly IReadOnlyCollection<string> BoardIds = ["10"];
 
+    /// <summary>
+    /// Build the two mocks every test needs: <see cref="IBackendConfigurationCalendarService"/>
+    /// pinned to return <paramref name="rotations"/>, plus
+    /// <see cref="IEFormCoreService"/>. When <paramref name="core"/> is supplied
+    /// the mock's <c>GetCore()</c> is wired; otherwise it's left unstubbed so the
+    /// no-op fast-path tests can assert via <c>DidNotReceive().GetCore()</c>.
+    /// </summary>
+    private static (IBackendConfigurationCalendarService Calendar, IEFormCoreService CoreHelper)
+        MakeMocks(IEnumerable<CalendarTaskResponseModel> rotations, eFormCore.Core? core = null)
+    {
+        var calendar = Substitute.For<IBackendConfigurationCalendarService>();
+        calendar.GetTasksForWeek(Arg.Any<CalendarTaskRequestModel>())
+            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(
+                true, rotations.ToList()));
+
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        if (core != null)
+        {
+            coreHelper.GetCore().Returns(Task.FromResult(core));
+        }
+        return (calendar, coreHelper);
+    }
+
+    /// <summary>
+    /// Build the SUT against the contexts inherited from <see cref="TestBaseSetup"/>.
+    /// Pass a custom <paramref name="logger"/> when the test needs to inspect log
+    /// output (idempotence-guard test); otherwise defaults to
+    /// <see cref="NullLogger{T}.Instance"/>.
+    /// </summary>
+    private EventDeployService MakeService(
+        IBackendConfigurationCalendarService calendar,
+        IEFormCoreService coreHelper,
+        ILogger<EventDeployService>? logger = null)
+        => new(
+            BackendConfigurationPnDbContext!,
+            ItemsPlanningPnDbContext!,
+            coreHelper,
+            calendar,
+            logger ?? NullLogger<EventDeployService>.Instance);
+
+    /// <summary>
+    /// Factory for the rotation DTO that every test arranges. Defaults match the
+    /// shape the existing tests used pre-refactor (planningId=200, eformId=300);
+    /// callers override per case.
+    /// </summary>
+    private static CalendarTaskResponseModel MakeRotation(
+        int id,
+        DateTime date,
+        bool isFromCompliance = false,
+        int planningId = 200,
+        int eformId = 300)
+        => new()
+        {
+            Id = id,
+            PlanningId = planningId,
+            EformId = eformId,
+            TaskDate = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            IsFromCompliance = isFromCompliance
+        };
+
     // ------------------------------------------------------------------
     // 1. EnsureDeployedAsync_NoRotationsInWindow_DoesNothing
     // ------------------------------------------------------------------
@@ -68,17 +128,8 @@ public class EventDeployServiceTest : TestBaseSetup
     public async Task EnsureDeployedAsync_NoRotationsInWindow_DoesNothing()
     {
         // Arrange — calendar returns zero rotations for the window.
-        var calendar = Substitute.For<IBackendConfigurationCalendarService>();
-        calendar.GetTasksForWeek(Arg.Any<CalendarTaskRequestModel>())
-            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, []));
-
-        var coreHelper = Substitute.For<IEFormCoreService>();
-        var service = new EventDeployService(
-            BackendConfigurationPnDbContext!,
-            ItemsPlanningPnDbContext!,
-            coreHelper,
-            calendar,
-            NullLogger<EventDeployService>.Instance);
+        var (calendar, coreHelper) = MakeMocks([]);
+        var service = MakeService(calendar, coreHelper);
 
         // Act
         await service.EnsureDeployedAsync(
@@ -98,27 +149,9 @@ public class EventDeployServiceTest : TestBaseSetup
     {
         // Arrange — yesterday's rotation. EventDeployService should refuse
         // to back-deploy historical rows (the scheduler owns those).
-        var yesterday = DateTime.UtcNow.Date.AddDays(-1).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-        var pastRotation = new CalendarTaskResponseModel
-        {
-            Id = 100,
-            PlanningId = 200,
-            EformId = 300,
-            TaskDate = yesterday,
-            IsFromCompliance = false
-        };
-
-        var calendar = Substitute.For<IBackendConfigurationCalendarService>();
-        calendar.GetTasksForWeek(Arg.Any<CalendarTaskRequestModel>())
-            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, [pastRotation]));
-
-        var coreHelper = Substitute.For<IEFormCoreService>();
-        var service = new EventDeployService(
-            BackendConfigurationPnDbContext!,
-            ItemsPlanningPnDbContext!,
-            coreHelper,
-            calendar,
-            NullLogger<EventDeployService>.Instance);
+        var pastRotation = MakeRotation(id: 100, date: DateTime.UtcNow.Date.AddDays(-1));
+        var (calendar, coreHelper) = MakeMocks([pastRotation]);
+        var service = MakeService(calendar, coreHelper);
 
         // Act
         await service.EnsureDeployedAsync(
@@ -139,27 +172,14 @@ public class EventDeployServiceTest : TestBaseSetup
         // Arrange — a future rotation that is already backed by a Compliance
         // (IsFromCompliance=true). EventDeployService should filter these out
         // because they need no deploy.
-        var future = DateTime.UtcNow.Date.AddDays(2).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-        var complianceBackedRotation = new CalendarTaskResponseModel
-        {
-            Id = 101,
-            PlanningId = 201,
-            EformId = 301,
-            TaskDate = future,
-            IsFromCompliance = true
-        };
-
-        var calendar = Substitute.For<IBackendConfigurationCalendarService>();
-        calendar.GetTasksForWeek(Arg.Any<CalendarTaskRequestModel>())
-            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, [complianceBackedRotation]));
-
-        var coreHelper = Substitute.For<IEFormCoreService>();
-        var service = new EventDeployService(
-            BackendConfigurationPnDbContext!,
-            ItemsPlanningPnDbContext!,
-            coreHelper,
-            calendar,
-            NullLogger<EventDeployService>.Instance);
+        var complianceBackedRotation = MakeRotation(
+            id: 101,
+            date: DateTime.UtcNow.Date.AddDays(2),
+            isFromCompliance: true,
+            planningId: 201,
+            eformId: 301);
+        var (calendar, coreHelper) = MakeMocks([complianceBackedRotation]);
+        var service = MakeService(calendar, coreHelper);
 
         // Act
         await service.EnsureDeployedAsync(
@@ -185,7 +205,6 @@ public class EventDeployServiceTest : TestBaseSetup
         // Boot a real Core so the SDK schema is materialised against the
         // testcontainer; we'll seed a Site/Language directly.
         var core = await GetCore();
-        Assert.That(core, Is.Not.Null);
 
         // GetCore() seeds the SDK's default languages (Language.AddDefaultLanguages);
         // grab any one of them rather than inserting a duplicate.
@@ -215,20 +234,11 @@ public class EventDeployServiceTest : TestBaseSetup
         await BackendConfigurationPnDbContext!.Compliances.AddAsync(existingCompliance);
         await BackendConfigurationPnDbContext.SaveChangesAsync();
 
-        var rotation = new CalendarTaskResponseModel
-        {
-            Id = 102,
-            PlanningId = planningId,
-            EformId = 400,
-            TaskDate = rotationDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-            IsFromCompliance = false
-        };
-        var calendar = Substitute.For<IBackendConfigurationCalendarService>();
-        calendar.GetTasksForWeek(Arg.Any<CalendarTaskRequestModel>())
-            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, [rotation]));
-
-        var coreHelper = Substitute.For<IEFormCoreService>();
-        coreHelper.GetCore().Returns(Task.FromResult(core));
+        var rotation = MakeRotation(
+            id: 102,
+            date: rotationDate,
+            planningId: planningId,
+            eformId: 400);
 
         // Use a capturing TestLogger so we can prove the idempotence guard
         // (EventDeployService.cs:184-195) short-circuited. Asserting only
@@ -241,12 +251,8 @@ public class EventDeployServiceTest : TestBaseSetup
         // emitted, we pin that the guard fired before either downstream
         // null-fallthrough.
         var logger = new TestLogger<EventDeployService>();
-        var service = new EventDeployService(
-            BackendConfigurationPnDbContext!,
-            ItemsPlanningPnDbContext!,
-            coreHelper,
-            calendar,
-            logger);
+        var (calendar, coreHelper) = MakeMocks([rotation], core);
+        var service = MakeService(calendar, coreHelper, logger);
 
         // Act
         await service.EnsureDeployedAsync(
@@ -306,30 +312,14 @@ public class EventDeployServiceTest : TestBaseSetup
         // pipeline gets past the candidate filter and into the SDK Sites
         // EF query, which honours the token.
         var core = await GetCore();
-        Assert.That(core, Is.Not.Null);
 
-        var future = DateTime.UtcNow.Date.AddDays(2).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-        var rotation = new CalendarTaskResponseModel
-        {
-            Id = 103,
-            PlanningId = 700,
-            EformId = 800,
-            TaskDate = future,
-            IsFromCompliance = false
-        };
-        var calendar = Substitute.For<IBackendConfigurationCalendarService>();
-        calendar.GetTasksForWeek(Arg.Any<CalendarTaskRequestModel>())
-            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, [rotation]));
-
-        var coreHelper = Substitute.For<IEFormCoreService>();
-        coreHelper.GetCore().Returns(Task.FromResult(core));
-
-        var service = new EventDeployService(
-            BackendConfigurationPnDbContext!,
-            ItemsPlanningPnDbContext!,
-            coreHelper,
-            calendar,
-            NullLogger<EventDeployService>.Instance);
+        var rotation = MakeRotation(
+            id: 103,
+            date: DateTime.UtcNow.Date.AddDays(2),
+            planningId: 700,
+            eformId: 800);
+        var (calendar, coreHelper) = MakeMocks([rotation], core);
+        var service = MakeService(calendar, coreHelper);
 
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
@@ -1,0 +1,349 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+using System.Globalization;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using NSubstitute;
+
+/// <summary>
+/// Integration tests for <see cref="EventDeployService"/> — the inline-deploy
+/// pipeline that backs <c>EventsGrpcService.ListEvents</c>. Each test pins one
+/// invariant from <c>EventDeployService.cs:42-50</c> so a future regression in
+/// the eager-deploy contract surfaces in CI before reaching master.
+///
+/// All tests use a real <see cref="BackendConfigurationPnDbContext"/> +
+/// <see cref="ItemsPlanningPnDbContext"/> from <see cref="TestBaseSetup"/> and
+/// mock <see cref="IBackendConfigurationCalendarService"/> so we can pin the
+/// rotation stream the deploy pipeline iterates over without standing up the
+/// full calendar service. <see cref="IEFormCoreService"/> is also mocked
+/// because the no-op fast paths (tests 1-3) return before
+/// <c>coreHelper.GetCore()</c> is reached; tests that DO reach the SDK path
+/// (4, 7) seed a real SDK site via <see cref="TestBaseSetup.GetCore"/>.
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class EventDeployServiceTest : TestBaseSetup
+{
+    private const string PropertyId = "1";
+    private const int SdkSiteId = 1;
+    private static readonly IReadOnlyCollection<string> BoardIds = ["10"];
+
+    // ------------------------------------------------------------------
+    // 1. EnsureDeployedAsync_NoRotationsInWindow_DoesNothing
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task EnsureDeployedAsync_NoRotationsInWindow_DoesNothing()
+    {
+        // Arrange — calendar returns zero rotations for the window.
+        var calendar = Substitute.For<IBackendConfigurationCalendarService>();
+        calendar.GetTasksForWeek(Arg.Any<CalendarTaskRequestModel>())
+            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, []));
+
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        var service = new EventDeployService(
+            BackendConfigurationPnDbContext!,
+            ItemsPlanningPnDbContext!,
+            coreHelper,
+            calendar,
+            NullLogger<EventDeployService>.Instance);
+
+        // Act
+        await service.EnsureDeployedAsync(
+            PropertyId, BoardIds, "2026-05-14", "2026-05-20", SdkSiteId, CancellationToken.None);
+
+        // Assert — nothing was written, and the SDK Core was never even fetched.
+        var complianceCount = await BackendConfigurationPnDbContext!.Compliances.CountAsync();
+        Assert.That(complianceCount, Is.EqualTo(0));
+        await coreHelper.DidNotReceive().GetCore();
+    }
+
+    // ------------------------------------------------------------------
+    // 2. EnsureDeployedAsync_RotationInPast_SkippedNotDeployed
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task EnsureDeployedAsync_RotationInPast_SkippedNotDeployed()
+    {
+        // Arrange — yesterday's rotation. EventDeployService should refuse
+        // to back-deploy historical rows (the scheduler owns those).
+        var yesterday = DateTime.UtcNow.Date.AddDays(-1).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var pastRotation = new CalendarTaskResponseModel
+        {
+            Id = 100,
+            PlanningId = 200,
+            EformId = 300,
+            TaskDate = yesterday,
+            IsFromCompliance = false
+        };
+
+        var calendar = Substitute.For<IBackendConfigurationCalendarService>();
+        calendar.GetTasksForWeek(Arg.Any<CalendarTaskRequestModel>())
+            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, [pastRotation]));
+
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        var service = new EventDeployService(
+            BackendConfigurationPnDbContext!,
+            ItemsPlanningPnDbContext!,
+            coreHelper,
+            calendar,
+            NullLogger<EventDeployService>.Instance);
+
+        // Act
+        await service.EnsureDeployedAsync(
+            PropertyId, BoardIds, "2026-05-01", "2026-05-31", SdkSiteId, CancellationToken.None);
+
+        // Assert — past rotation skipped before reaching the SDK path.
+        var complianceCount = await BackendConfigurationPnDbContext!.Compliances.CountAsync();
+        Assert.That(complianceCount, Is.EqualTo(0));
+        await coreHelper.DidNotReceive().GetCore();
+    }
+
+    // ------------------------------------------------------------------
+    // 3. EnsureDeployedAsync_RotationIsFromCompliance_SkippedNotDeployed
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task EnsureDeployedAsync_RotationIsFromCompliance_SkippedNotDeployed()
+    {
+        // Arrange — a future rotation that is already backed by a Compliance
+        // (IsFromCompliance=true). EventDeployService should filter these out
+        // because they need no deploy.
+        var future = DateTime.UtcNow.Date.AddDays(2).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var complianceBackedRotation = new CalendarTaskResponseModel
+        {
+            Id = 101,
+            PlanningId = 201,
+            EformId = 301,
+            TaskDate = future,
+            IsFromCompliance = true
+        };
+
+        var calendar = Substitute.For<IBackendConfigurationCalendarService>();
+        calendar.GetTasksForWeek(Arg.Any<CalendarTaskRequestModel>())
+            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, [complianceBackedRotation]));
+
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        var service = new EventDeployService(
+            BackendConfigurationPnDbContext!,
+            ItemsPlanningPnDbContext!,
+            coreHelper,
+            calendar,
+            NullLogger<EventDeployService>.Instance);
+
+        // Act
+        await service.EnsureDeployedAsync(
+            PropertyId, BoardIds, "2026-05-14", "2026-05-20", SdkSiteId, CancellationToken.None);
+
+        // Assert — no Compliance row created, SDK Core never fetched.
+        var complianceCount = await BackendConfigurationPnDbContext!.Compliances.CountAsync();
+        Assert.That(complianceCount, Is.EqualTo(0));
+        await coreHelper.DidNotReceive().GetCore();
+    }
+
+    // ------------------------------------------------------------------
+    // 4. EnsureDeployedAsync_ComplianceAlreadyExists_SkipsRotation
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task EnsureDeployedAsync_ComplianceAlreadyExists_SkipsRotation()
+    {
+        // Arrange — a Compliance row already exists for
+        // (planningId, rotationDate). The pipeline's idempotence guard
+        // (EventDeployService.cs:184-195) must short-circuit before any
+        // PlanningCase / CaseCreate is attempted.
+
+        // Boot a real Core so the SDK schema is materialised against the
+        // testcontainer; we'll seed a Site/Language directly.
+        var core = await GetCore();
+        Assert.That(core, Is.Not.Null);
+
+        // GetCore() seeds the SDK's default languages (Language.AddDefaultLanguages);
+        // grab any one of them rather than inserting a duplicate.
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        var site = new Site
+        {
+            Name = "test-site",
+            MicrotingUid = 42,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(site);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        const int planningId = 500;
+        var rotationDate = DateTime.UtcNow.Date.AddDays(3);
+        var existingCompliance = new Compliance
+        {
+            PlanningId = planningId,
+            PropertyId = 1,
+            AreaId = 1,
+            Deadline = rotationDate,
+            StartDate = rotationDate.AddDays(-7),
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await BackendConfigurationPnDbContext!.Compliances.AddAsync(existingCompliance);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var rotation = new CalendarTaskResponseModel
+        {
+            Id = 102,
+            PlanningId = planningId,
+            EformId = 400,
+            TaskDate = rotationDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            IsFromCompliance = false
+        };
+        var calendar = Substitute.For<IBackendConfigurationCalendarService>();
+        calendar.GetTasksForWeek(Arg.Any<CalendarTaskRequestModel>())
+            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, [rotation]));
+
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+
+        var service = new EventDeployService(
+            BackendConfigurationPnDbContext!,
+            ItemsPlanningPnDbContext!,
+            coreHelper,
+            calendar,
+            NullLogger<EventDeployService>.Instance);
+
+        // Act
+        await service.EnsureDeployedAsync(
+            PropertyId, BoardIds, "2026-05-14", "2026-05-20", site.Id, CancellationToken.None);
+
+        // Assert — still exactly 1 Compliance row, no duplicate from the deploy pass.
+        var complianceCount = await BackendConfigurationPnDbContext.Compliances.CountAsync();
+        Assert.That(complianceCount, Is.EqualTo(1));
+    }
+
+    // ------------------------------------------------------------------
+    // 5. EnsureDeployedAsync_PlanningStateRemainsUntouched
+    // SKIPPED — to drive the pipeline PAST the idempotence guard we'd need
+    // to seed the full Planning + PlanningNameTranslation + AreaRulePlanning
+    // + Area + AreaRule + Property graph AND make the real Core's CaseCreate
+    // succeed against a real eForm template (or stub the Core, which is not
+    // an interface). The Planning-state invariant is enforced structurally:
+    // EventDeployService.cs:168-358 reads `planning.LastExecutedTime` only as
+    // a fallback for `Compliance.StartDate` and otherwise never writes to
+    // LastExecutedTime / DoneInPeriod / NextExecutionTime / PushMessageSent.
+    // The dual-subagent code review on PR #813 already pinned this; covering
+    // it as an integration test would cost more setup than the regression
+    // surface justifies. Re-evaluate if the deploy path grows a Planning
+    // write.
+    // ------------------------------------------------------------------
+
+    // ------------------------------------------------------------------
+    // 6. EnsureDeployedAsync_RotationFailureDoesNotAbortOthers
+    // SKIPPED — same blocker as test 5. To make CaseCreate throw on the
+    // first rotation and succeed on the second we'd need to stub
+    // <c>eFormCore.Core</c>, which is a concrete class (no interface). The
+    // per-rotation try/catch on EventDeployService.cs:351-357 is structural
+    // and was pinned by the PR #813 review. Re-evaluate if we extract an
+    // ICoreFacade or similar that lets us inject failures at the SDK seam.
+    // ------------------------------------------------------------------
+
+    // ------------------------------------------------------------------
+    // 7. EnsureDeployedAsync_CancellationRequested_HonoursToken
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task EnsureDeployedAsync_CancellationRequested_HonoursToken()
+    {
+        // Arrange — pre-cancelled token + a future-day rotation, so the
+        // pipeline gets past the candidate filter and into the SDK Sites
+        // EF query, which honours the token.
+        var core = await GetCore();
+        Assert.That(core, Is.Not.Null);
+
+        var future = DateTime.UtcNow.Date.AddDays(2).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var rotation = new CalendarTaskResponseModel
+        {
+            Id = 103,
+            PlanningId = 700,
+            EformId = 800,
+            TaskDate = future,
+            IsFromCompliance = false
+        };
+        var calendar = Substitute.For<IBackendConfigurationCalendarService>();
+        calendar.GetTasksForWeek(Arg.Any<CalendarTaskRequestModel>())
+            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, [rotation]));
+
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+
+        var service = new EventDeployService(
+            BackendConfigurationPnDbContext!,
+            ItemsPlanningPnDbContext!,
+            coreHelper,
+            calendar,
+            NullLogger<EventDeployService>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act + Assert — either the cancellation token cascades into an
+        // OperationCanceledException (preferred) or the call returns
+        // without writing. Both shapes honour the contract.
+        var beforeCount = await BackendConfigurationPnDbContext!.Compliances.CountAsync();
+
+        try
+        {
+            await service.EnsureDeployedAsync(
+                PropertyId, BoardIds, "2026-05-14", "2026-05-20", SdkSiteId, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected path — the EF query in the foreach loop (or the
+            // sdkSite lookup) sees the cancelled token and throws.
+        }
+
+        var afterCount = await BackendConfigurationPnDbContext.Compliances.CountAsync();
+        Assert.That(afterCount, Is.EqualTo(beforeCount),
+            "Cancellation must not produce any Compliance writes.");
+    }
+
+    // ------------------------------------------------------------------
+    // 8. EnsureDeployedAsync_HappyPath_CreatesPlanningCaseSiteAndCompliance
+    // SKIPPED (deferred). The end-to-end deploy needs:
+    //   - real Planning + PlanningNameTranslation
+    //   - real AreaRule + AreaRulePlanning + Area + Property
+    //   - real eForm template in the SDK so ReadeForm / CaseCreate succeed
+    //   - real SDK Site/Worker/Unit chain
+    // That's ~10 entities + a parsed XML template. The closest precedent is
+    // BackendConfigurationTaskTrackerServiceHelperTest which does set this
+    // up; replicating it here is high-value but beyond the budget for this
+    // first batch. Track as a follow-up: copy the TaskTracker bootstrap and
+    // assert that one call to EnsureDeployedAsync creates exactly one
+    // PlanningCase + PlanningCaseSite + Compliance with the documented
+    // column-name quirk (PlanningCaseSiteId = PlanningCase.Id; see
+    // EventDeployService.cs:392-395).
+    // ------------------------------------------------------------------
+}


### PR DESCRIPTION
## Summary

Adds NUnit integration tests covering the inline-deploy invariants of `EventDeployService` (added in PR #813). Catches regressions before they reach master.

## Tests added (5)

- `EnsureDeployedAsync_NoRotationsInWindow_DoesNothing` — empty calendar result, no Compliance writes, SDK core never reached.
- `EnsureDeployedAsync_RotationInPast_SkippedNotDeployed` — yesterday-dated rotation filtered before the deploy path.
- `EnsureDeployedAsync_RotationIsFromCompliance_SkippedNotDeployed` — `IsFromCompliance=true` rotation filtered by the candidate `.Where`.
- `EnsureDeployedAsync_ComplianceAlreadyExists_SkipsRotation` — seeds a Compliance for `(planningId, deadline.Date)`, asserts the idempotence guard prevents a duplicate. Uses a custom TestLogger to also pin that the post-guard not-found warning paths are NOT taken — without this, a broken guard would silently produce the same Compliance count via the `AreaRulePlanning == null` fallthrough.
- `EnsureDeployedAsync_CancellationRequested_HonoursToken` — pre-cancelled token, asserts `OperationCanceledException` is thrown and no Compliance rows are written.

## Tests deferred (with justifications in code)

- Planning-state immutability — requires a full `Planning + PlanningNameTranslation + AreaRulePlanning + AreaRule + Area + Property` graph + a real `CaseCreate` against a real eForm template. Invariant is structurally enforced by the source (no writes to `LastExecutedTime`/`DoneInPeriod`/`NextExecutionTime`/`PushMessageSent` anywhere) and was pinned by the pre-push code-reviewer on PR #813.
- Per-rotation failure isolation — `eFormCore.Core` is a concrete class with no interface, so we can't make `CaseCreate` throw selectively. Follow-up: extract an `ICoreFacade` or similar.
- Happy-path end-to-end — same setup blocker as Planning-state.

## Pre-push gate

- Code-reviewer found two findings, both fixed in `3814d58d`:
  - Test #4 tautological (Compliance count == 1 in both "guard fired" AND "guard missed → AreaRulePlanning null fallthrough" branches) — now uses TestLogger to assert the fallthrough paths are NOT taken.
  - Test #7 cancellation try/catch too permissive — now uses `Assert.ThrowsAsync<OperationCanceledException>`.
- Code-simplifier found duplication — applied in this PR's final commit.

## CI

These tests run as part of the existing `test-dotnet` job in `.github/workflows/dotnet-core-master.yml`, which spins up MariaDB via Testcontainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)