### PR TITLE
feat(calendar): route recurring-event delete through repeat-scope dialog

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-delete-modal/task-delete-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-delete-modal/task-delete-modal.component.html
@@ -2,12 +2,6 @@
 
 <div mat-dialog-content>
   <p>{{ 'Are you sure you want to delete' | translate }} <strong>{{ data.task.title }}</strong>?</p>
-
-  <mat-radio-group [(ngModel)]="scope" *ngIf="data.hasSeries" class="scope-group">
-    <mat-radio-button value="this">{{ 'Only this' | translate }}</mat-radio-button>
-    <mat-radio-button value="thisAndFollowing">{{ 'This and following' | translate }}</mat-radio-button>
-    <mat-radio-button value="all">{{ 'All in series' | translate }}</mat-radio-button>
-  </mat-radio-group>
 </div>
 
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-delete-modal/task-delete-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-delete-modal/task-delete-modal.component.ts
@@ -1,11 +1,10 @@
 import {Component, Inject} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {BackendConfigurationPnCalendarService} from '../../../../services';
-import {CalendarTaskModel, RepeatDeleteScope} from '../../../../models/calendar';
+import {CalendarTaskModel} from '../../../../models/calendar';
 
 export interface TaskDeleteModalData {
   task: CalendarTaskModel;
-  hasSeries: boolean;
 }
 
 @Component({
@@ -14,8 +13,6 @@ export interface TaskDeleteModalData {
   templateUrl: './task-delete-modal.component.html',
 })
 export class TaskDeleteModalComponent {
-  scope: RepeatDeleteScope = 'this';
-
   constructor(
     private dialogRef: MatDialogRef<TaskDeleteModalComponent>,
     @Inject(MAT_DIALOG_DATA) public data: TaskDeleteModalData,
@@ -23,7 +20,7 @@ export class TaskDeleteModalComponent {
   ) {}
 
   onConfirm() {
-    this.calendarService.deleteTask(this.data.task.id, this.scope, this.data.task.taskDate).subscribe(res => {
+    this.calendarService.deleteTask(this.data.task.id, 'this', this.data.task.taskDate).subscribe(res => {
       if (res && res.success) this.dialogRef.close(true);
     });
   }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.ts
@@ -3,11 +3,10 @@ import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material/dialog
 import {Overlay} from '@angular/cdk/overlay';
 import {dialogConfigHelper} from 'src/app/common/helpers';
 import {BackendConfigurationPnCalendarService} from '../../../../services';
-import {CalendarBoardModel, CalendarTaskModel} from '../../../../models/calendar';
+import {CalendarBoardModel, CalendarTaskModel, RepeatDeleteScope} from '../../../../models/calendar';
 import {CommonDictionaryModel} from 'src/app/common/models';
 import {TaskDeleteModalComponent} from '../task-delete-modal/task-delete-modal.component';
 import {RepeatScopeModalComponent} from '../repeat-scope-modal/repeat-scope-modal.component';
-import {RepeatDeleteScope} from '../../../../models/calendar';
 import {TranslateService} from '@ngx-translate/core';
 
 export interface TaskPreviewModalData {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.ts
@@ -6,6 +6,8 @@ import {BackendConfigurationPnCalendarService} from '../../../../services';
 import {CalendarBoardModel, CalendarTaskModel} from '../../../../models/calendar';
 import {CommonDictionaryModel} from 'src/app/common/models';
 import {TaskDeleteModalComponent} from '../task-delete-modal/task-delete-modal.component';
+import {RepeatScopeModalComponent} from '../repeat-scope-modal/repeat-scope-modal.component';
+import {RepeatDeleteScope} from '../../../../models/calendar';
 import {TranslateService} from '@ngx-translate/core';
 
 export interface TaskPreviewModalData {
@@ -87,12 +89,26 @@ export class TaskPreviewModalComponent {
   }
 
   onDelete() {
+    const task = this.data.task;
+    const isRepeating = !!task.repeatRule && task.repeatRule !== 'none';
+    if (isRepeating) {
+      const scopeRef = this.dialog.open(
+        RepeatScopeModalComponent,
+        dialogConfigHelper(this.overlay, {mode: 'delete'})
+      );
+      scopeRef.afterClosed().subscribe((scope: RepeatDeleteScope | null) => {
+        if (!scope) return;
+        this.calendarService
+          .deleteTask(task.id, scope, task.taskDate)
+          .subscribe(res => {
+            if (res && res.success) this.close('reload');
+          });
+      });
+      return;
+    }
     const ref = this.dialog.open(
       TaskDeleteModalComponent,
-      dialogConfigHelper(this.overlay, {
-        task: this.data.task,
-        hasSeries: !!this.data.task.repeatSeriesId,
-      })
+      dialogConfigHelper(this.overlay, {task})
     );
     ref.afterClosed().subscribe(result => {
       if (result) this.close('reload');


### PR DESCRIPTION
## Summary
- Right-click → **Delete** on a recurring calendar event now opens the same polished `RepeatScopeModalComponent` already used by move-on-drag (mode `'delete'`, title *Delete repeat*, three radios *Only this / This and following / All in series*). The chosen scope is passed to the existing `DeleteTask` backend endpoint, which already handles all three semantics.
- Non-recurring deletes are unchanged: `TaskDeleteModalComponent` still shows the simple *Are you sure...* confirm.
- Detection of "is this a recurring event" now uses `task.repeatRule !== 'none'`, matching the move / resize flows. The previous `task.repeatSeriesId` check was always false because the backend `CalendarTaskResponseModel` never populates that field — so the old scope-radios path under `*ngIf="data.hasSeries"` was silently dead. This PR fixes that drift.
- Cleanup: removes the now-dead scope-radio block, `RepeatDeleteScope` import, `scope` field, and `hasSeries` data flag from `TaskDeleteModalComponent`.

Spec: [`docs/superpowers/specs/2026-05-14-calendar-delete-repeat-scope-design.md`](https://github.com/microting/eform-angular-frontend/blob/master/docs/superpowers/specs/2026-05-14-calendar-delete-repeat-scope-design.md)

## Test plan
- [ ] Right-click a recurring event (e.g. weekly) → **Delete** → see `Delete repeat` dialog with the three radios.
- [ ] *Only this* → confirm → only that occurrence disappears.
- [ ] *This and following* → confirm → that occurrence + all later disappear; earlier occurrences remain.
- [ ] *All in series* → confirm → entire series gone.
- [ ] Right-click a one-off event → **Delete** → unchanged `Delete task / Are you sure...` confirm; no radios.
- [ ] Cancel on the new dialog closes without an API call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)