### PR TITLE
feat(events): DoneAt also tracks worker's done_at_user_modifiable override

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -1204,25 +1204,29 @@ public class EventsGrpcService(
                 $"Opgave {opgaveId} has no pending compliance — there is no SDK case to complete."));
         }
 
-        // DoneAt is composed: the DATE comes from compliance.Deadline (the
-        // rotation's scheduled date) so missed-rotation reports stay dated to
-        // the scheduled rotation day — a worker closing a Monday rotation on
-        // Wednesday must still produce a Monday-dated report so the angular
-        // admin "filled cases" view (queries PlanningCases WHERE
-        // MicrotingSdkCaseDoneAt >= fromDate) and per-rotation history line
-        // up. The TIME is restored from the client's wall-clock tap
-        // (request.ClientTsUnix); previously the value was truncated to
-        // midnight UTC, but the worker's actual time-of-completion is the
-        // more informative signal for reports and is what BackendConfiguration
-        // CompliancesService.Update preserves on the angular side. Falls back
-        // to DateTime.UtcNow if ClientTsUnix is 0 (legacy clients pre-dating
-        // the field).
+        // DoneAt and DoneAtUserModifiable both track the same target value:
         //
-        // Compliance.Deadline is non-nullable (DateTime, not DateTime?) but
-        // can be default(DateTime) on legacy / partially-populated rows; the
+        //   • If the client sends an explicit `done_at_user_modifiable` override
+        //     (the worker tapped the chip and picked a different date), both
+        //     fields receive that override date combined with the wall-clock
+        //     time-of-day. The worker's explicit choice trumps the auto
+        //     deadline-dating.
+        //
+        //   • If no override is sent (worker tapped Complete without touching
+        //     the chip), `userModifiable` falls back to `dayDoneAt`, which is
+        //     composed from `compliance.Deadline` (date) + `request.ClientTsUnix`
+        //     (wall-clock time). Missed-rotation reports therefore stay dated to
+        //     the scheduled rotation day in this default path — a Monday closed
+        //     on Wednesday produces a Monday-dated report so the angular admin
+        //     "filled cases" view (queries PlanningCases WHERE
+        //     MicrotingSdkCaseDoneAt >= fromDate) and per-rotation history line
+        //     up.
+        //
+        // Compliance.Deadline is non-nullable (DateTime, not DateTime?) but can
+        // be default(DateTime) on legacy / partially-populated rows; the
         // != default guard mirrors lines 1681 / 1938 / 2734 in this file.
-        // Falling back to DateTime.UtcNow keeps the previous behaviour for
-        // those edge cases.
+        // Falling back to DateTime.UtcNow keeps the previous behaviour for those
+        // edge cases.
         var deadlineDate = compliance.Deadline != default
             ? compliance.Deadline
             : DateTime.UtcNow;
@@ -1240,9 +1244,10 @@ public class EventsGrpcService(
             deadlineDate.Year, deadlineDate.Month, deadlineDate.Day,
             wall.Hour, wall.Minute, wall.Second,
             DateTimeKind.Utc);
