### PR TITLE
fix(events): don't zero StartHour for all-day compliance tasks

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -320,8 +320,8 @@ public class BackendConfigurationCalendarService(
                         continue;
 
                     var effectiveDate = exception?.NewDate?.Date ?? occurrenceDate;
-                    var effectiveStartHour = exception?.StartHour ?? (isAllDay ? 0 : calConfig?.StartHour ?? 9.0);
-                    var effectiveDuration = exception?.Duration ?? (isAllDay ? 0 : calConfig?.Duration ?? 1.0);
+                    var effectiveStartHour = exception?.StartHour ?? calConfig?.StartHour ?? 9.0;
+                    var effectiveDuration = exception?.Duration ?? calConfig?.Duration ?? 1.0;
                     var effectiveAssignees = exception?.ExceptionSites is { Count: > 0 }
                         ? exception.ExceptionSites
                             .Where(s => s.WorkflowState != Constants.WorkflowStates.Removed)
@@ -397,8 +397,8 @@ public class BackendConfigurationCalendarService(
                         // movedInExceptions pass at the destination week.
                         if (orphan.NewDate.HasValue && orphan.NewDate.Value.Date != orphan.OriginalDate.Date) continue;
 
-                        var orphanStartHour = orphan.StartHour ?? (isAllDay ? 0 : calConfig?.StartHour ?? 9.0);
-                        var orphanDuration = orphan.Duration ?? (isAllDay ? 0 : calConfig?.Duration ?? 1.0);
+                        var orphanStartHour = orphan.StartHour ?? calConfig?.StartHour ?? 9.0;
+                        var orphanDuration = orphan.Duration ?? calConfig?.Duration ?? 1.0;
                         var orphanAssignees = orphan.ExceptionSites is { Count: > 0 }
                             ? orphan.ExceptionSites
                                 .Where(s => s.WorkflowState != Constants.WorkflowStates.Removed)
@@ -483,8 +483,8 @@ public class BackendConfigurationCalendarService(
                 {
                     Id = arp.Id,
                     Title = title,
-                    StartHour = movedIn.StartHour ?? (isAllDay ? 0 : movedCalConfig?.StartHour ?? 9.0),
-                    Duration = movedIn.Duration ?? (isAllDay ? 0 : movedCalConfig?.Duration ?? 1.0),
+                    StartHour = movedIn.StartHour ?? movedCalConfig?.StartHour ?? 9.0,
+                    Duration = movedIn.Duration ?? movedCalConfig?.Duration ?? 1.0,
                     TaskDate = movedIn.NewDate!.Value.ToString("yyyy-MM-dd"),
                     Tags = movedTags,
                     AssigneeIds = movedAssignees,
@@ -669,8 +669,8 @@ public class BackendConfigurationCalendarService(
                 {
                     Id = arp?.Id ?? 0,
                     Title = title,
-                    StartHour = compIsAllDay ? 0 : effectiveStartHour,
-                    Duration = compIsAllDay ? 0 : effectiveDuration,
+                    StartHour = effectiveStartHour,
+                    Duration = effectiveDuration,
                     TaskDate = effectiveTaskDate.ToString("yyyy-MM-dd"),
                     Tags = tags,
                     AssigneeIds = arp?.PlanningSites?
@@ -2661,8 +2661,8 @@ public class BackendConfigurationCalendarService(
                 {
                     Id = arp?.Id ?? 0,
                     Title = title,
-                    StartHour = compIsAllDay ? 0 : calConfig?.StartHour ?? 9.0,
-                    Duration = compIsAllDay ? 0 : calConfig?.Duration ?? 1.0,
+                    StartHour = calConfig?.StartHour ?? 9.0,
+                    Duration = calConfig?.Duration ?? 1.0,
                     TaskDate = compliance.Deadline.ToString("yyyy-MM-dd"),
                     Tags = tags,
                     AssigneeIds = arp?.PlanningSites?


### PR DESCRIPTION
## Summary
Follow-up to PR #830. The new `PlannedAt = FormatStartHour(task.StartHour)` projection on the gRPC ListEvents path was rendering "00:00" on event cards for all-day compliance tasks because `BackendConfigurationCalendarService` zeroed `StartHour` whenever the all-day flag was set.

Remove the zeroing. `effectiveStartHour` (which already falls back to 9.0 when no calendar config exists) is now always used regardless of the all-day flag. The flag itself stays for downstream display semantics (e.g. an "all day" badge elsewhere); it just no longer overrides the configured planned start time.

## Test plan
- [x] `dotnet build` — 0 errors.
- [x] `dotnet test --filter "FullyQualifiedName~BackendConfigurationCalendarService"` — all passing.
- [ ] Backend rebuild + reload on local emulator (paired with flutter PR re: date+time-above-chips that's also in flight) — verify cards show a non-zero `HH:mm` time.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)