### PR TITLE
fix(calendar): preserve single-weekday selection on custom-repeat save

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -658,12 +658,18 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
       repeatEndMode,
       repeatOccurrences,
       repeatUntilDate,
-      // CSV of JS getDay() weekday indices for multi-day weekly custom rules.
-      // Sent as null for any non-custom rule (isCustomRule=false), which
-      // unconditionally clears any stale CSV the row may carry from a prior
-      // custom selection. See spec — Layer 3 / "explicit clearing rule".
-      repeatWeekdaysCsv: (isCustomRule && this.customRepeatMeta?.weekdays?.length)
-        ? this.customRepeatMeta.weekdays.join(',')
+      // CSV of JS getDay() weekday indices for weekly custom rules.
+      // Single-weekday rules (weeklyOne / everyNWeekOne) live in
+      // meta.weekday (singular); multi-day rules in meta.weekdays (plural).
+      // The service helper collapses both shapes into the wire format so
+      // a Tuesday-only pick doesn't ship as null (which would otherwise let
+      // the server-stored DayOfWeek default of 0 win on reload, showing
+      // "Sunday" instead of the picked weekday). Sent as null for any
+      // non-custom rule (isCustomRule=false), which unconditionally clears
+      // any stale CSV the row may carry from a prior custom selection.
+      // See spec — Layer 3 / "explicit clearing rule".
+      repeatWeekdaysCsv: isCustomRule
+        ? this.repeatService.metaToWeekdaysCsv(this.customRepeatMeta)
         : null,
       driveLink: this.driveLinkControl.value ?? '',
       propertyId: this.propertyControl.value ?? this.data.propertyId,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
@@ -770,4 +770,113 @@ describe('CalendarRepeatService', () => {
       expect(r?.untilTs).toBe(ts);
     });
   });
