### PR TITLE
fix(events): eager-deploy EndDate must be end-of-rotation-day, not midnight

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
@@ -341,35 +341,30 @@ public class EventDeployServiceTest : TestBaseSetup
     }
 
     // ------------------------------------------------------------------
-    // 7b. EnsureDeployedAsync_TodayRotation_DoesNotShortCircuitOnEndDateGuard
+    // 7b. EnsureDeployedAsync_TodayRotation_AdmittedByCandidateFilter
     //
-    // Regression for the bug where mainElement.EndDate was set to
-    // rotationDate (00:00 UTC). The downstream guard
-    // `if (mainElement.EndDate > DateTime.UtcNow)` then silently skipped
-    // _sdkCore.CaseCreate for any today-rotation deploy that ran after 00:00
-    // UTC, leaving Compliance rows with MicrotingSdkCaseId=0. The fix sets
-    // EndDate to end-of-rotation-day UTC (rotationDate.AddDays(1).AddTicks(-1)).
+    // Pins that the candidate filter at EventDeployService.cs:131
+    // (`rotationDate >= todayUtc`) admits today's rotation. A refactor that
+    // narrows this to `> todayUtc` would silently exclude today's rotations
+    // from eager deploy.
     //
-    // Direct unit coverage of the EndDate guard would require seeding the full
-    // Planning + AreaRulePlanning + Area + Property + eForm template graph
-    // (see the SKIPPED test 8 below). What we CAN pin here with the existing
-    // partial fixture is the broader contract: a today-rotation must enter
-    // the deploy pipeline at all (not be silently filtered out by the
-    // candidate filter at EventDeployService.cs:131
-    // `rotationDate >= todayUtc`). Observed via the warning emitted at
-    // EventDeployService.cs:208-210 when planning is missing. Without the
-    // candidate filter accepting today, that warning would never fire.
+    // This is NOT a regression test for the EndDate end-of-day fix from this
+    // commit. The assertion below fires at step 2 (planning lookup) of the
+    // deploy pipeline; the EndDate guard lives at step 7. Pre-fix and
+    // post-fix code emit the same planning-not-found warning for this
+    // fixture. Direct regression coverage of the EndDate guard requires a
+    // full Planning + AreaRulePlanning + Area + Property + eForm template
+    // graph (already deferred in the SKIPPED comments for tests #5/#6/#8
+    // below).
     // ------------------------------------------------------------------
     [Test]
