### PR TITLE
fix(calendar): apply occurrence-exception overrides to past compliance rows

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -540,6 +540,33 @@ public class BackendConfigurationCalendarService(
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                 .ToDictionaryAsync(x => x.AreaRulePlanningId);
 
+            // Top up exceptionsByArp with any exceptions for compliance ARPs not
+            // already covered. The earlier exceptionsInWeek query (line ~210) filtered
+            // by arpIds — which are only Status=true plannings. Compliance rows can
+            // exist for Status=false plannings too, and their move/resize exceptions
+            // must reach the compliance loop below.
+            var complianceOnlyArpIds = complianceArpIds.Except(arpIds).ToList();
+            if (complianceOnlyArpIds.Count > 0)
+            {
+                var extraExceptions = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
+                    .Where(x => complianceOnlyArpIds.Contains(x.AreaRulePlanningId))
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Where(x =>
+                        (x.OriginalDate >= weekStart && x.OriginalDate <= weekEnd) ||
+                        (x.NewDate.HasValue && x.NewDate.Value >= weekStart && x.NewDate.Value <= weekEnd))
+                    .Include(x => x.ExceptionSites)
+                    .ToListAsync();
+                foreach (var ex in extraExceptions)
+                {
+                    if (!exceptionsByArp.TryGetValue(ex.AreaRulePlanningId, out var perArpDict))
+                    {
+                        perArpDict = new Dictionary<DateTime, CalendarOccurrenceException>();
+                        exceptionsByArp[ex.AreaRulePlanningId] = perArpDict;
+                    }
+                    perArpDict[ex.OriginalDate.Date] = ex;
+                }
+            }
+
             // Batch-load tags for compliance ARPs
             var complianceArpTags = await backendConfigurationPnDbContext.AreaRulePlanningTags
                 .Where(x => complianceArpIds.Contains(x.AreaRulePlanningId))
@@ -636,13 +663,14 @@ public class BackendConfigurationCalendarService(
 
                 var effectiveTaskDate = complianceException?.NewDate?.Date ?? compliance.Deadline.Date;
                 var effectiveStartHour = complianceException?.StartHour ?? calConfig?.StartHour ?? 9.0;
+                var effectiveDuration = complianceException?.Duration ?? calConfig?.Duration ?? 1.0;
 
                 var model = new CalendarTaskResponseModel
                 {
                     Id = arp?.Id ?? 0,
                     Title = title,
                     StartHour = compIsAllDay ? 0 : effectiveStartHour,
-                    Duration = compIsAllDay ? 0 : calConfig?.Duration ?? 1.0,
+                    Duration = compIsAllDay ? 0 : effectiveDuration,
                     TaskDate = effectiveTaskDate.ToString("yyyy-MM-dd"),
                     Tags = tags,
                     AssigneeIds = arp?.PlanningSites?

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -610,13 +610,40 @@ public class BackendConfigurationCalendarService(
                     && weekComplianceCasesById.TryGetValue(compliance.MicrotingSdkCaseId, out var weekSdkCase)
                     && weekSdkCase.Status == 100;
 
+                // Apply any "this"-scope move/resize exception that overrides this past
+                // compliance occurrence's date / start-hour. Without this consultation, a
+                // user-applied move via MoveTask scope='this' would write an exception that
+                // the compliance loop never reads, and the event would snap back to
+                // compliance.Deadline on the next fetch. Mirrors the recurrence-expansion
+                // loop's exception handling above (around line 313).
+                CalendarOccurrenceException complianceException = null;
+                if (arp != null
+                    && exceptionsByArp.TryGetValue(arp.Id, out var complianceArpExceptions))
+                {
+                    complianceArpExceptions.TryGetValue(compliance.Deadline.Date, out complianceException);
+                }
+
+                // Soft-deleted occurrence: hide it.
+                if (complianceException?.IsDeleted == true) continue;
+
+                // Moved out of the current week: hide it here (the destination week's
+                // movedInExceptions pass at line ~387 renders it).
+                if (complianceException?.NewDate is { } movedDate
+                    && (movedDate < weekStart || movedDate > weekEnd))
+                {
+                    continue;
+                }
+
+                var effectiveTaskDate = complianceException?.NewDate?.Date ?? compliance.Deadline.Date;
+                var effectiveStartHour = complianceException?.StartHour ?? calConfig?.StartHour ?? 9.0;
+
                 var model = new CalendarTaskResponseModel
                 {
                     Id = arp?.Id ?? 0,
                     Title = title,
-                    StartHour = compIsAllDay ? 0 : calConfig?.StartHour ?? 9.0,
+                    StartHour = compIsAllDay ? 0 : effectiveStartHour,
                     Duration = compIsAllDay ? 0 : calConfig?.Duration ?? 1.0,
-                    TaskDate = compliance.Deadline.ToString("yyyy-MM-dd"),
+                    TaskDate = effectiveTaskDate.ToString("yyyy-MM-dd"),
                     Tags = tags,
                     AssigneeIds = arp?.PlanningSites?
                         .Where(ps => ps.WorkflowState != Constants.WorkflowStates.Removed)
@@ -645,7 +672,8 @@ public class BackendConfigurationCalendarService(
                     DescriptionHtml = compliancePlanningsDict.TryGetValue(compliance.PlanningId, out var cp)
                         ? cp.Description
                         : null,
-                    Attachments = MapAttachments(arp)
+                    Attachments = MapAttachments(arp),
+                    ExceptionId = complianceException?.Id,
                 };
 
                 if (ShouldIncludeTask(model, requestModel))


### PR DESCRIPTION
## Summary

Follow-up to PR #820 / #823. When you drag a past, uncompleted recurring event to a different past slot and accept *Only this* in the scope dialog, the move appears to succeed but then snaps back on the next fetch.

**Root cause.** `MoveTask` with `scope='this'` correctly writes a `CalendarOccurrenceException` row carrying `NewDate` + `StartHour`. Past occurrences in `GetTasksForWeek` are emitted by the **compliance loop** (line 581+), which renders straight from `Compliance.Deadline` and never consulted the exception — so the user's move was silently ignored on the next fetch.

**Fix.** Mirror the recurrence-expansion loop's exception handling (line ~313) inside the compliance loop:

- Look up `exceptionsByArp[arp.Id][compliance.Deadline.Date]`.
- Skip the row if the exception is soft-deleted, or if its `NewDate` falls outside the current week (the destination week renders it via `movedInExceptions`).
- Apply `NewDate` / `StartHour` overrides to the response model.
- Propagate `ExceptionId` so a follow-up move updates the existing exception row instead of creating a duplicate (caught by gate-1 review).

## Known follow-up

Cross-week compliance-origin moves still need a fix — the `movedInExceptions` orphan-render at line ~430 sets `IsFromCompliance = false` and drops `ComplianceId`. Tracked separately; the user's report is same-week.

## Test plan
- [ ] Drag a past, uncompleted recurring event to another past slot in the same week → scope dialog → pick *Only this* → confirm the event renders at the new slot after the reload (no snap-back).
- [ ] Drag the same moved event a second time → pick *Only this* → confirm it moves to the new slot without creating a duplicate exception row (verify via DB or by repeating moves and observing one row in `CalendarOccurrenceExceptions`).
- [ ] Soft-deleting an occurrence still hides it correctly.
- [ ] Non-past flows (future→future, today, etc.) unchanged.
- [ ] CI `pn-playwright-test (l)` shard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)