+
+  // ─── metaToWeekdaysCsv ───────────────────────────────────────────────────
+  // Wire-format serializer used by the modal's save flow to produce the
+  // request payload's `repeatWeekdaysCsv` field. Pre-fix the modal inlined a
+  // `meta.weekdays?.length ? meta.weekdays.join(',') : null` ternary, which
+  // shipped `null` for single-weekday rules — those store the chosen day in
+  // `meta.weekday` (singular). The server's AreaRulePlanning.DayOfWeek then
+  // kept its `int` default of 0, so reopening a Tuesday-only event read
+  // back as "Sunday". This suite + the regression test below pin the
+  // wire-format down so that class of bug can't regress unnoticed.
+  describe('metaToWeekdaysCsv', () => {
+    it('null meta → null', () => {
+      expect(service.metaToWeekdaysCsv(null)).toBeNull();
+    });
+
+    it('undefined meta → null', () => {
+      expect(service.metaToWeekdaysCsv(undefined)).toBeNull();
+    });
+
+    it('weeklyOne with weekday=2 (Tuesday) → "2"', () => {
+      const meta: CalendarRepeatMeta = {kind: 'weeklyOne', weekday: 2, endMode: 'never', n: 1};
+      expect(service.metaToWeekdaysCsv(meta)).toBe('2');
+    });
+
+    it('weeklyOne with weekday=0 (Sunday) → "0"', () => {
+      const meta: CalendarRepeatMeta = {kind: 'weeklyOne', weekday: 0, endMode: 'never', n: 1};
+      expect(service.metaToWeekdaysCsv(meta)).toBe('0');
+    });
+
+    it('everyNWeekOne with weekday=5 (Friday) → "5"', () => {
+      const meta: CalendarRepeatMeta = {kind: 'everyNWeekOne', weekday: 5, endMode: 'never', n: 3};
+      expect(service.metaToWeekdaysCsv(meta)).toBe('5');
+    });
+
+    it('weeklyMulti with weekdays=[1,3,5] → "1,3,5"', () => {
+      const meta: CalendarRepeatMeta = {kind: 'weeklyMulti', weekdays: [1, 3, 5], endMode: 'never', n: 1};
+      expect(service.metaToWeekdaysCsv(meta)).toBe('1,3,5');
+    });
+
+    it('everyNWeekMulti with weekdays=[0,6] → "0,6"', () => {
+      const meta: CalendarRepeatMeta = {kind: 'everyNWeekMulti', weekdays: [0, 6], endMode: 'never', n: 2};
+      expect(service.metaToWeekdaysCsv(meta)).toBe('0,6');
+    });
+
+    it('weeklyOne with no weekday → null', () => {
+      const meta: CalendarRepeatMeta = {kind: 'weeklyOne', endMode: 'never', n: 1};
+      expect(service.metaToWeekdaysCsv(meta)).toBeNull();
+    });
+
+    it('non-weekly: monthlyDom → null', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyDom', dom: 15, endMode: 'never', n: 1};
+      expect(service.metaToWeekdaysCsv(meta)).toBeNull();
+    });
+
+    it('non-weekly: daily → null', () => {
+      const meta: CalendarRepeatMeta = {kind: 'daily', endMode: 'never'};
+      expect(service.metaToWeekdaysCsv(meta)).toBeNull();
+    });
+
+    it('non-weekly: yearlyOne → null', () => {
+      const meta: CalendarRepeatMeta = {kind: 'yearlyOne', dom: 1, month: 0, endMode: 'never', n: 1};
+      expect(service.metaToWeekdaysCsv(meta)).toBeNull();
+    });
+
+    it('weeklyMulti where weekdays=[] (empty) → null (no plural shape)', () => {
+      const meta: CalendarRepeatMeta = {kind: 'weeklyMulti', weekdays: [], endMode: 'never', n: 1};
+      expect(service.metaToWeekdaysCsv(meta)).toBeNull();
+    });
+  });
+
+  // Regression test for the "Ugentligt hver søndag" bug:
+  // build a single-weekday Tuesday rule via the same path the modal uses,
+  // serialise via metaToWeekdaysCsv, then feed the resulting payload back
+  // into reconstructMetaFromTask while simulating the backend's broken
+  // DayOfWeek = 0 default. The CSV must win and the weekday must come back
+  // as Tuesday (2), not Sunday (0). Pre-fix this would have failed because
+  // the modal serialised the same meta as `null` and the dayOfWeek=0
+  // fallback rewrote it to Sunday.
+  describe('custom-repeat Tuesday round-trip (regression)', () => {
+    it('weeklyOne Tuesday survives metaToWeekdaysCsv → reconstructMetaFromTask even when dayOfWeek is the server default 0', () => {
+      // 1. Build the meta the way buildMetaFromCustomConfig would for
+      //    "Tilpasset" → "Gentag på" T (Tuesday) → step 1 → no end.
+      const meta = service.buildMetaFromCustomConfig(1, 'week', [2], 'never');
+      expect(meta.kind).toBe('weeklyOne');
+      expect(meta.weekday).toBe(2);
+
+      // 2. Modal's save path now flows through this helper.
+      const csv = service.metaToWeekdaysCsv(meta);
+      expect(csv).toBe('2');
+
+      // 3. Simulate the backend response: CSV is persisted correctly, but
+      //    arp.DayOfWeek defaults to 0 because Create/Update don't write
+      //    it. The reconstruction must prefer the CSV. (Use csv directly —
+      //    the field's type accepts string | null, and we want the fixture
+      //    to surface a string-vs-null mismatch if the helper ever regresses
+      //    to null for this kind.)
+      const task: CalendarTaskModel = {
+        id: 1, title: 't', startHour: 9, duration: 1, startText: '09:00',
+        endText: '10:00', tags: [], assigneeIds: [], boardId: 1, color: '',
+        descriptionHtml: '', taskDate: '2026-05-19', completed: false,
+        propertyId: 1, repeatRule: 'weeklyOne', repeatEvery: 1, repeatEndMode: 0,
+        repeatWeekdaysCsv: csv, dayOfWeek: 0,
+      } as CalendarTaskModel;
+
+      const reconstructed = service.reconstructMetaFromTask(task);
+      expect(reconstructed?.kind).toBe('weeklyOne');
+      expect(reconstructed?.weekday).toBe(2);
+    });
+  });
 });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