-        // User-overridable variant: the client may override the DATE while wall-clock TIME is preserved.
-        // DoneAt stays deadline-dated (load-bearing for the angular "filled cases" admin view, see 1195-1216);
-        // only DoneAtUserModifiable picks up the override.
+        // User-overridable variant: the client may override the DATE while
+        // wall-clock TIME is preserved. Both DoneAt and DoneAtUserModifiable
+        // track this value (see rationale block above); when no override is
+        // sent it falls back to dayDoneAt so the default path is unchanged.
         var userModifiable = dayDoneAt;
         if (!string.IsNullOrEmpty(request.DoneAtUserModifiable)
             && DateTime.TryParseExact(
@@ -1376,7 +1381,7 @@ public class EventsGrpcService(
             }
 
             foundCase.DoneAtUserModifiable = userModifiable;
-            foundCase.DoneAt = dayDoneAt;
+            foundCase.DoneAt = userModifiable;
             foundCase.SiteId = sdkSiteId;
             foundCase.Status = 100;
             // Direct WorkflowState assignment (not entity.Delete) is the
@@ -1644,11 +1649,11 @@ public class EventsGrpcService(
             // identically at the primary assignment above. This
             // belt-and-suspenders re-load + re-write reads the row back
             // through a fresh sdkDbContext (so the change tracker is empty),
-            // sets each column to its expected value (DoneAt → dayDoneAt;
-            // DoneAtUserModifiable → userModifiable), and calls Update only
-            // when at least one diverges. Logged at Debug level — divergence is
-            // expected steady-state until the upstream mutator is identified;
-            // a Warning here would spam prod logs.
+            // sets each column to userModifiable (which equals dayDoneAt when
+            // no override is sent), and calls Update only when at least one
+            // diverges. Logged at Debug level — divergence is expected
+            // steady-state until the upstream mutator is identified; a Warning
+            // here would spam prod logs.
             try
             {
                 var sdkDbContextReread = core.DbContextHelper.GetDbContext();
@@ -1656,16 +1661,16 @@ public class EventsGrpcService(
                     .FirstOrDefaultAsync(x => x.Id == foundCase.Id)
                     .ConfigureAwait(false);
                 if (reaffirmCase != null
-                    && (reaffirmCase.DoneAt != dayDoneAt
+                    && (reaffirmCase.DoneAt != userModifiable
                         || reaffirmCase.DoneAtUserModifiable != userModifiable))
                 {
                     logger.LogDebug(
                         "CompleteOpgave: re-affirm correcting DoneAt/DoneAtUserModifiable "
-                        + "for caseId={CaseId}: DoneAt was {DoneAt} expected {DayDoneAt}, "
+                        + "for caseId={CaseId}: DoneAt was {DoneAt} expected {UserModifiable}, "
                         + "DoneAtUserModifiable was {DoneAtUserModifiable} expected {UserModifiable}.",
-                        reaffirmCase.Id, reaffirmCase.DoneAt, dayDoneAt,
+                        reaffirmCase.Id, reaffirmCase.DoneAt, userModifiable,
                         reaffirmCase.DoneAtUserModifiable, userModifiable);
-                    reaffirmCase.DoneAt = dayDoneAt;
+                    reaffirmCase.DoneAt = userModifiable;
                     reaffirmCase.DoneAtUserModifiable = userModifiable;
                     await reaffirmCase.Update(sdkDbContextReread).ConfigureAwait(false);
                 }


### PR DESCRIPTION
## Summary

When the mobile client sends a `done_at_user_modifiable` override, both `Case.DoneAt` and `Case.DoneAtUserModifiable` now receive it. Previously only `DoneAtUserModifiable` flexed; `DoneAt` always stayed deadline-dated.

## Why

A worker who explicitly picks a different done-at-date via the chip is making a deliberate product choice that the canonical `DoneAt` should reflect. The original deadline-dating logic was meant as the default (no-override) behavior, not a hard floor under the worker's explicit pick.

## Backwards-compatible

- When the request has no override -> `userModifiable` falls back to `dayDoneAt` (compliance.Deadline + wall-clock time) -> both columns get the same dayDoneAt -> identical observable behavior to before.
- When the request HAS an override -> both columns get the override date + wall-clock time.

So old clients and the default Complete-tap flow are unaffected. Only the explicit-override path changes.

## What changed

- `foundCase.DoneAt = userModifiable;` (was `dayDoneAt`)
- Re-affirm safety block now compares + rewrites both columns against `userModifiable`
- Rationale comment at lines 1195-1216 rewritten to reflect the new semantics

## Test plan

- [ ] No-override Complete: case row gets `DoneAt = DoneAtUserModifiable = dayDoneAt` (regression test of default path)
- [ ] Override Complete: case row gets `DoneAt = DoneAtUserModifiable = override @ wall-time` (the new behavior)
- [ ] Re-affirm block triggers cleanly on either path
- [ ] Angular "filled cases" admin view continues to render correctly when override is used (the date shown will now be the worker's pick, which is the intended product behavior)

Generated with [Claude Code](https://claude.com/claude-code)