### PR TITLE
feat(calendar): hide My teams + My employees sidebar sections

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-sidebar/calendar-sidebar.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-sidebar/calendar-sidebar.component.html
@@ -57,6 +57,7 @@
     <a class="sidebar-action-link" (click)="createBoard.emit()">+ {{ 'Opret tavle' | translate }}</a>
   </mat-expansion-panel>
 
+  <!-- My teams — hidden for now, will be re-enabled later
   <mat-expansion-panel [expanded]="true">
     <mat-expansion-panel-header>
       <mat-panel-title>{{ 'My teams' | translate }}</mat-panel-title>
@@ -83,7 +84,9 @@
     </div>
     <a class="sidebar-action-link" (click)="openCreateTeamDialog()">+ {{ 'Opret team' | translate }}</a>
   </mat-expansion-panel>
+  -->
 
+  <!-- My employees — hidden for now, will be re-enabled later
   <mat-expansion-panel [expanded]="true">
     <mat-expansion-panel-header>
       <mat-panel-title>{{ 'My employees' | translate }}</mat-panel-title>
@@ -100,6 +103,7 @@
     </div>
     <a class="sidebar-action-link" (click)="createEmployee.emit()">+ {{ 'Create employee' | translate }}</a>
   </mat-expansion-panel>
+  -->
 
   <!-- My tags — hidden for now, will be re-enabled later
   <mat-expansion-panel [expanded]="true">


### PR DESCRIPTION
## Summary

Wrap the two sidebar expansion panels (**Mine hold** / My teams and **Mine medarbejdere** / My employees) in HTML comments — same convention already used in this file for the **My tags** section — so they stop rendering in the calendar page.

The component `.ts` is unchanged: `teams`, `employees`, `activeTeamIds`, and the parent's `loadTeams()` / `loadEmployees()` stay in place so re-enabling is a single uncomment.

Spec: [`docs/superpowers/specs/2026-05-18-calendar-sidebar-hide-teams-employees-design.md`](https://github.com/microting/eform-angular-frontend/blob/master/docs/superpowers/specs/2026-05-18-calendar-sidebar-hide-teams-employees-design.md)

## Test plan
- [ ] Reload `/plugins/backend-configuration-pn/calendar` — sidebar shows only **Mine ejendomme**, **Mine tavler** (plus the still-commented **My tags** placeholder). No **Mine hold**, no **Mine medarbejdere**, no `+ Opret hold` / `+ Opret medarbejder` links.
- [ ] Drag, resize, move, delete, completion-toggle still work on events.
- [ ] Property selection still filters the calendar grid.
- [ ] CI `pn-playwright-test (l)` shard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)