@@ -619,6 +619,22 @@ export class CalendarRepeatService {
     }
   }
 
+  /**
+   * Wire-format CSV for the request payload's `repeatWeekdaysCsv` field.
+   * Single-weekday rules store the chosen day in `meta.weekday` (singular),
+   * multi-day rules in `meta.weekdays` (plural array); the request payload
+   * has only the CSV field, so collapse both shapes here. Returns null for
+   * non-weekly metas (no weekday info to ship) and for null input.
+   */
+  metaToWeekdaysCsv(meta: CalendarRepeatMeta | null | undefined): string | null {
+    if (!meta) return null;
+    if (meta.weekdays?.length) return meta.weekdays.join(',');
+    if (meta.kind === 'weeklyOne' || meta.kind === 'everyNWeekOne') {
+      return meta.weekday != null ? `${meta.weekday}` : null;
+    }
+    return null;
+  }
+
   /** Convert a custom repeat config to a CalendarRepeatMeta */
   buildMetaFromCustomConfig(
     step: number,


### PR DESCRIPTION
## Summary

**Bug.** Creating a calendar event with **Tilpasset** → **Gentag på** picking a single weekday (e.g. **T** for Tuesday) and reopening the event read back as *"Ugentligt hver søndag"* (Weekly every Sunday). The chosen weekday was lost on save.

**Root cause.** `task-create-edit-modal.onSave` built `repeatWeekdaysCsv` from `meta.weekdays?.length` only. Single-weekday rules (`weeklyOne` / `everyNWeekOne`) store the choice in `meta.weekday` (singular int), so the request shipped `repeatWeekdaysCsv: null`. The server's `AreaRulePlanning.DayOfWeek` (non-nullable int) defaulted to `0` because `Create`/`Update` never write that field; reconstruction's CSV-first → `dayOfWeek` fallback then read Sunday.

**Fix.** Add `CalendarRepeatService.metaToWeekdaysCsv(meta)` — the single source of truth for the wire-format CSV. Collapses both `meta.weekday` (singular) and `meta.weekdays` (plural array) into one string. The modal's save flow now calls it directly. Non-weekly metas and null meta return null.

**Tests.** 11 new `metaToWeekdaysCsv` unit cases (each weekday-aware kind + non-weekly kinds + null input) plus a regression test that mirrors the user's repro: build Tuesday `weeklyOne` → serialise via the helper → simulate the backend's broken `dayOfWeek: 0` response → assert reconstruction returns Tuesday (`weekday: 2`) not Sunday (`weekday: 0`). Pre-fix that test would fail. All 86 specs pass locally.

Spec: [`docs/superpowers/specs/2026-05-19-calendar-custom-repeat-single-weekday-csv-design.md`](https://github.com/microting/eform-angular-frontend/blob/master/docs/superpowers/specs/2026-05-19-calendar-custom-repeat-single-weekday-csv-design.md)

## Test plan
- [ ] Manual: create event today → Tilpasset → click **T** (Tuesday) → Slutter På future Friday → save → reopen — modal shows Tuesday active, label "Ugentligt hver tirsdag".
- [ ] Repeat with **F** (Friday), **M** (Monday), **S** (Sunday) — each round-trips.
- [ ] Multi-day custom (M + W + F) still round-trips — unchanged path.
- [ ] `npx jest calendar-repeat.service.spec.ts` — 86 pass.
- [ ] CI `pn-playwright-test (l)` shard passes.

## Known follow-up (out of scope here)

`Create`/`Update` in `BackendConfigurationCalendarService` still don't write `AreaRulePlanning.DayOfWeek` from the request. That column stays at its `int` default forever. With the CSV fix in place reconstruction prefers CSV, so the staleness is effectively inert — but if any future consumer reads `DayOfWeek` directly it would still see 0. Track separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)