### PR TITLE
fix(calendar): turn completion check_circle icon green when task completed

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
@@ -102,7 +102,8 @@
     // green so users can spot completion at a glance. The block also
     // dims to opacity 0.6 + line-through via .task-block.completed above,
     // but at 16px on the red background those are easy to miss.
-    // Hex from $eform-green in eform-client/src/scss/utilities/_colors.scss.
+    // #61BA5B matches the project's $eform-green palette token (used
+    // elsewhere in the frontend); grep $eform-green to find the source.
     &.done mat-icon {
       color: #61BA5B;
     }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
@@ -97,6 +97,15 @@
       width: 16px;
       height: 16px;
     }
+
+    // Completed task (SDK case Status == 100): turn the check_circle glyph
+    // green so users can spot completion at a glance. The block also
+    // dims to opacity 0.6 + line-through via .task-block.completed above,
+    // but at 16px on the red background those are easy to miss.
+    // Hex from $eform-green in eform-client/src/scss/utilities/_colors.scss.
+    &.done mat-icon {
+      color: #61BA5B;
+    }
   }
 
   .task-content {


### PR DESCRIPTION
## Summary

On `/plugins/backend-configuration-pn/calendar` the upper-left completion icon on each event already swaps glyphs based on `task.completed` (`check_circle` ↔ `radio_button_unchecked`), but both rendered in white on the red event block — so at 16 px users couldn't tell completed events apart at the icon level. The only existing affordance was the parent block dimming to `opacity: 0.6` + strikethrough, which is subtle.

PR #824 already wired `task.completed = (sdkCase.Status == 100)` in `GetTasksForWeek`'s compliance loop, so the data is correct. This PR is the missing visual signal: a single nested SCSS rule on `.completion-btn.done mat-icon { color: #61BA5B }` — matching the `.done` class the template already binds via `[class.done]="task.completed"`.

Hex is from `$eform-green` in `eform-client/src/scss/utilities/_colors.scss`; hardcoded here with a pointer comment to avoid being the first import of that file into this module for a single value.

Spec: [`docs/superpowers/specs/2026-05-21-calendar-completed-icon-green-design.md`](https://github.com/microting/eform-angular-frontend/blob/master/docs/superpowers/specs/2026-05-21-calendar-completed-icon-green-design.md)

## Test plan
- [ ] Reload the calendar. A compliance occurrence with `Status == 100` shows a **green** `check_circle` in the upper-left.
- [ ] An uncompleted occurrence still shows the white `radio_button_unchecked`.
- [ ] Tooltip still toggles "Mark as completed" / "Mark as not completed".
- [ ] Block continues to dim + strikethrough when complete (unchanged).
- [ ] CI `pn-playwright-test (l)` shard passes — pure CSS, no selectors broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)