-    public async Task EnsureDeployedAsync_TodayRotation_DoesNotShortCircuitOnEndDateGuard()
+    public async Task EnsureDeployedAsync_TodayRotation_AdmittedByCandidateFilter()
     {
-        // Arrange — a today rotation. Pre-fix this could be silently skipped
-        // by the EndDate guard; the candidate filter (>= todayUtc) admits it.
-        // We do NOT seed a Planning, so the pipeline must reach line 208's
-        // "planning ... not found" warning — which proves the rotation passed
-        // both the candidate filter AND the idempotence guard for today's
-        // date. If a future regression re-introduces a strict `> todayUtc`
-        // filter or otherwise excludes today, this test fails.
+        // Arrange — a today rotation. We do NOT seed a Planning, so when
+        // the rotation is admitted by the candidate filter the pipeline
+        // reaches the planning lookup and emits a "planning ... not found"
+        // warning. That warning is the observable canary that the filter
+        // admitted today's date.
         var core = await GetCore();
 
         // GetCore() seeds the SDK's default languages; reuse one.
@@ -399,13 +394,16 @@ public class EventDeployServiceTest : TestBaseSetup
 
         var todayKey = today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
-        // Act
+        // Act — drive the deploy pipeline with a today-keyed range. If the
+        // candidate filter at line ~131 admits today, control reaches the
+        // planning lookup (step 2). If a future refactor narrows the filter
+        // to `> todayUtc`, the rotation is dropped before step 2 fires.
         await service.EnsureDeployedAsync(
             PropertyId, BoardIds, todayKey, todayKey, site.Id, CancellationToken.None);
 
         // Assert — the today rotation reached the planning lookup at
-        // EventDeployService.cs:200-212, proving it was admitted by the
-        // candidate filter. The "planning ... not found" warning is the
+        // EventDeployService.cs:200-212, proving the candidate filter
+        // admitted it. The "planning ... not found" warning is the
         // observable canary. If the test fails, today rotations are being
         // silently filtered out before the deploy work begins.
         Assert.That(

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
@@ -341,6 +341,89 @@ public class EventDeployServiceTest : TestBaseSetup
     }
 
     // ------------------------------------------------------------------
+    // 7b. EnsureDeployedAsync_TodayRotation_DoesNotShortCircuitOnEndDateGuard
+    //
+    // Regression for the bug where mainElement.EndDate was set to
+    // rotationDate (00:00 UTC). The downstream guard
+    // `if (mainElement.EndDate > DateTime.UtcNow)` then silently skipped
+    // _sdkCore.CaseCreate for any today-rotation deploy that ran after 00:00
+    // UTC, leaving Compliance rows with MicrotingSdkCaseId=0. The fix sets
+    // EndDate to end-of-rotation-day UTC (rotationDate.AddDays(1).AddTicks(-1)).
+    //
+    // Direct unit coverage of the EndDate guard would require seeding the full
+    // Planning + AreaRulePlanning + Area + Property + eForm template graph
+    // (see the SKIPPED test 8 below). What we CAN pin here with the existing
+    // partial fixture is the broader contract: a today-rotation must enter
+    // the deploy pipeline at all (not be silently filtered out by the
+    // candidate filter at EventDeployService.cs:131
+    // `rotationDate >= todayUtc`). Observed via the warning emitted at
+    // EventDeployService.cs:208-210 when planning is missing. Without the
+    // candidate filter accepting today, that warning would never fire.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task EnsureDeployedAsync_TodayRotation_DoesNotShortCircuitOnEndDateGuard()
+    {
+        // Arrange — a today rotation. Pre-fix this could be silently skipped
+        // by the EndDate guard; the candidate filter (>= todayUtc) admits it.
+        // We do NOT seed a Planning, so the pipeline must reach line 208's
+        // "planning ... not found" warning — which proves the rotation passed
+        // both the candidate filter AND the idempotence guard for today's
+        // date. If a future regression re-introduces a strict `> todayUtc`
+        // filter or otherwise excludes today, this test fails.
+        var core = await GetCore();
+
+        // GetCore() seeds the SDK's default languages; reuse one.
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        var site = new Site
+        {
+            Name = "test-site-today",
+            MicrotingUid = 43,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(site);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var today = DateTime.UtcNow.Date;
+        const int planningId = 900;
+        var rotation = MakeRotation(
+            id: 104,
+            date: today,
+            planningId: planningId,
+            eformId: 901);
+
+        var logger = new TestLogger<EventDeployService>();
+        var (calendar, coreHelper) = MakeMocks([rotation], core);
+        var service = MakeService(calendar, coreHelper, logger);
+
+        var todayKey = today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        // Act
+        await service.EnsureDeployedAsync(
+            PropertyId, BoardIds, todayKey, todayKey, site.Id, CancellationToken.None);
+
+        // Assert — the today rotation reached the planning lookup at
+        // EventDeployService.cs:200-212, proving it was admitted by the
+        // candidate filter. The "planning ... not found" warning is the
+        // observable canary. If the test fails, today rotations are being
+        // silently filtered out before the deploy work begins.
+        Assert.That(
+            logger.Entries.Any(e =>
+                e.Level == LogLevel.Warning
+                && e.Message.Contains("planning")
+                && e.Message.Contains("not found")),
+            Is.True,
+            "Today rotation must reach the planning-lookup step at "
+            + "EventDeployService.cs:200-212. If this fails, today's "
+            + "rotations are being silently excluded from the deploy path.");
+
+        var complianceCount = await BackendConfigurationPnDbContext!.Compliances.CountAsync();
+        Assert.That(complianceCount, Is.EqualTo(0),
+            "Missing-planning path must not leave any Compliance rows behind.");
+    }
+
+    // ------------------------------------------------------------------
     // 8. EnsureDeployedAsync_HappyPath_CreatesPlanningCaseSiteAndCompliance
     // SKIPPED (deferred). The end-to-end deploy needs:
     //   - real Planning + PlanningNameTranslation

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
@@ -323,9 +323,11 @@ public class EventDeployService(
                 mainElement.EndDate = rotationDate.AddDays(1).AddTicks(-1);
 
                 // 7. Only call CaseCreate when EndDate is in the future
-                //    (mirrors ItemCaseCreateHandler.cs:236). Defensive — our
-                //    `rotationDate >= todayUtc` filter already covers this for
-                //    same-day rotations, but a clock-skew check costs nothing.
+                //    (mirrors ItemCaseCreateHandler.cs:236). The EndDate value
+                //    itself — end-of-rotation-day UTC (23:59:59.9999999) — is
+                //    what makes the guard pass for same-day deploys; this is
+                //    now a clock-skew belt + safety net for future changes to
+                //    rotationDate semantics.
                 if (mainElement.EndDate > DateTime.UtcNow)
                 {
                     var caseId = await sdkCore.CaseCreate(

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
@@ -313,10 +313,14 @@ public class EventDeployService(
                 }
 
                 mainElement.CheckListFolderName = folderId;
-                // EndDate = the rotation date itself. Compare with the handler
-                // which uses planning.NextExecutionTime — here we want the
-                // deploy bounded to the rotation we're filling.
-                mainElement.EndDate = rotationDate;
+                // Use end-of-rotation-day UTC so the SDK Case is created any time during the
+                // deadline day, not only when the deploy fires BEFORE 00:00 UTC.
+                // rotationDate is parsed at line 123-128 with
+                // AssumeUniversal | AdjustToUniversal then .Date, so it lands at 00:00 UTC.
+                // The downstream guard at line 325 (`mainElement.EndDate > DateTime.UtcNow`)
+                // otherwise silently skips CaseCreate for any same-day deploy, leaving
+                // Compliance rows with MicrotingSdkCaseId=0.
+                mainElement.EndDate = rotationDate.AddDays(1).AddTicks(-1);
 
                 // 7. Only call CaseCreate when EndDate is in the future
                 //    (mirrors ItemCaseCreateHandler.cs:236). Defensive — our


### PR DESCRIPTION
## Summary

Companion fix to PR #813 (eager-deploy of future events). When `EnsureDeployedAsync` ran on a TODAY rotation, the SDK case was never created because of a stale `mainElement.EndDate` value:

- `mainElement.EndDate = rotationDate` (parsed as midnight UTC)
- Downstream guard: `if (mainElement.EndDate > DateTime.UtcNow)` skips CaseCreate
- Today's deploy fires after 00:00 UTC → guard fails → `_sdkCore.CaseCreate` is silently skipped
- Compliance row written anyway with `MicrotingSdkCaseId=0` (from the unmodified `planningCaseSite.MicrotingSdkCaseId`)
- Result: `UploadPhoto` / `CompleteEvent` for these rotations fail with `FailedPrecondition`

Fix: use `rotationDate.AddDays(1).AddTicks(-1)` (end-of-rotation-day UTC) so the guard passes any time the deploy fires within the rotation day.

## Why this slipped past PR #814's tests

PR #814's 5 tests covered: empty window, past rotation, IsFromCompliance filter, idempotence guard, cancellation. None drove a today rotation through to the EndDate guard, because doing so cleanly requires the full Planning+AreaRulePlanning+Area+Property+eForm graph that we deferred (the SKIPPED tests #5/#6/#8 in the test file).

## Regression test included

`EnsureDeployedAsync_TodayRotation_AdmittedByCandidateFilter` — pins that today's rotation is admitted by the candidate filter at line 131 (`rotationDate >= todayUtc`). A future refactor that accidentally narrowed this to `> todayUtc` would silently exclude today's rotations again. The test comment is honest about what it does and doesn't cover (doesn't directly exercise the EndDate guard — that needs the full graph).

## Verification

- Pre-push dual-subagent gate (code-reviewer + code-simplifier).
- Code-reviewer initially flagged the test name oversold its scope; consolidation commit `7031c567` renamed to be honest about what's pinned vs deferred.
- `dotnet build` clean (0 errors).

Also worth knowing: two existing Compliance rows in the local DB (`420_eform-backend-configuration-plugin.Compliances` IDs 10219 + 10222) have `MicrotingSdkCaseId=0` from before the fix. They need to be soft-deleted (`WorkflowState='Removed'`) so the next eager deploy creates them properly. That's a runtime data-cleanup task, not part of this code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)