### PR TITLE
feat(events): user-overridable DoneAtUserModifiable on CompleteEvent

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
@@ -85,6 +85,8 @@ message CompleteEventRequest {
   // Cases.Custom envelope is left untouched. Non-empty replaces the
   // OpgaverComment body verbatim, matching SetComment semantics.
   string comment = 8;
+  // ISO-8601 date (yyyy-MM-dd); empty = fall back to deadline date
+  string done_at_user_modifiable = 9;
 }
 message CompleteEventResponse { Event opgave = 1; }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -1090,6 +1090,18 @@ public class EventsGrpcService(
     {
         var opgaveId = ParseOpgaveId(request.OpgaveId);
 
+        // Permanent entry trace: captures the raw wire payload so we can tell
+        // whether a client-side override (done_at_user_modifiable) actually
+        // reached the server. Logged before any branching so idempotent
+        // re-taps, legacy fallbacks, and the happy path all leave a record.
+        logger.LogInformation(
+            "CompleteEvent entry: opgaveId={OpgaveId} completed={Completed} " +
+            "complianceId={ComplianceId} microtingSdkCaseId={SdkCaseId} " +
+            "doneAtUserModifiable=\"{DoneAtUserModifiable}\" clientTsUnix={ClientTsUnix}",
+            request.OpgaveId, request.Completed,
+            request.ComplianceId, request.MicrotingSdkCaseId,
+            request.DoneAtUserModifiable, request.ClientTsUnix);
+
         // Idempotent re-tap path. The flutter UI sends `!o.completed` when a
         // worker re-taps a row, so a row whose local state already says
         // "completed" arrives here as Completed=false. There is nothing to

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -1228,6 +1228,21 @@ public class EventsGrpcService(
             deadlineDate.Year, deadlineDate.Month, deadlineDate.Day,
             wall.Hour, wall.Minute, wall.Second,
             DateTimeKind.Utc);
+        // User-overridable variant: the client may override the DATE while wall-clock TIME is preserved.
+        // DoneAt stays deadline-dated (load-bearing for the angular "filled cases" admin view, see 1195-1216);
+        // only DoneAtUserModifiable picks up the override.
+        var userModifiable = dayDoneAt;
+        if (!string.IsNullOrEmpty(request.DoneAtUserModifiable)
+            && DateTime.TryParseExact(
+                request.DoneAtUserModifiable, "yyyy-MM-dd",
+                CultureInfo.InvariantCulture, DateTimeStyles.None,
+                out var overrideDate))
+        {
+            userModifiable = new DateTime(
+                overrideDate.Year, overrideDate.Month, overrideDate.Day,
+                wall.Hour, wall.Minute, wall.Second,
+                DateTimeKind.Utc);
+        }
         // Wall-clock "when the worker actually closed this on the device" —
         // still used for the comment TsUnix audit trail below. DoneAt fields
         // now combine deadline DATE + wall TIME (see dayDoneAt above).
@@ -1348,7 +1363,7 @@ public class EventsGrpcService(
                     .ConfigureAwait(false);
             }
 
-            foundCase.DoneAtUserModifiable = dayDoneAt;
+            foundCase.DoneAtUserModifiable = userModifiable;
             foundCase.DoneAt = dayDoneAt;
             foundCase.SiteId = sdkSiteId;
             foundCase.Status = 100;
@@ -1617,8 +1632,9 @@ public class EventsGrpcService(
             // identically at the primary assignment above. This
             // belt-and-suspenders re-load + re-write reads the row back
             // through a fresh sdkDbContext (so the change tracker is empty),
-            // sets both columns to dayDoneAt, and calls Update only when at
-            // least one diverges. Logged at Debug level — divergence is
+            // sets each column to its expected value (DoneAt → dayDoneAt;
+            // DoneAtUserModifiable → userModifiable), and calls Update only
+            // when at least one diverges. Logged at Debug level — divergence is
             // expected steady-state until the upstream mutator is identified;
             // a Warning here would spam prod logs.
             try
@@ -1629,16 +1645,16 @@ public class EventsGrpcService(
                     .ConfigureAwait(false);
                 if (reaffirmCase != null
                     && (reaffirmCase.DoneAt != dayDoneAt
-                        || reaffirmCase.DoneAtUserModifiable != dayDoneAt))
+                        || reaffirmCase.DoneAtUserModifiable != userModifiable))
                 {
                     logger.LogDebug(
                         "CompleteOpgave: re-affirm correcting DoneAt/DoneAtUserModifiable "
                         + "for caseId={CaseId}: DoneAt was {DoneAt} expected {DayDoneAt}, "
-                        + "DoneAtUserModifiable was {DoneAtUserModifiable} expected {DayDoneAt}.",
+                        + "DoneAtUserModifiable was {DoneAtUserModifiable} expected {UserModifiable}.",
                         reaffirmCase.Id, reaffirmCase.DoneAt, dayDoneAt,
-                        reaffirmCase.DoneAtUserModifiable, dayDoneAt);
+                        reaffirmCase.DoneAtUserModifiable, userModifiable);
                     reaffirmCase.DoneAt = dayDoneAt;
-                    reaffirmCase.DoneAtUserModifiable = dayDoneAt;
+                    reaffirmCase.DoneAtUserModifiable = userModifiable;
                     await reaffirmCase.Update(sdkDbContextReread).ConfigureAwait(false);
                 }
             }


### PR DESCRIPTION
## Summary

- Adds optional `CompleteEventRequest.done_at_user_modifiable` (yyyy-MM-dd ISO date).
- Server (`EventsGrpcService.CompleteEvent`) combines the override DATE with the wall-clock TIME and writes the result to `Case.DoneAtUserModifiable`.
- `Case.DoneAt` is **unchanged** — still deadline-date + wall-time, which is load-bearing for the angular "filled cases" admin view (rationale at `EventsGrpcService.cs:1195-1216`).
- The downstream re-affirm safety-net now compares and rewrites `DoneAtUserModifiable` against `userModifiable` rather than `dayDoneAt`, so user overrides survive it.
- Empty / unparseable input falls back to current behavior (backwards-compatible with mobile clients pre-dating this change).

## Test plan

- [ ] Backend builds and starts cleanly with the new plugin (verified locally)
- [ ] Mobile client diff (separate flutter-eform PR) sends the new field and the value is observed on the SDK `Cases.DoneAtUserModifiable` column
- [ ] Default path (empty `done_at_user_modifiable`) still produces `DoneAtUserModifiable == dayDoneAt`
- [ ] Override path produces `DoneAtUserModifiable == picked-date @ wall-time` while `DoneAt == deadline-date @ wall-time`
- [ ] Angular case editor's "Submitted date" reflects the override

🤖 Generated with [Claude Code](https://claude.com/claude-code)