### PR TITLE
fix(calendar): rejected future→past drop now snaps back to original slot

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.ts
@@ -374,46 +374,56 @@ export class CalendarWeekGridComponent implements OnInit, AfterViewInit, OnChang
         const sourceIsPast = sourceDateTime < now;
         const targetIsPast = targetDateTime < now;
 
-        if (sourceIsPast || !targetIsPast) {
-          const originalDate = task.taskDate;
-
-          // Reset CDK transform first (element still in original DOM position)
+        if (!sourceIsPast && targetIsPast) {
+          // Future task dropped before now: rejected. Reset the CDK
+          // transform and force a tasks reload so the parent re-renders
+          // the task at its original slot from server state — a bare
+          // reset() alone has been observed to leave the dragged block
+          // invisible when the drop target was in a past slot.
           event.source.reset();
-
-          // Then optimistically move the task in the local array.
-          // weekDays indices (0..N) may not align with tasksByDay (always
-          // Mon..Sun, 0..6) — e.g. day view has weekDays=[currentDate]
-          // which may map to tasksByDay[2] (Wed). Translate through
-          // allDayIndexFor so the optimistic update targets the right slot.
-          const origDayIndex = this.weekDays.findIndex(
-            d => this.toLocalDateString(d) === originalDate
-          );
-          if (origDayIndex >= 0) {
-            const origMappedIdx = this.allDayIndexFor(origDayIndex);
-            if (origMappedIdx >= 0) {
-              const origArr = this.tasksByDay[origMappedIdx];
-              if (origArr) {
-                const idx = origArr.findIndex(t => t.id === task.id);
-                if (idx >= 0) origArr.splice(idx, 1);
-              }
-            }
-          }
-          task.startHour = newStartHour;
-          task.taskDate = newDate;
-          const targetMappedIdx = this.allDayIndexFor(dayIndex);
-          if (targetMappedIdx >= 0 && this.tasksByDay[targetMappedIdx]) {
-            this.tasksByDay[targetMappedIdx].push(task);
-          }
-
-          this.taskMoved.emit({
-            taskId: task.id,
-            newDate,
-            newStartHour,
-            repeatSeriesId: task.repeatSeriesId,
-            originalDate,
-          });
+          this.tasksReload.emit();
           return;
         }
+
+        // Allowed: past→anywhere, or future→future. Optimistically move
+        // the task locally so the UI doesn't flash, then emit upward.
+        const originalDate = task.taskDate;
+
+        // Reset CDK transform first (element still in original DOM position)
+        event.source.reset();
+
+        // weekDays indices (0..N) may not align with tasksByDay (always
+        // Mon..Sun, 0..6) — e.g. day view has weekDays=[currentDate]
+        // which may map to tasksByDay[2] (Wed). Translate through
+        // allDayIndexFor so the optimistic update targets the right slot.
+        const origDayIndex = this.weekDays.findIndex(
+          d => this.toLocalDateString(d) === originalDate
+        );
+        if (origDayIndex >= 0) {
+          const origMappedIdx = this.allDayIndexFor(origDayIndex);
+          if (origMappedIdx >= 0) {
+            const origArr = this.tasksByDay[origMappedIdx];
+            if (origArr) {
+              const idx = origArr.findIndex(t => t.id === task.id);
+              if (idx >= 0) origArr.splice(idx, 1);
+            }
+          }
+        }
+        task.startHour = newStartHour;
+        task.taskDate = newDate;
+        const targetMappedIdx = this.allDayIndexFor(dayIndex);
+        if (targetMappedIdx >= 0 && this.tasksByDay[targetMappedIdx]) {
+          this.tasksByDay[targetMappedIdx].push(task);
+        }
+
+        this.taskMoved.emit({
+          taskId: task.id,
+          newDate,
+          newStartHour,
+          repeatSeriesId: task.repeatSeriesId,
+          originalDate,
+        });
+        return;
       }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #820. The new move-rule guards correctly **reject** dragging a future event to a moment before now, but the visual snap-back is incomplete: the bare `event.source.reset()` has been observed to leave the dragged task-block invisible after a rejected drop (likely a `.cdk-drag-dragging { opacity: 0 !important }` interaction with how CDK handles a drop into a foreign DOM position).

This change makes the rejected branch explicit:

1. Call `event.source.reset()` to clear the CDK transform.
2. Emit `tasksReload` so the parent re-fetches and re-renders the task from authoritative server state — guaranteeing the task reappears at its original slot.

While here, de-indent the now-redundant `if (sourceIsPast || !targetIsPast)` wrapper around the allowed-path code since the rejected case returns early.

## Test plan
- [ ] Drag a future event (e.g. tomorrow 08:00) backward to today at a start hour before the current clock → drop. The event should snap back to tomorrow 08:00 (no longer disappear).
- [ ] Drag the same future event to a future slot → still moves correctly (allowed path unchanged).
- [ ] Drag a past, uncompleted event to another past slot → still moves correctly.
- [ ] Drag outside the calendar (no valid drop) → still snaps back via the bottom reset.
- [ ] CI `pn-playwright-test (l)` shard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)