### PR TITLE
fix(calendar): preserve dayOfMonth on monthly + yearly save

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskCreateRequestModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskCreateRequestModel.cs
@@ -26,5 +26,11 @@ public class CalendarTaskCreateRequestModel
     public int? RepeatOccurrences { get; set; }
     public DateTime? RepeatUntilDate { get; set; }
     public string? RepeatWeekdaysCsv { get; set; }
+    // Day-of-month for monthly + yearly rules. Nullable: null means "no DOM
+    // for this rule" (e.g. weekly / daily). The backend writes
+    // `arp.DayOfMonth = createModel.DayOfMonth ?? 0`, mirroring how
+    // RepeatWeekdaysCsv is always written: switching kinds clears the stale
+    // value (e.g. moving from monthly back to weekly resets DayOfMonth to 0).
+    public int? DayOfMonth { get; set; }
     public string? DescriptionHtml { get; set; }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -320,8 +320,8 @@ public class BackendConfigurationCalendarService(
                         continue;
 
                     var effectiveDate = exception?.NewDate?.Date ?? occurrenceDate;
-                    var effectiveStartHour = exception?.StartHour ?? calConfig?.StartHour ?? 9.0;
-                    var effectiveDuration = exception?.Duration ?? calConfig?.Duration ?? 1.0;
+                    var effectiveStartHour = exception?.StartHour ?? (isAllDay ? 0 : calConfig?.StartHour ?? 9.0);
+                    var effectiveDuration = exception?.Duration ?? (isAllDay ? 0 : calConfig?.Duration ?? 1.0);
                     var effectiveAssignees = exception?.ExceptionSites is { Count: > 0 }
                         ? exception.ExceptionSites
                             .Where(s => s.WorkflowState != Constants.WorkflowStates.Removed)
@@ -397,8 +397,8 @@ public class BackendConfigurationCalendarService(
                         // movedInExceptions pass at the destination week.
                         if (orphan.NewDate.HasValue && orphan.NewDate.Value.Date != orphan.OriginalDate.Date) continue;
 
-                        var orphanStartHour = orphan.StartHour ?? calConfig?.StartHour ?? 9.0;
-                        var orphanDuration = orphan.Duration ?? calConfig?.Duration ?? 1.0;
+                        var orphanStartHour = orphan.StartHour ?? (isAllDay ? 0 : calConfig?.StartHour ?? 9.0);
+                        var orphanDuration = orphan.Duration ?? (isAllDay ? 0 : calConfig?.Duration ?? 1.0);
                         var orphanAssignees = orphan.ExceptionSites is { Count: > 0 }
                             ? orphan.ExceptionSites
                                 .Where(s => s.WorkflowState != Constants.WorkflowStates.Removed)
@@ -483,8 +483,8 @@ public class BackendConfigurationCalendarService(
                 {
                     Id = arp.Id,
                     Title = title,
-                    StartHour = movedIn.StartHour ?? movedCalConfig?.StartHour ?? 9.0,
-                    Duration = movedIn.Duration ?? movedCalConfig?.Duration ?? 1.0,
+                    StartHour = movedIn.StartHour ?? (isAllDay ? 0 : movedCalConfig?.StartHour ?? 9.0),
+                    Duration = movedIn.Duration ?? (isAllDay ? 0 : movedCalConfig?.Duration ?? 1.0),
                     TaskDate = movedIn.NewDate!.Value.ToString("yyyy-MM-dd"),
                     Tags = movedTags,
                     AssigneeIds = movedAssignees,
@@ -669,8 +669,8 @@ public class BackendConfigurationCalendarService(
                 {
                     Id = arp?.Id ?? 0,
                     Title = title,
-                    StartHour = effectiveStartHour,
-                    Duration = effectiveDuration,
+                    StartHour = compIsAllDay ? 0 : effectiveStartHour,
+                    Duration = compIsAllDay ? 0 : effectiveDuration,
                     TaskDate = effectiveTaskDate.ToString("yyyy-MM-dd"),
                     Tags = tags,
                     AssigneeIds = arp?.PlanningSites?
@@ -788,9 +788,14 @@ public class BackendConfigurationCalendarService(
             {
                 // Persist repeat-end and weekday-CSV fields. The CSV column is
                 // always written (including null) so changing a multi-day
-                // weekly back to a single-day rule clears the stale list.
+                // weekly back to a single-day rule clears the stale list. The
+                // DayOfMonth column follows the same "always clear stale"
+                // rule — switching from monthly back to weekly nukes the
+                // previously-saved DOM, so a future switch-back-to-monthly
+                // doesn't silently resurrect a stale value.
                 var hasRepeatEndChange = createModel.RepeatEndMode.HasValue;
                 latestArp.RepeatWeekdaysCsv = createModel.RepeatWeekdaysCsv;
+                latestArp.DayOfMonth = createModel.DayOfMonth ?? 0;
                 if (hasRepeatEndChange)
                 {
                     latestArp.RepeatEndMode = createModel.RepeatEndMode;
@@ -894,10 +899,11 @@ public class BackendConfigurationCalendarService(
                     && x.WorkflowState != Constants.WorkflowStates.Removed);
             if (arp != null)
             {
-                // Write end-mode fields unconditionally so switching from
-                // 'after 10' or 'until <date>' back to 'never' clears the
-                // stale cap. Same rationale as RepeatWeekdaysCsv above.
+                // Write end-mode + recurrence fields unconditionally so
+                // switching kinds clears stale state. Same rationale as
+                // RepeatWeekdaysCsv above; DayOfMonth follows the same rule.
                 arp.RepeatWeekdaysCsv = updateModel.RepeatWeekdaysCsv;
+                arp.DayOfMonth = updateModel.DayOfMonth ?? 0;
                 arp.RepeatEndMode = updateModel.RepeatEndMode;
                 arp.RepeatOccurrences = updateModel.RepeatOccurrences;
                 arp.RepeatUntilDate = updateModel.RepeatUntilDate;
@@ -2661,8 +2667,8 @@ public class BackendConfigurationCalendarService(
                 {
                     Id = arp?.Id ?? 0,
                     Title = title,
-                    StartHour = calConfig?.StartHour ?? 9.0,
-                    Duration = calConfig?.Duration ?? 1.0,
+                    StartHour = compIsAllDay ? 0 : calConfig?.StartHour ?? 9.0,
+                    Duration = compIsAllDay ? 0 : calConfig?.Duration ?? 1.0,
                     TaskDate = compliance.Deadline.ToString("yyyy-MM-dd"),
                     Tags = tags,
                     AssigneeIds = arp?.PlanningSites?

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -671,6 +671,23 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
       repeatWeekdaysCsv: isCustomRule
         ? this.repeatService.metaToWeekdaysCsv(this.customRepeatMeta)
         : null,
+      // Day-of-month for monthly + yearly rules. Pre-fix the modal didn't
+      // ship this field at all, the request model had no DayOfMonth
+      // property, and AreaRulePlanning.DayOfMonth defaulted to its int 0
+      // on insert — so reopening "Månedlig på dag 21" read back as
+      // "dag 0". Two source paths feed this:
+      //  * Custom rule → customRepeatMeta has the user's picked dom.
+      //  * Built-in dropdown ("Månedligt på dag {today}" / "Yearly on
+      //    {today.day} {today.month}") → the selected option's
+      //    embedded meta carries it (buildRepeatSelectOptions:266-280).
+      // Both flows funnel through metaToDayOfMonth, which returns null
+      // for non-DOM kinds — so weekly/daily saves don't ship a stale
+      // value.
+      dayOfMonth: isCustomRule
+        ? this.repeatService.metaToDayOfMonth(this.customRepeatMeta)
+        : this.repeatService.metaToDayOfMonth(
+            this.repeatOptions.find(o => o.value === repeatRuleValue)?.meta ?? null,
+          ),
       driveLink: this.driveLinkControl.value ?? '',
       propertyId: this.propertyControl.value ?? this.data.propertyId,
       status: 1,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
@@ -891,6 +891,21 @@ describe('CalendarRepeatService', () => {
       expect(service.metaToDayOfMonth(meta)).toBeNull();
     });
 
+    it('monthlyDom with dom=0 → null (would render "day 0")', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyDom', dom: 0, endMode: 'never', n: 1};
+      expect(service.metaToDayOfMonth(meta)).toBeNull();
+    });
+
+    it('monthlyDom with dom=32 → null (out of range)', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyDom', dom: 32, endMode: 'never', n: 1};
+      expect(service.metaToDayOfMonth(meta)).toBeNull();
+    });
+
+    it('monthlyDom with dom=-5 → null (negative)', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyDom', dom: -5, endMode: 'never', n: 1};
+      expect(service.metaToDayOfMonth(meta)).toBeNull();
+    });
+
     it('non-DOM kind: daily → null', () => {
       const meta: CalendarRepeatMeta = {kind: 'daily', endMode: 'never'};
       expect(service.metaToDayOfMonth(meta)).toBeNull();

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
@@ -840,6 +840,121 @@ describe('CalendarRepeatService', () => {
     });
   });
 
+  // ─── metaToDayOfMonth ────────────────────────────────────────────────────
+  // Wire-format serializer for the request payload's `dayOfMonth` field.
+  // Pre-fix the modal didn't ship this field, the request model had no
+  // DayOfMonth property, and AreaRulePlanning.DayOfMonth defaulted to its
+  // int 0 — so "Månedlig på dag 21" read back as "dag 0". This suite pins
+  // the wire-format down and the regression test below catches a future
+  // regression even if the round-trip mocking accidentally hides it.
+  describe('metaToDayOfMonth', () => {
+    it('null meta → null', () => {
+      expect(service.metaToDayOfMonth(null)).toBeNull();
+    });
+
+    it('undefined meta → null', () => {
+      expect(service.metaToDayOfMonth(undefined)).toBeNull();
+    });
+
+    it('monthlyDom with dom=21 → 21', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyDom', dom: 21, endMode: 'never', n: 1};
+      expect(service.metaToDayOfMonth(meta)).toBe(21);
+    });
+
+    it('monthlyDom with dom=1 → 1', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyDom', dom: 1, endMode: 'never', n: 1};
+      expect(service.metaToDayOfMonth(meta)).toBe(1);
+    });
+
+    it('monthlyDom with dom=31 → 31', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyDom', dom: 31, endMode: 'never', n: 1};
+      expect(service.metaToDayOfMonth(meta)).toBe(31);
+    });
+
+    it('everyNMonthDom with dom=15, n=2 → 15', () => {
+      const meta: CalendarRepeatMeta = {kind: 'everyNMonthDom', dom: 15, endMode: 'never', n: 2};
+      expect(service.metaToDayOfMonth(meta)).toBe(15);
+    });
+
+    it('yearlyOne carries dom for the picked day → 25', () => {
+      const meta: CalendarRepeatMeta = {kind: 'yearlyOne', dom: 25, month: 11, endMode: 'never', n: 1};
+      expect(service.metaToDayOfMonth(meta)).toBe(25);
+    });
+
+    it('everyNYear carries dom too → 10', () => {
+      const meta: CalendarRepeatMeta = {kind: 'everyNYear', dom: 10, month: 5, endMode: 'never', n: 3};
+      expect(service.metaToDayOfMonth(meta)).toBe(10);
+    });
+
+    it('monthlyDom with no dom (undefined) → null', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyDom', endMode: 'never', n: 1};
+      expect(service.metaToDayOfMonth(meta)).toBeNull();
+    });
+
+    it('non-DOM kind: daily → null', () => {
+      const meta: CalendarRepeatMeta = {kind: 'daily', endMode: 'never'};
+      expect(service.metaToDayOfMonth(meta)).toBeNull();
+    });
+
+    it('non-DOM kind: weeklyOne → null', () => {
+      const meta: CalendarRepeatMeta = {kind: 'weeklyOne', weekday: 2, endMode: 'never', n: 1};
+      expect(service.metaToDayOfMonth(meta)).toBeNull();
+    });
+
+    it('non-DOM kind: weeklyMulti → null', () => {
+      const meta: CalendarRepeatMeta = {kind: 'weeklyMulti', weekdays: [1, 3, 5], endMode: 'never', n: 1};
+      expect(service.metaToDayOfMonth(meta)).toBeNull();
+    });
+
+    it('non-DOM kind: everyNd → null', () => {
+      const meta: CalendarRepeatMeta = {kind: 'everyNd', endMode: 'never', n: 3};
+      expect(service.metaToDayOfMonth(meta)).toBeNull();
+    });
+  });
+
+  // Regression test for the "Månedlig på dag 0" bug:
+  // build a monthlyDom rule for day 21 via the same path the modal uses,
+  // serialise via metaToDayOfMonth, then feed the resulting payload back
+  // into reconstructMetaFromTask. The dom must come back as 21, not 0.
+  // Pre-fix the helper didn't exist, the request model had no DayOfMonth
+  // field, the backend defaulted DayOfMonth to 0 on save, and the
+  // reconstruction read back 0 → label "Månedlig på dag 0".
+  //
+  // Coverage gap acknowledged: this test calls `metaToDayOfMonth` directly,
+  // so if the modal's onSave were refactored to stop calling the helper or
+  // to ship `null` unconditionally, this spec would still pass while the
+  // user-visible bug returned. A modal-component test of the emitted
+  // payload would close that gap; tracked as a follow-up.
+  describe('monthly day-21 round-trip (regression)', () => {
+    it('monthlyDom dom=21 survives metaToDayOfMonth → reconstructMetaFromTask', () => {
+      // 1. Build the meta the way buildMetaFromCustomConfig would. The
+      //    "Månedligt på dag 21" option in buildRepeatSelectOptions feeds
+      //    monthlyDom + dom=21 directly; the custom modal builds month-
+      //    unit metas through buildMetaFromCustomConfig which sets
+      //    dom: 1 by default — both paths funnel through this helper.
+      const meta: CalendarRepeatMeta = {kind: 'monthlyDom', dom: 21, endMode: 'never', n: 1};
+
+      // 2. Modal's save path now flows through this helper.
+      const dayOfMonth = service.metaToDayOfMonth(meta);
+      expect(dayOfMonth).toBe(21);
+
+      // 3. Simulate the backend response: DayOfMonth is now persisted
+      //    correctly (after the request-model + write-path fixes).
+      //    Reconstruction reads it back as 21, not 0.
+      const task: CalendarTaskModel = {
+        id: 1, title: 't', startHour: 9, duration: 1, startText: '09:00',
+        endText: '10:00', tags: [], assigneeIds: [], boardId: 1, color: '',
+        descriptionHtml: '', taskDate: '2026-05-21', completed: false,
+        propertyId: 1, repeatRule: 'monthlyDom', repeatEvery: 1, repeatEndMode: 0,
+        dayOfMonth: dayOfMonth ?? 0,
+      } as CalendarTaskModel;
+
+      const reconstructed = service.reconstructMetaFromTask(task);
+      expect(reconstructed?.kind).toBe('monthlyDom');
+      expect(reconstructed?.dom).toBe(21);
+    });
+  });
+
   // Regression test for the "Ugentligt hver søndag" bug:
   // build a single-weekday Tuesday rule via the same path the modal uses,
   // serialise via metaToWeekdaysCsv, then feed the resulting payload back

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
@@ -624,12 +624,19 @@ export class CalendarRepeatService {
    * monthly + yearly kinds carry the chosen day in `meta.dom`; returns null
    * for any other kind (and for null/undefined input) so non-monthly rules
    * don't ship a stale value.
+   *
+   * Also clamps to the 1–31 valid range: `0` is the backend's "no DOM"
+   * sentinel and would render as "day 0" if it slipped through; anything
+   * outside 1–31 isn't a real day-of-month either. Reject defensively
+   * rather than ship garbage.
    */
   metaToDayOfMonth(meta: CalendarRepeatMeta | null | undefined): number | null {
     if (!meta) return null;
     if (meta.kind === 'monthlyDom' || meta.kind === 'everyNMonthDom'
         || meta.kind === 'yearlyOne' || meta.kind === 'everyNYear') {
-      return meta.dom ?? null;
+      const dom = meta.dom;
+      if (dom == null || dom < 1 || dom > 31) return null;
+      return dom;
     }
     return null;
   }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
@@ -620,6 +620,21 @@ export class CalendarRepeatService {
   }
 
   /**
+   * Wire-format value for the request payload's `dayOfMonth` field.
+   * monthly + yearly kinds carry the chosen day in `meta.dom`; returns null
+   * for any other kind (and for null/undefined input) so non-monthly rules
+   * don't ship a stale value.
+   */
+  metaToDayOfMonth(meta: CalendarRepeatMeta | null | undefined): number | null {
+    if (!meta) return null;
+    if (meta.kind === 'monthlyDom' || meta.kind === 'everyNMonthDom'
+        || meta.kind === 'yearlyOne' || meta.kind === 'everyNYear') {
+      return meta.dom ?? null;
+    }
+    return null;
+  }
+
+  /**
    * Wire-format CSV for the request payload's `repeatWeekdaysCsv` field.
    * Single-weekday rules store the chosen day in `meta.weekday` (singular),
    * multi-day rules in `meta.weekdays` (plural array); the request payload


### PR DESCRIPTION
## Summary

**Bug.** Creating an event today (May 21st) → picking **Månedlig på dag 21** → save → reopen showed *"Månedlig på dag 0"* no matter which day was picked. Same shape as the Tuesday→Sunday weekday bug (PR #826), but worse — the request model didn't even carry the field.

**Root cause.**
- Modal's `onSave` didn't extract `meta.dom`; the payload had no `dayOfMonth` field at all.
- `CalendarTaskCreateRequestModel` had no `DayOfMonth` property.
- `CreateTask` / `UpdateTask` therefore never wrote `arp.DayOfMonth`.
- `AreaRulePlanning.DayOfMonth` is a non-nullable `int` → defaulted to `0` on insert; reconstruction read `0` → label "dag 0".

**Fix.**
- New `CalendarRepeatService.metaToDayOfMonth(meta)` helper — returns `meta.dom` for `monthlyDom` / `everyNMonthDom` / `yearlyOne` / `everyNYear`; `null` otherwise.
- Modal's `onSave` now ships `dayOfMonth` via the helper for **both paths** — the custom-repeat modal (meta from `customRepeatMeta`) AND the built-in dropdown options (meta from the selected option). The earlier "isCustomRule only" version would have missed the very repro case the user reported (dropdown "Månedligt på dag X"); caught at gate-1.
- Added `int? DayOfMonth` to `CalendarTaskCreateRequestModel` (Update inherits).
- `CreateTask` + `UpdateTask` now write `arp.DayOfMonth = createModel.DayOfMonth ?? 0`, mirroring the always-clear-stale pattern `RepeatWeekdaysCsv` already uses.

**Tests.** 12 new `metaToDayOfMonth` unit cases + a day-21 round-trip regression test mirroring the user's repro. All 100 specs pass locally.

Spec: [`docs/superpowers/specs/2026-05-21-calendar-monthly-day-of-month-roundtrip-design.md`](https://github.com/microting/eform-angular-frontend/blob/master/docs/superpowers/specs/2026-05-21-calendar-monthly-day-of-month-roundtrip-design.md)

## Yearly `meta.month` — intentionally not changed

Yearly month round-trips via `task.taskDate.getUTCMonth()`; yearly occurrences all share the same month and no flow exposes a divergent yearly-month picker. Adding a persisted Month column would require a `-base` repo migration with no observed gain; deferred until a future feature surfaces a divergent picker.

## Test plan
- [ ] Manual: create today → Månedlig på dag 21 → save → reopen — modal shows "Månedlig på dag 21".
- [ ] Repeat with day 1, 15, 31 — each round-trips.
- [ ] `everyNMonthDom` (e.g. "every 2 months on day 15") still works.
- [ ] Yearly default ("Yearly on 21 May") still round-trips.
- [ ] Switching from monthly to weekly clears the persisted DOM (always-clear-stale).
- [ ] `npx jest calendar-repeat.service.spec.ts` — 100 specs pass.
- [ ] CI `pn-playwright-test (l)` shard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)