### PR TITLE
feat(calendar): materialise compliance on demand when completing event

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarAttachmentTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarAttachmentTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -96,6 +97,7 @@ public class CalendarAttachmentTests : TestBaseSetup
             _userService,
             BackendConfigurationPnDbContext!,
             new EFormCoreService(_sdkConnectionString),
+            Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
             NullLogger<BackendConfigurationCalendarService>.Instance

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOccurrenceExceptionTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOccurrenceExceptionTests.cs
@@ -2,6 +2,7 @@ using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -71,6 +72,7 @@ public class CalendarOccurrenceExceptionTests : TestBaseSetup
             _userService,
             BackendConfigurationPnDbContext!,
             null,
+            Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
             NullLogger<BackendConfigurationCalendarService>.Instance

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarRepeatPersistenceTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarRepeatPersistenceTests.cs
@@ -2,6 +2,7 @@ using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
 using Microting.eForm.Infrastructure.Data.Entities;
@@ -69,6 +70,7 @@ public class CalendarRepeatPersistenceTests : TestBaseSetup
             _userService,
             BackendConfigurationPnDbContext!,
             null,
+            Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
             NullLogger<BackendConfigurationCalendarService>.Instance

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarResizeTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarResizeTests.cs
@@ -2,6 +2,7 @@ using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -69,6 +70,7 @@ public class CalendarResizeTests : TestBaseSetup
             _userService,
             BackendConfigurationPnDbContext!,
             null,
+            Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
             NullLogger<BackendConfigurationCalendarService>.Instance

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
@@ -29,6 +29,7 @@ using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.EventDeployService;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -94,12 +95,17 @@ public class EventDeployServiceTest : TestBaseSetup
         IBackendConfigurationCalendarService calendar,
         IEFormCoreService coreHelper,
         ILogger<EventDeployService>? logger = null)
-        => new(
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(calendar);
+        var sp = services.BuildServiceProvider();
+        return new EventDeployService(
             BackendConfigurationPnDbContext!,
             ItemsPlanningPnDbContext!,
             coreHelper,
-            calendar,
+            sp,
             logger ?? NullLogger<EventDeployService>.Instance);
+    }
 
     /// <summary>
     /// Factory for the rotation DTO that every test arranges. Defaults match the

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/CalendarController.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/CalendarController.cs
@@ -86,7 +86,8 @@ public class CalendarController : Controller
     [HttpPut("tasks/{id:int}/complete")]
     public async Task<OperationDataResult<CalendarToggleCompleteResult>> ToggleComplete(int id, [FromBody] CalendarToggleCompleteModel model)
     {
-        return await _backendConfigurationCalendarService.ToggleComplete(id, model.Completed, model.ComplianceId);
+        return await _backendConfigurationCalendarService.ToggleComplete(
+            id, model.Completed, model.ComplianceId, model.OccurrenceDate);
     }
 
     [HttpPost("tasks/{id:int}/files")]

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarToggleCompleteModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarToggleCompleteModel.cs
@@ -10,4 +10,12 @@ public class CalendarToggleCompleteModel
     // Deadline" lookup on PlanningId, which would silently target the
     // wrong week when multiple compliances exist for the same planning.
     public int? ComplianceId { get; set; }
+
+    // Calendar-day key (YYYY-MM-DD) for the specific occurrence the user
+    // clicked. Forwarded to the on-demand Compliance materialiser when
+    // ComplianceId is missing/zero — for recurrence rows the nightly
+    // batch has not yet deployed, this is the only way the backend can
+    // identify which deadline to create the Compliance row for. Sent as
+    // task.taskDate from the calendar response.
+    public string? OccurrenceDate { get; set; }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/EnsureComplianceResult.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/EnsureComplianceResult.cs
@@ -1,0 +1,20 @@
+namespace BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+
+/// <summary>
+/// Result of an on-demand Compliance materialisation for a single calendar
+/// occurrence. Returned by
+/// <see cref="Services.EventDeployService.IEventDeployService.EnsureComplianceForOccurrenceAsync"/>.
+/// </summary>
+public class EnsureComplianceResult
+{
+    /// <summary>
+    /// True when a new Compliance / PlanningCase / PlanningCaseSite / SDK
+    /// Case set was created; false when an existing Compliance row was
+    /// returned by the idempotence guard.
+    /// </summary>
+    public bool Created { get; set; }
+
+    public int ComplianceId { get; set; }
+    public int SdkCaseId { get; set; }
+    public int TemplateId { get; set; }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/localization.json
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/localization.json
@@ -5027,6 +5027,37 @@
     }
   },
   {
+    "Key": "NoAssignedWorker",
+    "LocalizedValue": {
+      "en-US": "This event has no assigned worker",
+      "da": "Denne begivenhed har ingen tildelt medarbejder",
+      "de": "Für diese Veranstaltung ist kein Mitarbeiter zugewiesen.",
+      "uk-UA": "Для цієї події не призначено жодного працівника",
+      "pl-PL": "To wydarzenie nie ma przypisanego pracownika",
+      "no-NO": "Denne hendelsen har ingen tildelt arbeider",
+      "sv-SE": "Denna händelse har ingen tilldelad arbetare",
+      "es-ES": "Este evento no tiene ningún trabajador asignado.",
+      "fr-FR": "Aucun travailleur n&#39;est assigné à cet événement.",
+      "it-IT": "A questo evento non è stato assegnato alcun lavoratore.",
+      "nl-NL": "Aan dit evenement is geen medewerker toegewezen.",
+      "pt-BR": "Este evento não tem nenhum trabalhador atribuído.",
+      "pt-PT": "Este evento não tem nenhum trabalhador atribuído.",
+      "fi-FI": "Tälle tapahtumalle ei ole määritetty työntekijää",
+      "et-ET": "Sellel sündmusel pole määratud töötajat",
+      "lv-LV": "Šim notikumam nav piešķirts darbinieks",
+      "lt-LT": "Šiam įvykiui nėra priskirto darbuotojo",
+      "ro-RO": "Acest eveniment nu are niciun lucrător atribuit",
+      "hr-HR": "Ovaj događaj nema dodijeljenog radnika",
+      "sl-SL": "Ta dogodek nima dodeljenega delavca",
+      "cs-CZ": "Tato událost nemá přiřazeného pracovníka.",
+      "sk-SK": "Táto udalosť nemá priradeného pracovníka",
+      "hu-HU": "Ehhez az eseményhez nincs hozzárendelve dolgozó",
+      "bg-BG": "Това събитие няма назначен служител",
+      "el-GR": "Αυτό το συμβάν δεν έχει ανατεθειμένο εργαζόμενο",
+      "is-IS": "Þessi viðburður hefur engan úthlutaðan starfsmann"
+    }
+  },
+  {
     "Key": "SdkCaseNotFound",
     "LocalizedValue": {
       "en-US": "The compliance case could not be found",

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using BackendConfigurationLocalizationService;
 using BackendConfigurationTaskWizardService;
+using EventDeployService;
 using Infrastructure.Models.Calendar;
 using Infrastructure.Models.TaskWizard;
 using Microsoft.AspNetCore.Http;
@@ -32,6 +33,7 @@ public class BackendConfigurationCalendarService(
     IUserService userService,
     BackendConfigurationPnDbContext backendConfigurationPnDbContext,
     IEFormCoreService coreHelper,
+    IEventDeployService eventDeployService,
     ItemsPlanningPnDbContext itemsPlanningPnDbContext,
     IBackendConfigurationTaskWizardService taskWizardService,
     ILogger<BackendConfigurationCalendarService> logger)
@@ -1562,14 +1564,22 @@ public class BackendConfigurationCalendarService(
         }
     }
 
-    public async Task<OperationDataResult<CalendarToggleCompleteResult>> ToggleComplete(int id, bool completed, int? complianceId)
+    public async Task<OperationDataResult<CalendarToggleCompleteResult>> ToggleComplete(
+        int id, bool completed, int? complianceId, string? occurrenceDate)
     {
         // Calendar "complete from indicator" — resolves the specific Compliance
         // occurrence the user clicked (via complianceId from the calendar
         // response), then either completes the SDK case in place (no mandatory
         // fields) or returns RequiresForm=true with the route params the
         // frontend needs to open the compliance form.
+        //
+        // When the nightly batch has not yet deployed the occurrence (no
+        // complianceId in the row, or the lookup misses), we materialise it
+        // on demand via IEventDeployService so the user does not have to
+        // wait until the next morning to complete a future event.
+        //
         // See spec: docs/superpowers/specs/2026-05-21-calendar-complete-case-from-indicator-design.md
+        //           docs/superpowers/specs/2026-05-21-calendar-ensure-compliance-on-complete-design.md
         try
         {
             if (!completed)
@@ -1579,6 +1589,8 @@ public class BackendConfigurationCalendarService(
             }
 
             var arp = await backendConfigurationPnDbContext.AreaRulePlannings
+                .Include(x => x.AreaRule)
+                .Include(x => x.PlanningSites)
                 .Where(x => x.Id == id)
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                 .FirstOrDefaultAsync();
@@ -1589,35 +1601,85 @@ public class BackendConfigurationCalendarService(
                     localizationService.GetString("AreaRulePlanningNotFound"));
             }
 
-            // Non-compliance events have no Compliance row to target; bail
-            // before the lookup so the frontend gets a deterministic "no-op"
-            // result without scanning the table.
-            if (complianceId == null || complianceId.Value <= 0)
-            {
-                return new OperationDataResult<CalendarToggleCompleteResult>(false,
-                    localizationService.GetString("TaskHasNoComplianceCase"));
-            }
-
             // Look up the SPECIFIC compliance row the user clicked. Previously
             // this queried by PlanningId and took "latest by Deadline" — that
             // silently picked the wrong week when a planning had multiple
             // compliance occurrences (e.g. an overdue January row alongside a
             // pending May row), completing or navigating to the wrong case.
-            var compliance = await backendConfigurationPnDbContext.Compliances
-                .Where(c => c.Id == complianceId.Value
-                         && c.PlanningId == arp.ItemPlanningId
-                         && c.WorkflowState != Constants.WorkflowStates.Removed
-                         && c.MicrotingSdkCaseId > 0)
-                .FirstOrDefaultAsync();
+            Compliance? compliance = null;
+            if (complianceId is > 0)
+            {
+                compliance = await backendConfigurationPnDbContext.Compliances
+                    .Where(c => c.Id == complianceId.Value
+                             && c.PlanningId == arp.ItemPlanningId
+                             && c.WorkflowState != Constants.WorkflowStates.Removed
+                             && c.MicrotingSdkCaseId > 0)
+                    .FirstOrDefaultAsync();
+            }
 
             if (compliance == null)
             {
-                return new OperationDataResult<CalendarToggleCompleteResult>(false,
-                    localizationService.GetString("TaskHasNoComplianceCase"));
+                // The user clicked an occurrence whose Compliance row has not
+                // yet been materialised (nightly batch has not run, or this
+                // is a future-day recurrence). Try to materialise on demand.
+                //
+                // Genuinely non-compliance events (no EformId on the AreaRule)
+                // still get the deterministic "no-op" result — there is
+                // nothing to complete for those.
+                if (arp.AreaRule == null
+                    || arp.AreaRule.EformId == null
+                    || arp.AreaRule.EformId == 0)
+                {
+                    return new OperationDataResult<CalendarToggleCompleteResult>(false,
+                        localizationService.GetString("TaskHasNoComplianceCase"));
+                }
+
+                var planningSite = arp.PlanningSites?
+                    .FirstOrDefault(s => s.WorkflowState != Constants.WorkflowStates.Removed);
+                if (planningSite == null)
+                {
+                    return new OperationDataResult<CalendarToggleCompleteResult>(false,
+                        localizationService.GetString("NoAssignedWorker"));
+                }
+
+                if (string.IsNullOrWhiteSpace(occurrenceDate))
+                {
+                    return new OperationDataResult<CalendarToggleCompleteResult>(false,
+                        localizationService.GetString("TaskHasNoComplianceCase"));
+                }
+
+                // Compliance.Deadline is persisted as DateTimeKind.Unspecified
+                // 00:00 calendar-day — parse strictly so we never end up
+                // with an off-by-one across the UTC/local boundary.
+                if (!DateTime.TryParseExact(occurrenceDate, "yyyy-MM-dd",
+                        CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate))
+                {
+                    return new OperationDataResult<CalendarToggleCompleteResult>(false,
+                        localizationService.GetString("TaskHasNoComplianceCase"));
+                }
+                var deadline = parsedDate.Date;
+
+                var ensure = await eventDeployService
+                    .EnsureComplianceForOccurrenceAsync(arp, deadline, planningSite.SiteId)
+                    .ConfigureAwait(false);
+                if (ensure == null || ensure.ComplianceId <= 0)
+                {
+                    return new OperationDataResult<CalendarToggleCompleteResult>(false,
+                        localizationService.GetString("TaskHasNoComplianceCase"));
+                }
+
+                compliance = await backendConfigurationPnDbContext.Compliances
+                    .FirstOrDefaultAsync(c => c.Id == ensure.ComplianceId);
+
+                if (compliance == null)
+                {
+                    return new OperationDataResult<CalendarToggleCompleteResult>(false,
+                        localizationService.GetString("TaskHasNoComplianceCase"));
+                }
             }
 
             var sdkCore = await coreHelper.GetCore().ConfigureAwait(false);
-            var sdkDbContext = sdkCore.DbContextHelper.GetDbContext();
+            await using var sdkDbContext = sdkCore.DbContextHelper.GetDbContext();
 
             var sdkCase = await sdkDbContext.Cases
                 .FirstOrDefaultAsync(c => c.Id == compliance.MicrotingSdkCaseId);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -1669,7 +1669,9 @@ public class BackendConfigurationCalendarService(
                 }
 
                 compliance = await backendConfigurationPnDbContext.Compliances
-                    .FirstOrDefaultAsync(c => c.Id == ensure.ComplianceId);
+                    .FirstOrDefaultAsync(c => c.Id == ensure.ComplianceId
+                                           && c.WorkflowState != Constants.WorkflowStates.Removed
+                                           && c.MicrotingSdkCaseId > 0);
 
                 if (compliance == null)
                 {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -81,12 +81,48 @@ public class BackendConfigurationCalendarService(
                 = new();
             if (!requestModel.ActionableOnly)
             {
-                // Default branch — bit-identical to the pre-c2637800 prefetch.
-                compliancesInWeek = await backendConfigurationPnDbContext.Compliances
-                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                // Load both:
+                //   * non-removed compliances (the live week view).
+                //   * removed-but-COMPLETED compliances. The canonical compliance
+                //     Update path (CompliancesService.Update + mobile gRPC) soft-
+                //     deletes the Compliance row after setting the backing SDK
+                //     Case to Status=100. Without including these here, the
+                //     recurrence-expansion loop below would emit a fresh
+                //     uncompleted task for the same date (because its dedup set
+                //     is built from `compliancesInWeek`), and the user would
+                //     see the just-completed event "snap back" to uncompleted.
+                //
+                //     The Where below still excludes removed compliances that
+                //     never deployed (SdkCaseId == 0 — retracted-without-case
+                //     shape) so genuinely missed/retracted rotations stay
+                //     hidden. The post-load filter further narrows
+                //     removed rows to those whose SDK case is Status=100.
+                var loadedCompliances = await backendConfigurationPnDbContext.Compliances
                     .Where(x => x.PropertyId == requestModel.PropertyId)
                     .Where(x => x.Deadline >= weekStart && x.Deadline <= weekEnd)
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed
+                                || x.MicrotingSdkCaseId > 0)
                     .ToListAsync();
+
+                var loadedCaseIds = loadedCompliances
+                    .Select(c => c.MicrotingSdkCaseId)
+                    .Where(id => id > 0)
+                    .Distinct()
+                    .ToList();
+                var loadedCases = new Dictionary<int, Microting.eForm.Infrastructure.Data.Entities.Case>();
+                if (loadedCaseIds.Count > 0)
+                {
+                    var sdkCoreForPrefilter = await coreHelper.GetCore().ConfigureAwait(false);
+                    await using var sdkDbContextForPrefilter = sdkCoreForPrefilter.DbContextHelper.GetDbContext();
+                    loadedCases = await sdkDbContextForPrefilter.Cases
+                        .Where(c => loadedCaseIds.Contains(c.Id))
+                        .ToDictionaryAsync(c => c.Id);
+                }
+
+                compliancesInWeek = loadedCompliances
+                    .Where(c => c.WorkflowState != Constants.WorkflowStates.Removed
+                            || (loadedCases.TryGetValue(c.MicrotingSdkCaseId, out var sdk) && sdk.Status == 100))
+                    .ToList();
             }
             else
             {
@@ -1732,9 +1768,13 @@ public class BackendConfigurationCalendarService(
             }
 
             // No mandatory fields → complete the SDK case in place. Mirrors
-            // CompliancesGrpcService:159-174 (the form-submit path).
+            // CompliancesGrpcService:159-174 (the form-submit path) — set
+            // Status=100 + done-at timestamps so subsequent reads of the SDK
+            // case report the case as fully completed.
             sdkCase.Status = 100;
             sdkCase.WorkflowState = Constants.WorkflowStates.Created;
+            sdkCase.DoneAt = DateTime.UtcNow;
+            sdkCase.DoneAtUserModifiable = DateTime.UtcNow;
             await sdkCase.Update(sdkDbContext).ConfigureAwait(false);
 
             return new OperationDataResult<CalendarToggleCompleteResult>(true,

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/IBackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/IBackendConfigurationCalendarService.cs
@@ -35,7 +35,8 @@ public interface IBackendConfigurationCalendarService
     Task<OperationResult> DeleteTask(CalendarTaskDeleteRequestModel deleteModel);
     Task<OperationResult> MoveTask(CalendarTaskMoveRequestModel moveModel);
     Task<OperationResult> ResizeTask(CalendarTaskResizeRequestModel resizeModel);
-    Task<OperationDataResult<CalendarToggleCompleteResult>> ToggleComplete(int id, bool completed, int? complianceId);
+    Task<OperationDataResult<CalendarToggleCompleteResult>> ToggleComplete(
+        int id, bool completed, int? complianceId, string? occurrenceDate);
     Task<OperationDataResult<List<CalendarBoardModel>>> GetBoards(int propertyId);
     Task<OperationResult> CreateBoard(CalendarBoardCreateModel model);
     Task<OperationResult> UpdateBoard(CalendarBoardUpdateModel model);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microting.eForm.Infrastructure.Constants;
 using Microting.eFormApi.BasePn.Abstractions;
@@ -57,7 +58,7 @@ public class EventDeployService(
     BackendConfigurationPnDbContext dbContext,
     ItemsPlanningPnDbContext itemsPlanningPnDbContext,
     IEFormCoreService coreHelper,
-    IBackendConfigurationCalendarService calendarService,
+    IServiceProvider serviceProvider,
     ILogger<EventDeployService> logger) : IEventDeployService
 {
     public async Task EnsureDeployedAsync(
@@ -101,6 +102,7 @@ public class EventDeployService(
             ActionableOnly = false
         };
 
+        var calendarService = serviceProvider.GetRequiredService<IBackendConfigurationCalendarService>();
         var calendarResult = await calendarService.GetTasksForWeek(model).ConfigureAwait(false);
         if (!calendarResult.Success || calendarResult.Model == null)
         {
@@ -582,14 +584,31 @@ public class EventDeployService(
                 logger.LogInformation(
                     "EventDeployService: compliance for planning {PlanningId} deadline {Deadline} already exists (race) — fetching winning row",
                     planning.Id, rotationDate);
-                return await dbContext.Compliances
-                    .AsNoTracking()
+
+                // Tracked (NOT AsNoTracking) so we can revive a half-deployed
+                // row in place when this call has just produced a fresh SDK case.
+                var existing = await dbContext.Compliances
                     .FirstOrDefaultAsync(c =>
                             c.PlanningId == planning.Id
                             && c.Deadline.Date == rotationDate.Date
                             && c.WorkflowState != Constants.WorkflowStates.Removed,
                         cancellationToken)
                     .ConfigureAwait(false);
+
+                if (existing != null
+                    && existing.MicrotingSdkCaseId <= 0
+                    && planningCaseSite.MicrotingSdkCaseId > 0)
+                {
+                    // Half-deployed row found AND we have a fresh SDK case from this
+                    // call. Adopt the new SDK case to avoid orphaning it. Never
+                    // overwrite a row that already has a valid SDK case id (that
+                    // would be a real race winner; let them keep it).
+                    existing.MicrotingSdkCaseId = planningCaseSite.MicrotingSdkCaseId;
+                    existing.MicrotingSdkeFormId = planning.RelatedEFormId;
+                    await existing.Update(dbContext).ConfigureAwait(false);
+                }
+
+                return existing;
             }
             throw;
         }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
@@ -14,6 +14,10 @@ using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
 using Microting.ItemsPlanningBase.Infrastructure.Data;
 using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using SdkCore = eFormCore.Core;
+using SdkDbContext = Microting.eForm.Infrastructure.MicrotingDbContext;
+using SdkSite = Microting.eForm.Infrastructure.Data.Entities.Site;
+using SdkLanguage = Microting.eForm.Infrastructure.Data.Entities.Language;
 
 namespace BackendConfiguration.Pn.Services.EventDeployService;
 
@@ -116,8 +120,7 @@ public class EventDeployService(
         var candidates = calendarResult.Model
             .Where(t => t.PlanningId.HasValue)
             .Where(t => t.EformId.HasValue && t.EformId.Value > 0)
-            .Where(t => !t.IsFromCompliance
-                        || t.SdkCaseId.GetValueOrDefault() == 0) // recurrence-only OR stuck Compliance (SdkCaseId not yet assigned)
+            .Where(t => !t.IsFromCompliance) // rows already backed by a Compliance need no deploy
             .Select(t => new
             {
                 Task = t,
@@ -182,22 +185,12 @@ public class EventDeployService(
                 //    is keyed on PlanningId + Deadline; we additionally scope
                 //    to the requested sdk site below when locating the
                 //    PlanningCaseSite).
-                //    The slot is "taken — skip" if it's soft-removed (user
-                //    already completed this rotation; the SDK Case still
-                //    exists, just the Compliance was retracted) OR fully
-                //    deployed (MicrotingSdkCaseId > 0). We re-deploy ONLY for
-                //    the genuine stuck-row shape: Created + MicrotingSdkCaseId
-                //    == 0, where an earlier deploy left a Compliance row
-                //    behind without an SDK Case (e.g. the SDK 10.0.27 EndDate
-                //    validation bug). EnsureComplianceRowAsync revives that
-                //    row in place.
                 var alreadyDeployed = await dbContext.Compliances
                     .AsNoTracking()
                     .AnyAsync(c =>
                             c.PlanningId == planningId
                             && c.Deadline.Date == rotationDate
-                            && (c.WorkflowState == Constants.WorkflowStates.Removed
-                                || c.MicrotingSdkCaseId > 0),
+                            && c.WorkflowState != Constants.WorkflowStates.Removed,
                         cancellationToken)
                     .ConfigureAwait(false);
                 if (alreadyDeployed)
@@ -237,127 +230,20 @@ public class EventDeployService(
                     continue;
                 }
 
-                // 3. Resolve / create PlanningCase.
-                //    Mirrors ItemCaseCreateHandler.cs:83-89, scoped to the
-                //    rotation we're deploying (one PlanningCase per
-                //    rotation deploy). We do NOT retract sibling PlanningCases
-                //    here because we're filling a future-day gap, not
-                //    re-deploying — the scheduler microservice owns that.
-                var planningCase = new PlanningCase
-                {
-                    PlanningId = planning.Id,
-                    Status = 66,
-                    MicrotingSdkeFormId = eformId
-                };
-                await planningCase.Create(itemsPlanningPnDbContext).ConfigureAwait(false);
-
-                // 4. Resolve / create PlanningCaseSite.
-                //    Mirrors ItemCaseCreateHandler.cs:179-194.
-                var planningCaseSite = new PlanningCaseSite
-                {
-                    MicrotingSdkSiteId = sdkSiteId,
-                    MicrotingSdkeFormId = eformId,
-                    Status = 66,
-                    PlanningId = planning.Id,
-                    PlanningCaseId = planningCase.Id
-                };
-                await planningCaseSite.Create(itemsPlanningPnDbContext).ConfigureAwait(false);
-
-                // 5. SDK case idempotence guard — mirrors
-                //    ItemCaseCreateHandler.cs:205. A freshly-created
-                //    PlanningCaseSite has MicrotingSdkCaseId == 0, so this
-                //    branch is taken on the deploy path.
-                if (planningCaseSite.MicrotingSdkCaseId >= 1)
-                {
-                    // Still ensure the Compliance row exists for this rotation
-                    // before continuing.
-                    await EnsureComplianceRowAsync(
-                            areaRulePlanning,
-                            planning,
-                            rotationDate,
-                            planningCaseSite,
-                            cancellationToken)
-                        .ConfigureAwait(false);
-                    continue;
-                }
-
-                // 6. Build mainElement. Mirrors ItemCaseCreateHandler.cs:113-153.
-                //    KEY DIFFERENCE: EndDate is the rotation we're deploying
-                //    (not planning.NextExecutionTime), so backfill of a future
-                //    rotation date stays bounded to that day.
-                var mainElement = await sdkCore.ReadeForm(eformId, language).ConfigureAwait(false);
-
-                var planningNameTranslation = await itemsPlanningPnDbContext.PlanningNameTranslation
-                    .FirstOrDefaultAsync(x =>
-                            x.LanguageId == language.Id && x.PlanningId == planning.Id,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                var translation = planningNameTranslation?.Name;
-
-                string folderId = string.Empty;
-                if (planning.SdkFolderId.HasValue)
-                {
-                    var folder = await sdkDbContext.Folders
-                        .FirstOrDefaultAsync(x => x.Id == planning.SdkFolderId.Value, cancellationToken)
-                        .ConfigureAwait(false);
-                    folderId = folder?.MicrotingUid?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
-                }
-
-                mainElement.Label = string.IsNullOrEmpty(planning.PlanningNumber) ? "" : planning.PlanningNumber;
-                mainElement.StartDate = DateTime.UtcNow;
-                if (!string.IsNullOrEmpty(translation))
-                {
-                    mainElement.Label += string.IsNullOrEmpty(mainElement.Label) ? $"{translation}" : $" - {translation}";
-                }
-                if (!string.IsNullOrEmpty(planning.BuildYear))
-                {
-                    mainElement.Label += string.IsNullOrEmpty(mainElement.Label) ? $"{planning.BuildYear}" : $" - {planning.BuildYear}";
-                }
-                if (!string.IsNullOrEmpty(planning.Type))
-                {
-                    mainElement.Label += string.IsNullOrEmpty(mainElement.Label) ? $"{planning.Type}" : $" - {planning.Type}";
-                }
-
-                if (mainElement.ElementList.Count == 1)
-                {
-                    mainElement.ElementList[0].Label = mainElement.Label;
-                }
-
-                mainElement.CheckListFolderName = folderId;
-                // Use end-of-rotation-day UTC so the SDK Case is created any time during the
-                // deadline day, not only when the deploy fires BEFORE 00:00 UTC.
-                // rotationDate is parsed at line 123-128 with
-                // AssumeUniversal | AdjustToUniversal then .Date, so it lands at 00:00 UTC.
-                // The downstream guard at line 325 (`mainElement.EndDate > DateTime.UtcNow`)
-                // otherwise silently skips CaseCreate for any same-day deploy, leaving
-                // Compliance rows with MicrotingSdkCaseId=0.
-                mainElement.EndDate = rotationDate.AddDays(1).AddTicks(-1);
-
-                // 7. Only call CaseCreate when EndDate is in the future
-                //    (mirrors ItemCaseCreateHandler.cs:236). The EndDate value
-                //    itself — end-of-rotation-day UTC (23:59:59.9999999) — is
-                //    what makes the guard pass for same-day deploys; this is
-                //    now a clock-skew belt + safety net for future changes to
-                //    rotationDate semantics.
-                if (mainElement.EndDate > DateTime.UtcNow)
-                {
-                    var caseId = await sdkCore.CaseCreateLocalOnly(
-                        mainElement, "", (int)sdkSite.MicrotingUid!, null)
-                        .ConfigureAwait(false);
-
-                    if (caseId != null)
-                    {
-                        planningCaseSite.MicrotingSdkCaseId = (int)caseId;
-                        await planningCaseSite.Update(itemsPlanningPnDbContext).ConfigureAwait(false);
-                    }
-                }
-
-                // 8. Compliance row. Mirrors EformParsedByServerHandler.cs:170-182.
-                await EnsureComplianceRowAsync(
+                // 3-8. PlanningCase + PlanningCaseSite + SDK Case + Compliance.
+                //      Extracted so the on-demand calendar materialisation path
+                //      (EnsureComplianceForOccurrenceAsync) reuses byte-for-byte
+                //      the same writes in the same order.
+                await DeployForRotationAsync(
                         areaRulePlanning,
                         planning,
                         rotationDate,
-                        planningCaseSite,
+                        eformId,
+                        sdkSiteId,
+                        sdkCore,
+                        sdkDbContext,
+                        sdkSite,
+                        language,
                         cancellationToken)
                     .ConfigureAwait(false);
             }
@@ -371,50 +257,295 @@ public class EventDeployService(
         }
     }
 
-    private async Task EnsureComplianceRowAsync(
+    /// <summary>
+    /// Single source of truth for "create PlanningCase + PlanningCaseSite +
+    /// SDK Case + Compliance row for one (planning, rotationDate, sdkSite)
+    /// tuple". Used by both the nightly window deploy
+    /// (<see cref="EnsureDeployedAsync"/>) and the on-demand calendar
+    /// materialisation path
+    /// (<see cref="EnsureComplianceForOccurrenceAsync"/>).
+    ///
+    /// Preserves the historical write order: PlanningCase → PlanningCaseSite
+    /// → CaseCreate → Update PlanningCaseSite → EnsureComplianceRowAsync.
+    /// Returns the ids of the created compliance + SDK case so the on-demand
+    /// caller can hand them back to the calendar UI without a re-query.
+    /// </summary>
+    private async Task<(int ComplianceId, int SdkCaseId, int TemplateId)> DeployForRotationAsync(
+        AreaRulePlanning areaRulePlanning,
+        Planning planning,
+        DateTime rotationDate,
+        int eformId,
+        int sdkSiteId,
+        SdkCore sdkCore,
+        SdkDbContext sdkDbContext,
+        SdkSite sdkSite,
+        SdkLanguage language,
+        CancellationToken ct)
+    {
+        // 3. Resolve / create PlanningCase.
+        //    Mirrors ItemCaseCreateHandler.cs:83-89, scoped to the
+        //    rotation we're deploying (one PlanningCase per
+        //    rotation deploy). We do NOT retract sibling PlanningCases
+        //    here because we're filling a future-day gap, not
+        //    re-deploying — the scheduler microservice owns that.
+        var planningCase = new PlanningCase
+        {
+            PlanningId = planning.Id,
+            Status = 66,
+            MicrotingSdkeFormId = eformId
+        };
+        await planningCase.Create(itemsPlanningPnDbContext).ConfigureAwait(false);
+
+        // 4. Resolve / create PlanningCaseSite.
+        //    Mirrors ItemCaseCreateHandler.cs:179-194.
+        var planningCaseSite = new PlanningCaseSite
+        {
+            MicrotingSdkSiteId = sdkSiteId,
+            MicrotingSdkeFormId = eformId,
+            Status = 66,
+            PlanningId = planning.Id,
+            PlanningCaseId = planningCase.Id
+        };
+        await planningCaseSite.Create(itemsPlanningPnDbContext).ConfigureAwait(false);
+
+        // 5. SDK case idempotence guard — mirrors
+        //    ItemCaseCreateHandler.cs:205. A freshly-created
+        //    PlanningCaseSite has MicrotingSdkCaseId == 0, so this
+        //    branch is taken on the deploy path.
+        if (planningCaseSite.MicrotingSdkCaseId >= 1)
+        {
+            // Still ensure the Compliance row exists for this rotation
+            // before returning.
+            var existingRow = await EnsureComplianceRowAsync(
+                    areaRulePlanning,
+                    planning,
+                    rotationDate,
+                    planningCaseSite,
+                    ct)
+                .ConfigureAwait(false);
+            return (
+                existingRow?.Id ?? 0,
+                planningCaseSite.MicrotingSdkCaseId,
+                eformId);
+        }
+
+        // 6. Build mainElement. Mirrors ItemCaseCreateHandler.cs:113-153.
+        //    KEY DIFFERENCE: EndDate is the rotation we're deploying
+        //    (not planning.NextExecutionTime), so backfill of a future
+        //    rotation date stays bounded to that day.
+        var mainElement = await sdkCore.ReadeForm(eformId, language).ConfigureAwait(false);
+
+        var planningNameTranslation = await itemsPlanningPnDbContext.PlanningNameTranslation
+            .FirstOrDefaultAsync(x =>
+                    x.LanguageId == language.Id && x.PlanningId == planning.Id,
+                ct)
+            .ConfigureAwait(false);
+        var translation = planningNameTranslation?.Name;
+
+        string folderId = string.Empty;
+        if (planning.SdkFolderId.HasValue)
+        {
+            var folder = await sdkDbContext.Folders
+                .FirstOrDefaultAsync(x => x.Id == planning.SdkFolderId.Value, ct)
+                .ConfigureAwait(false);
+            folderId = folder?.MicrotingUid?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+        }
+
+        mainElement.Label = string.IsNullOrEmpty(planning.PlanningNumber) ? "" : planning.PlanningNumber;
+        mainElement.StartDate = DateTime.UtcNow;
+        if (!string.IsNullOrEmpty(translation))
+        {
+            mainElement.Label += string.IsNullOrEmpty(mainElement.Label) ? $"{translation}" : $" - {translation}";
+        }
+        if (!string.IsNullOrEmpty(planning.BuildYear))
+        {
+            mainElement.Label += string.IsNullOrEmpty(mainElement.Label) ? $"{planning.BuildYear}" : $" - {planning.BuildYear}";
+        }
+        if (!string.IsNullOrEmpty(planning.Type))
+        {
+            mainElement.Label += string.IsNullOrEmpty(mainElement.Label) ? $"{planning.Type}" : $" - {planning.Type}";
+        }
+
+        if (mainElement.ElementList.Count == 1)
+        {
+            mainElement.ElementList[0].Label = mainElement.Label;
+        }
+
+        mainElement.CheckListFolderName = folderId;
+        // Use end-of-rotation-day UTC so the SDK Case is created any time during the
+        // deadline day, not only when the deploy fires BEFORE 00:00 UTC.
+        // rotationDate is parsed by EnsureDeployedAsync with
+        // AssumeUniversal | AdjustToUniversal then .Date, so it lands at 00:00 UTC.
+        // The downstream guard (`mainElement.EndDate > DateTime.UtcNow`)
+        // otherwise silently skips CaseCreate for any same-day deploy, leaving
+        // Compliance rows with MicrotingSdkCaseId=0.
+        mainElement.EndDate = rotationDate.AddDays(1).AddTicks(-1);
+
+        // 7. Only call CaseCreate when EndDate is in the future
+        //    (mirrors ItemCaseCreateHandler.cs:236). The EndDate value
+        //    itself — end-of-rotation-day UTC (23:59:59.9999999) — is
+        //    what makes the guard pass for same-day deploys; this is
+        //    now a clock-skew belt + safety net for future changes to
+        //    rotationDate semantics.
+        if (mainElement.EndDate > DateTime.UtcNow)
+        {
+            var caseId = await sdkCore.CaseCreate(
+                mainElement, "", (int)sdkSite.MicrotingUid!, null)
+                .ConfigureAwait(false);
+
+            if (caseId != null)
+            {
+                var caseDto = await sdkCore.CaseLookupMUId((int)caseId).ConfigureAwait(false);
+                if (caseDto?.CaseId != null)
+                {
+                    planningCaseSite.MicrotingSdkCaseId = (int)caseDto.CaseId;
+                    await planningCaseSite.Update(itemsPlanningPnDbContext).ConfigureAwait(false);
+                }
+            }
+        }
+
+        // 8. Compliance row. Mirrors EformParsedByServerHandler.cs:170-182.
+        var created = await EnsureComplianceRowAsync(
+                areaRulePlanning,
+                planning,
+                rotationDate,
+                planningCaseSite,
+                ct)
+            .ConfigureAwait(false);
+
+        return (
+            created?.Id ?? 0,
+            planningCaseSite.MicrotingSdkCaseId,
+            eformId);
+    }
+
+    public async Task<EnsureComplianceResult?> EnsureComplianceForOccurrenceAsync(
+        AreaRulePlanning areaRulePlanning,
+        DateTime deadline,
+        int sdkSiteId,
+        CancellationToken cancellationToken = default)
+    {
+        if (areaRulePlanning == null)
+        {
+            return null;
+        }
+
+        var deadlineDate = deadline.Date;
+
+        // Idempotence guard: another caller (nightly batch, parallel request)
+        // may already have materialised this occurrence. Match the natural
+        // key the nightly path uses (PlanningId + Deadline.Date, non-removed)
+        // plus the canonical "case actually exists" filter
+        // (MicrotingSdkCaseId > 0) so we never hand back a half-deployed row.
+        var existing = await dbContext.Compliances
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c =>
+                    c.PlanningId == areaRulePlanning.ItemPlanningId
+                    && c.Deadline.Date == deadlineDate
+                    && c.WorkflowState != Constants.WorkflowStates.Removed
+                    && c.MicrotingSdkCaseId > 0,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (existing != null)
+        {
+            return new EnsureComplianceResult
+            {
+                Created = false,
+                ComplianceId = existing.Id,
+                SdkCaseId = existing.MicrotingSdkCaseId,
+                TemplateId = existing.MicrotingSdkeFormId
+            };
+        }
+
+        var planning = await itemsPlanningPnDbContext.Plannings
+            .FirstOrDefaultAsync(p =>
+                    p.Id == areaRulePlanning.ItemPlanningId
+                    && p.WorkflowState != Constants.WorkflowStates.Removed,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (planning == null)
+        {
+            logger.LogWarning(
+                "EventDeployService.EnsureComplianceForOccurrenceAsync: planning {PlanningId} not found for ARP {AreaRulePlanningId}",
+                areaRulePlanning.ItemPlanningId, areaRulePlanning.Id);
+            return null;
+        }
+
+        var sdkCore = await coreHelper.GetCore().ConfigureAwait(false);
+        await using var sdkDbContext = sdkCore.DbContextHelper.GetDbContext();
+
+        var sdkSite = await sdkDbContext.Sites
+            .FirstOrDefaultAsync(s => s.Id == sdkSiteId, cancellationToken)
+            .ConfigureAwait(false);
+        if (sdkSite == null)
+        {
+            logger.LogWarning(
+                "EventDeployService.EnsureComplianceForOccurrenceAsync: SDK site {SdkSiteId} not found",
+                sdkSiteId);
+            return null;
+        }
+
+        var language = await sdkDbContext.Languages
+            .FirstOrDefaultAsync(l => l.Id == sdkSite.LanguageId, cancellationToken)
+            .ConfigureAwait(false);
+        if (language == null)
+        {
+            logger.LogWarning(
+                "EventDeployService.EnsureComplianceForOccurrenceAsync: language {LanguageId} for sdk site {SdkSiteId} not found",
+                sdkSite.LanguageId, sdkSiteId);
+            return null;
+        }
+
+        // EformId source matches the nightly path's task.EformId (which is
+        // arp.AreaRule.EformId) — when AreaRule is loaded prefer that,
+        // otherwise fall back to planning.RelatedEFormId. Both are set from
+        // the same upstream value at task-wizard creation.
+        var eformId = areaRulePlanning.AreaRule?.EformId is { } eid && eid > 0
+            ? eid
+            : planning.RelatedEFormId;
+
+        if (eformId <= 0)
+        {
+            logger.LogWarning(
+                "EventDeployService.EnsureComplianceForOccurrenceAsync: no usable EformId for ARP {AreaRulePlanningId} (planning {PlanningId}); skipping deploy",
+                areaRulePlanning.Id, planning.Id);
+            return null;
+        }
+
+        var (complianceId, sdkCaseId, templateId) = await DeployForRotationAsync(
+                areaRulePlanning,
+                planning,
+                deadlineDate,
+                eformId,
+                sdkSiteId,
+                sdkCore,
+                sdkDbContext,
+                sdkSite,
+                language,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return new EnsureComplianceResult
+        {
+            Created = true,
+            ComplianceId = complianceId,
+            SdkCaseId = sdkCaseId,
+            TemplateId = templateId
+        };
+    }
+
+    private async Task<Compliance?> EnsureComplianceRowAsync(
         AreaRulePlanning areaRulePlanning,
         Planning planning,
         DateTime rotationDate,
         PlanningCaseSite planningCaseSite,
         CancellationToken cancellationToken)
     {
-        // Check-first / revive-if-found / INSERT-if-not. The UNIQUE index
-        // IX_PlanningId_Deadline on Compliances is on (PlanningId, Deadline)
-        // ONLY — it does NOT include WorkflowState. That means a soft-removed
-        // row still occupies the natural-key slot, and a blind INSERT after a
-        // prior failed deploy collides on the unique key.
-        //
-        // Revive ONLY the genuine stuck-row shape: Created + MicrotingSdkCaseId
-        // == 0 (earlier deploy persisted Compliance but failed CaseCreate,
-        // e.g. the SDK 10.0.27 EndDate validation bug). A soft-removed row in
-        // the slot belongs to a completed event — flipping it back to Created
-        // would phantom-uncomplete that event and orphan its SDK Case. The
-        // outer guard above already prevents us from reaching here for the
-        // Removed shape; this predicate is the defensive belt: if a Removed
-        // row ever falls through, the SELECT returns null, the INSERT below
-        // collides on the UNIQUE index, and the narrow catch logs and skips.
-        var existing = await dbContext.Compliances
-            .FirstOrDefaultAsync(c =>
-                    c.PlanningId == planning.Id
-                    && c.Deadline.Date == rotationDate.Date
-                    && c.WorkflowState == Constants.WorkflowStates.Created
-                    && c.MicrotingSdkCaseId == 0,
-                cancellationToken)
-            .ConfigureAwait(false);
-
-        if (existing != null)
-        {
-            existing.WorkflowState = Constants.WorkflowStates.Created;
-            existing.MicrotingSdkCaseId = planningCaseSite.MicrotingSdkCaseId;
-            existing.MicrotingSdkeFormId = planning.RelatedEFormId;
-            // The handler mistakenly stores PlanningCaseId in the
-            // PlanningCaseSiteId column — see EformParsedByServerHandler.cs:179.
-            // Preserve that convention so the round-trip matches the JSON
-            // oracle path.
-            existing.PlanningCaseSiteId = planningCaseSite.PlanningCaseId;
-            await existing.Update(dbContext).ConfigureAwait(false);
-            return;
-        }
+        // Race protection lives in the duplicate-key catch below (mirrors
+        // EformParsedByServerHandler.cs:185-196). The outer idempotence guard
+        // in EnsureDeployedAsync already filters out the common case before
+        // any writes happen, so a second AnyAsync here would only add a DB
+        // round-trip without changing behaviour.
 
         // The handler uses `planning.LastExecutedTime` for StartDate. For an
         // eager deploy that has not actually run yet, LastExecutedTime is the
@@ -422,34 +553,45 @@ public class EventDeployService(
         // is null so the StartDate column stays populated.
         var startDate = planning.LastExecutedTime ?? DateTime.UtcNow;
 
-        var compliance = new Compliance
-        {
-            PropertyId = areaRulePlanning.PropertyId,
-            PlanningId = planning.Id,
-            AreaId = areaRulePlanning.AreaId,
-            Deadline = new DateTime(rotationDate.Year, rotationDate.Month, rotationDate.Day, 0, 0, 0),
-            StartDate = startDate,
-            MicrotingSdkeFormId = planning.RelatedEFormId,
-            MicrotingSdkCaseId = planningCaseSite.MicrotingSdkCaseId,
-            // The handler mistakenly stores PlanningCaseId here (named
-            // PlanningCaseSiteId on the column) — see
-            // EformParsedByServerHandler.cs:179. Preserve that convention
-            // so the round-trip matches the JSON oracle path.
-            PlanningCaseSiteId = planningCaseSite.PlanningCaseId
-        };
         try
         {
+            var compliance = new Compliance
+            {
+                PropertyId = areaRulePlanning.PropertyId,
+                PlanningId = planning.Id,
+                AreaId = areaRulePlanning.AreaId,
+                Deadline = new DateTime(rotationDate.Year, rotationDate.Month, rotationDate.Day, 0, 0, 0),
+                StartDate = startDate,
+                MicrotingSdkeFormId = planning.RelatedEFormId,
+                MicrotingSdkCaseId = planningCaseSite.MicrotingSdkCaseId,
+                // The handler mistakenly stores PlanningCaseId here (named
+                // PlanningCaseSiteId on the column) — see
+                // EformParsedByServerHandler.cs:179. Preserve that convention
+                // so the round-trip matches the JSON oracle path.
+                PlanningCaseSiteId = planningCaseSite.PlanningCaseId
+            };
             await compliance.Create(dbContext).ConfigureAwait(false);
+            return compliance;
         }
-        catch (DbUpdateException ex) when (ex.InnerException is { HResult: -2147467259 })
+        catch (Exception ex)
         {
-            // UNIQUE index IX_PlanningId_Deadline collision — another
-            // concurrent ListEvents deploy beat us to the INSERT (both
-            // SELECTed null, both INSERTed). Benign: the other deploy
-            // produced a valid row. Log informational and skip.
-            logger.LogInformation(
-                "EventDeployService: compliance for planning {PlanningId} deadline {Deadline} created by a concurrent deploy — skipping",
-                planning.Id, rotationDate);
+            // Duplicate-key races are tolerated — mirrors
+            // EformParsedByServerHandler.cs:185-196.
+            if (ex.InnerException is { HResult: -2147467259 })
+            {
+                logger.LogInformation(
+                    "EventDeployService: compliance for planning {PlanningId} deadline {Deadline} already exists (race) — fetching winning row",
+                    planning.Id, rotationDate);
+                return await dbContext.Compliances
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(c =>
+                            c.PlanningId == planning.Id
+                            && c.Deadline.Date == rotationDate.Date
+                            && c.WorkflowState != Constants.WorkflowStates.Removed,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            throw;
         }
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
@@ -385,36 +385,31 @@ public class EventDeployService(
         }
 
         mainElement.CheckListFolderName = folderId;
-        // Use end-of-rotation-day UTC so the SDK Case is created any time during the
-        // deadline day, not only when the deploy fires BEFORE 00:00 UTC.
-        // rotationDate is parsed by EnsureDeployedAsync with
-        // AssumeUniversal | AdjustToUniversal then .Date, so it lands at 00:00 UTC.
-        // The downstream guard (`mainElement.EndDate > DateTime.UtcNow`)
-        // otherwise silently skips CaseCreate for any same-day deploy, leaving
-        // Compliance rows with MicrotingSdkCaseId=0.
-        mainElement.EndDate = rotationDate.AddDays(1).AddTicks(-1);
+        // EndDate must be in the future for CaseCreate to be accepted.
+        // For nightly deploys, rotationDate is always today-or-later (the
+        // candidate filter at line 132-ish enforces that). For on-demand
+        // calendar materialisation (EnsureComplianceForOccurrenceAsync),
+        // the user may click an event whose rotation date is in the past
+        // — in that case clamp the EndDate to end-of-tomorrow UTC so the
+        // SDK accepts the case, while keeping Compliance.Deadline at the
+        // true rotationDate (the column is set inside
+        // EnsureComplianceRowAsync independently of mainElement.EndDate).
+        var endOfRotationDay = rotationDate.AddDays(1).AddTicks(-1);
+        var endOfTomorrow = DateTime.UtcNow.Date.AddDays(2).AddTicks(-1);
+        mainElement.EndDate = endOfRotationDay > endOfTomorrow ? endOfRotationDay : endOfTomorrow;
 
-        // 7. Only call CaseCreate when EndDate is in the future
-        //    (mirrors ItemCaseCreateHandler.cs:236). The EndDate value
-        //    itself — end-of-rotation-day UTC (23:59:59.9999999) — is
-        //    what makes the guard pass for same-day deploys; this is
-        //    now a clock-skew belt + safety net for future changes to
-        //    rotationDate semantics.
-        if (mainElement.EndDate > DateTime.UtcNow)
+        // CaseCreateLocalOnly returns the SDK Case.Id directly (no
+        // MicrotingUid → Id lookup needed) AND skips the cloud XML
+        // deploy that the standard CaseCreate path performs. Mirrors
+        // the fix from PR #829.
+        var caseId = await sdkCore.CaseCreateLocalOnly(
+            mainElement, "", (int)sdkSite.MicrotingUid!, null)
+            .ConfigureAwait(false);
+
+        if (caseId != null)
         {
-            // CaseCreateLocalOnly returns the SDK Case.Id directly (no
-            // MicrotingUid → Id lookup needed) AND skips the cloud XML
-            // deploy that the standard CaseCreate path performs. Mirrors
-            // the fix from PR #829.
-            var caseId = await sdkCore.CaseCreateLocalOnly(
-                mainElement, "", (int)sdkSite.MicrotingUid!, null)
-                .ConfigureAwait(false);
-
-            if (caseId != null)
-            {
-                planningCaseSite.MicrotingSdkCaseId = (int)caseId;
-                await planningCaseSite.Update(itemsPlanningPnDbContext).ConfigureAwait(false);
-            }
+            planningCaseSite.MicrotingSdkCaseId = (int)caseId;
+            await planningCaseSite.Update(itemsPlanningPnDbContext).ConfigureAwait(false);
         }
 
         // 8. Compliance row. Mirrors EformParsedByServerHandler.cs:170-182.
@@ -566,23 +561,24 @@ public class EventDeployService(
         // is null so the StartDate column stays populated.
         var startDate = planning.LastExecutedTime ?? DateTime.UtcNow;
 
+        var compliance = new Compliance
+        {
+            PropertyId = areaRulePlanning.PropertyId,
+            PlanningId = planning.Id,
+            AreaId = areaRulePlanning.AreaId,
+            Deadline = new DateTime(rotationDate.Year, rotationDate.Month, rotationDate.Day, 0, 0, 0),
+            StartDate = startDate,
+            MicrotingSdkeFormId = planning.RelatedEFormId,
+            MicrotingSdkCaseId = planningCaseSite.MicrotingSdkCaseId,
+            // The handler mistakenly stores PlanningCaseId here (named
+            // PlanningCaseSiteId on the column) — see
+            // EformParsedByServerHandler.cs:179. Preserve that convention
+            // so the round-trip matches the JSON oracle path.
+            PlanningCaseSiteId = planningCaseSite.PlanningCaseId
+        };
+
         try
         {
-            var compliance = new Compliance
-            {
-                PropertyId = areaRulePlanning.PropertyId,
-                PlanningId = planning.Id,
-                AreaId = areaRulePlanning.AreaId,
-                Deadline = new DateTime(rotationDate.Year, rotationDate.Month, rotationDate.Day, 0, 0, 0),
-                StartDate = startDate,
-                MicrotingSdkeFormId = planning.RelatedEFormId,
-                MicrotingSdkCaseId = planningCaseSite.MicrotingSdkCaseId,
-                // The handler mistakenly stores PlanningCaseId here (named
-                // PlanningCaseSiteId on the column) — see
-                // EformParsedByServerHandler.cs:179. Preserve that convention
-                // so the round-trip matches the JSON oracle path.
-                PlanningCaseSiteId = planningCaseSite.PlanningCaseId
-            };
             await compliance.Create(dbContext).ConfigureAwait(false);
             return compliance;
         }
@@ -595,6 +591,17 @@ public class EventDeployService(
                 logger.LogInformation(
                     "EventDeployService: compliance for planning {PlanningId} deadline {Deadline} already exists (race) — fetching winning row",
                     planning.Id, rotationDate);
+
+                // Detach the failed-INSERT entity so the SaveChanges that
+                // happens inside the revive's existing.Update(...) below
+                // does not retry the same INSERT and re-hit the duplicate
+                // key. EF Core leaves a failed Add tracked as Added until
+                // explicitly detached.
+                var addedEntry = dbContext.Entry(compliance);
+                if (addedEntry.State == EntityState.Added)
+                {
+                    addedEntry.State = EntityState.Detached;
+                }
 
                 // Tracked (NOT AsNoTracking) so we can revive a half-deployed
                 // row in place when this call has just produced a fresh SDK case.

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
@@ -122,7 +122,8 @@ public class EventDeployService(
         var candidates = calendarResult.Model
             .Where(t => t.PlanningId.HasValue)
             .Where(t => t.EformId.HasValue && t.EformId.Value > 0)
-            .Where(t => !t.IsFromCompliance) // rows already backed by a Compliance need no deploy
+            .Where(t => !t.IsFromCompliance
+                        || t.SdkCaseId.GetValueOrDefault() == 0) // recurrence-only OR stuck Compliance (SdkCaseId not yet assigned)
             .Select(t => new
             {
                 Task = t,
@@ -187,12 +188,22 @@ public class EventDeployService(
                 //    is keyed on PlanningId + Deadline; we additionally scope
                 //    to the requested sdk site below when locating the
                 //    PlanningCaseSite).
+                //    The slot is "taken — skip" if it's soft-removed (user
+                //    already completed this rotation; the SDK Case still
+                //    exists, just the Compliance was retracted) OR fully
+                //    deployed (MicrotingSdkCaseId > 0). We re-deploy ONLY for
+                //    the genuine stuck-row shape: Created + MicrotingSdkCaseId
+                //    == 0, where an earlier deploy left a Compliance row
+                //    behind without an SDK Case (e.g. the SDK 10.0.27 EndDate
+                //    validation bug). EnsureComplianceRowAsync revives that
+                //    row in place via the duplicate-key catch.
                 var alreadyDeployed = await dbContext.Compliances
                     .AsNoTracking()
                     .AnyAsync(c =>
                             c.PlanningId == planningId
                             && c.Deadline.Date == rotationDate
-                            && c.WorkflowState != Constants.WorkflowStates.Removed,
+                            && (c.WorkflowState == Constants.WorkflowStates.Removed
+                                || c.MicrotingSdkCaseId > 0),
                         cancellationToken)
                     .ConfigureAwait(false);
                 if (alreadyDeployed)
@@ -391,18 +402,18 @@ public class EventDeployService(
         //    rotationDate semantics.
         if (mainElement.EndDate > DateTime.UtcNow)
         {
-            var caseId = await sdkCore.CaseCreate(
+            // CaseCreateLocalOnly returns the SDK Case.Id directly (no
+            // MicrotingUid → Id lookup needed) AND skips the cloud XML
+            // deploy that the standard CaseCreate path performs. Mirrors
+            // the fix from PR #829.
+            var caseId = await sdkCore.CaseCreateLocalOnly(
                 mainElement, "", (int)sdkSite.MicrotingUid!, null)
                 .ConfigureAwait(false);
 
             if (caseId != null)
             {
-                var caseDto = await sdkCore.CaseLookupMUId((int)caseId).ConfigureAwait(false);
-                if (caseDto?.CaseId != null)
-                {
-                    planningCaseSite.MicrotingSdkCaseId = (int)caseDto.CaseId;
-                    await planningCaseSite.Update(itemsPlanningPnDbContext).ConfigureAwait(false);
-                }
+                planningCaseSite.MicrotingSdkCaseId = (int)caseId;
+                await planningCaseSite.Update(itemsPlanningPnDbContext).ConfigureAwait(false);
             }
         }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/IEventDeployService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/IEventDeployService.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
 
 namespace BackendConfiguration.Pn.Services.EventDeployService;
 
@@ -20,4 +23,28 @@ public interface IEventDeployService
         string toDateKey,
         int sdkSiteId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// On-demand materialisation of a single Compliance row + backing
+    /// PlanningCase / PlanningCaseSite / SDK Case for one calendar
+    /// occurrence. Invoked from the angular calendar "complete from
+    /// indicator" flow when the nightly batch has not yet deployed the
+    /// occurrence the user clicked.
+    ///
+    /// Idempotent: if a Compliance row already exists for
+    /// (<paramref name="areaRulePlanning"/>.ItemPlanningId, <paramref name="deadline"/>.Date)
+    /// with a non-zero <c>MicrotingSdkCaseId</c>, returns it without
+    /// performing any writes.
+    ///
+    /// Returns <c>null</c> when materialisation could not proceed (planning
+    /// missing, SDK site missing, language missing). Per-call faults during
+    /// the SDK write path bubble through the existing duplicate-key tolerant
+    /// path in <c>EnsureComplianceRowAsync</c>; everything else throws so the
+    /// caller can surface it.
+    /// </summary>
+    Task<EnsureComplianceResult?> EnsureComplianceForOccurrenceAsync(
+        AreaRulePlanning areaRulePlanning,
+        DateTime deadline,
+        int sdkSiteId,
+        CancellationToken cancellationToken = default);
 }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/calendar.module.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/calendar.module.ts
@@ -28,6 +28,8 @@ import {MtxSelectModule} from '@ng-matero/extensions/select';
 import {MtxGridModule} from '@ng-matero/extensions/grid';
 import {EformSharedModule} from 'src/app/common/modules/eform-shared/eform-shared.module';
 import {EformImportedModule} from 'src/app/common/modules/eform-imported/eform-imported.module';
+import {EformCasesModule} from 'src/app/common/modules/eform-cases/eform-cases.module';
+import {CasesModule} from 'src/app/modules';
 import {TeamCreateDialogComponent} from './components/calendar-sidebar/team-create-dialog.component';
 import {TeamDeleteDialogComponent} from './components/calendar-sidebar/team-delete-dialog.component';
 import {TagCreateDialogComponent} from './components/calendar-sidebar/tag-create-dialog.component';
@@ -52,6 +54,7 @@ import {
   CustomRepeatModalComponent,
   BoardCreateModalComponent,
   BoardDeleteModalComponent,
+  ComplianceCaseModalComponent,
 } from './modals';
 
 // Re-export modal components for barrel
@@ -63,6 +66,7 @@ export {
   CustomRepeatModalComponent,
   BoardCreateModalComponent,
   BoardDeleteModalComponent,
+  ComplianceCaseModalComponent,
 };
 
 @NgModule({
@@ -84,6 +88,7 @@ export {
     CustomRepeatModalComponent,
     BoardCreateModalComponent,
     BoardDeleteModalComponent,
+    ComplianceCaseModalComponent,
     TeamCreateDialogComponent,
     TeamDeleteDialogComponent,
     TagCreateDialogComponent,
@@ -101,6 +106,8 @@ export {
     PortalModule,
     EformSharedModule,
     EformImportedModule,
+    EformCasesModule,
+    CasesModule,
     MatButtonModule,
     MatButtonToggleModule,
     MatCardModule,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.html
@@ -81,6 +81,7 @@
         [boards]="boards"
         (taskClicked)="onTaskClickedFromGrid($event)"
         (tasksReload)="loadTasks()"
+        (completeRequiresForm)="onCompleteRequiresForm($event)"
       ></app-calendar-schedule-view>
     </ng-container>
   </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -30,6 +30,7 @@ import {EformTagService} from 'src/app/common/services';
 import {BoardCreateModalComponent, BoardCreateModalData} from '../../modals/board-create-modal/board-create-modal.component';
 import {BoardDeleteModalComponent, BoardDeleteModalData} from '../../modals/board-delete-modal/board-delete-modal.component';
 import {RepeatScopeModalComponent} from '../../modals/repeat-scope-modal/repeat-scope-modal.component';
+import {ComplianceCaseModalComponent} from '../../modals/compliance-case-modal/compliance-case-modal.component';
 import {dialogConfigHelper} from 'src/app/common/helpers';
 import {RepeatEditScope} from '../../../../models/calendar';
 
@@ -562,11 +563,26 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
         || p.complianceId == null || p.workerId == null || !p.deadline) {
       return;
     }
-    this.router.navigate([
-      '/plugins/backend-configuration-pn/compliances/case',
-      p.sdkCaseId, p.templateId, p.propertyId, p.deadline, false,
-      p.complianceId, p.workerId,
-    ]);
+    const ref = this.dialog.open(ComplianceCaseModalComponent, {
+      data: {
+        sdkCaseId: p.sdkCaseId,
+        templateId: p.templateId,
+        propertyId: p.propertyId,
+        deadline: p.deadline,
+        complianceId: p.complianceId,
+        workerId: p.workerId,
+      },
+      width: 'min(90vw, 1080px)',
+      maxWidth: '95vw',
+      autoFocus: false,
+      restoreFocus: false,
+    });
+    ref.afterClosed().subscribe((result) => {
+      // Always reload — even on cancel — so any partial state (the
+      // freshly-materialised Compliance row, route timing, etc.) re-renders
+      // from the canonical server view.
+      this.loadTasks();
+    });
   }
 
   onTaskClickedFromGrid(event: {task: CalendarTaskLayoutModel; cellLeft: number; cellRight: number; slotTop: number}) {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.html
@@ -12,6 +12,14 @@
       [style.border-left-color]="task.color"
       (click)="onTaskClicked(task, $event)"
     >
+      <button
+        class="completion-btn"
+        [class.done]="task.completed"
+        (click)="onCompletionClick(task, $event)"
+        [title]="task.completed ? ('Completed' | translate) : ('Mark as completed' | translate)"
+      >
+        <mat-icon>{{ task.completed ? 'check_circle' : 'radio_button_unchecked' }}</mat-icon>
+      </button>
       <div class="task-time">{{ task.startText }} – {{ task.endText }}</div>
       <div class="task-info">
         <span class="task-title" [class.completed]="task.completed">{{ task.title }}</span>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.scss
@@ -38,6 +38,31 @@
         background: var(--bg-soft, #f1f3f4);
       }
 
+      .completion-btn {
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        color: #888;
+        flex-shrink: 0;
+        line-height: 0;
+
+        mat-icon {
+          font-size: 20px;
+          width: 20px;
+          height: 20px;
+        }
+
+        // Mirror the week-grid block's completed state — green check_circle
+        // (#61BA5B == $eform-green) and inert (no further click-through).
+        &.done {
+          cursor: default;
+          mat-icon {
+            color: #61BA5B;
+          }
+        }
+      }
+
       .task-time {
         font-size: 0.8rem;
         color: #888;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.ts
@@ -1,7 +1,8 @@
-import {Component, EventEmitter, Input, OnChanges, Output} from '@angular/core';
+import {Component, EventEmitter, Input, OnChanges, Output, inject} from '@angular/core';
 import {TranslateService} from '@ngx-translate/core';
-import {CalendarBoardModel, CalendarTaskLayoutModel} from '../../../../models/calendar';
+import {CalendarBoardModel, CalendarTaskLayoutModel, CalendarToggleCompleteResult} from '../../../../models/calendar';
 import {getCurrentLocale} from '../../services/calendar-locale.helper';
+import {BackendConfigurationPnCalendarService} from '../../../../services';
 
 interface ScheduleGroup {
   dateLabel: string;
@@ -21,10 +22,30 @@ export class CalendarScheduleViewComponent implements OnChanges {
 
   @Output() tasksReload = new EventEmitter<void>();
   @Output() taskClicked = new EventEmitter<{task: CalendarTaskLayoutModel; cellLeft: number; cellRight: number; slotTop: number}>();
+  @Output() completeRequiresForm = new EventEmitter<CalendarToggleCompleteResult>();
 
   groups: ScheduleGroup[] = [];
 
+  private calendarService = inject(BackendConfigurationPnCalendarService);
+
   constructor(private translate: TranslateService) {}
+
+  onCompletionClick(task: CalendarTaskLayoutModel, event: MouseEvent) {
+    event.stopPropagation();
+    // Match the week-grid indicator: the SDK case status is one-way, so
+    // once an event is completed the indicator is inert (no doomed PUT).
+    if (task.completed) return;
+    this.calendarService
+      .toggleComplete(task.id, !task.completed, task.complianceId, task.taskDate)
+      .subscribe(res => {
+        if (!res?.success) return;
+        if (res.model?.requiresForm) {
+          this.completeRequiresForm.emit(res.model);
+          return;
+        }
+        this.tasksReload.emit();
+      });
+  }
 
   ngOnChanges() {
     this.buildGroups();

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.ts
@@ -80,6 +80,11 @@ export class CalendarTaskBlockComponent {
 
   onCompletionClick(event: MouseEvent) {
     event.stopPropagation();
+    // Once completed, the indicator becomes inert — uncompletion is not
+    // supported (the SDK case status is one-way; mirrors the backend
+    // UncompleteNotSupported guard) and a click should be a no-op rather
+    // than firing a doomed HTTP round-trip.
+    if (this.task.completed) return;
     this.toggleComplete.emit(this.task);
   }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.ts
@@ -512,7 +512,7 @@ export class CalendarWeekGridComponent implements OnInit, AfterViewInit, OnChang
     // the rule, the ComplianceId to pick the exact occurrence the user
     // clicked (multiple compliance rows can share a planning when the
     // event recurs).
-    this.calendarService.toggleComplete(task.id, !task.completed, task.complianceId).subscribe(res => {
+    this.calendarService.toggleComplete(task.id, !task.completed, task.complianceId, task.taskDate).subscribe(res => {
       if (!res?.success) return;
       if (res.model?.requiresForm) {
         this.completeRequiresForm.emit(res.model);

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/compliance-case-modal/compliance-case-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/compliance-case-modal/compliance-case-modal.component.html
@@ -1,0 +1,75 @@
+<h2 mat-dialog-title>{{ replyElement?.label || ('Complete task' | translate) }}</h2>
+
+<mat-dialog-content class="compliance-case-modal__content">
+  <div class="d-flex flex-row justify-content-between">
+    <div class="flex-grow-1 mr-4 d-flex flex-column">
+      <!-- Done at — user editable -->
+      <mat-card class="mb-4">
+        <mat-card-title>
+          {{ 'Submitted date' | translate }}
+        </mat-card-title>
+        <mat-card-content>
+          <mat-form-field>
+            <mat-label>{{ 'Select date' | translate }}</mat-label>
+            <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+            <input
+              required
+              matInput
+              [matDatepicker]="picker"
+              [value]="replyElement.doneAt"
+              (dateChange)="replyElement.doneAt = $event.value"
+              (click)="picker.open()"
+            >
+            <mat-datepicker #picker></mat-datepicker>
+            <mat-error class="text-warn" *ngIf="!replyElement.doneAt">
+              {{ 'Date is required' | translate }}*
+            </mat-error>
+          </mat-form-field>
+        </mat-card-content>
+      </mat-card>
+
+      <app-case-edit-element
+        [element]="elem"
+        *ngFor="let elem of replyElement.elementList"
+        (needUpdate)="partialLoadCase()"
+      ></app-case-edit-element>
+    </div>
+
+    <div class="compliance-case-modal__nav" *ngIf="replyElement?.elementList?.length">
+      <mat-card>
+        <mat-card-content style="max-height: 50vh; overflow: auto;">
+          <div
+            *ngFor="let element of replyElement.elementList"
+            style="cursor: pointer"
+            routerLinkActive="active"
+          >
+            <a
+              mat-button
+              (click)="goToSection('#section' + element.id)"
+              class="d-flex w-100"
+            >
+              {{ element.label }}
+            </a>
+            <ng-container *ngIf="element.elementList">
+              <app-case-edit-nav [element]="element"></app-case-edit-nav>
+            </ng-container>
+          </div>
+        </mat-card-content>
+      </mat-card>
+    </div>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()" [disabled]="isSaving">
+    {{ 'Cancel' | translate }}
+  </button>
+  <button
+    class="btn-primary btn-primary--icon-left"
+    (click)="saveCase()"
+    [disabled]="isSaving || !replyElement.doneAt"
+    id="submit_form"
+  >
+    {{ 'Save' | translate }}
+  </button>
+</mat-dialog-actions>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/compliance-case-modal/compliance-case-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/compliance-case-modal/compliance-case-modal.component.scss
@@ -1,0 +1,11 @@
+.compliance-case-modal {
+  &__content {
+    min-width: min(90vw, 960px);
+    max-height: 75vh;
+  }
+
+  &__nav {
+    flex-shrink: 0;
+    width: 240px;
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/compliance-case-modal/compliance-case-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/compliance-case-modal/compliance-case-modal.component.ts
@@ -1,0 +1,184 @@
+import {
+  Component,
+  Inject,
+  OnInit,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  inject,
+} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {EFormService} from 'src/app/common/services';
+import {
+  TemplateDto,
+  CaseEditRequest,
+  ReplyElementDto,
+  ReplyRequest,
+  ElementDto,
+  DataItemDto,
+} from 'src/app/common/models';
+import {CaseEditElementComponent} from 'src/app/common/modules/eform-cases/components';
+import {BackendConfigurationPnCompliancesService} from '../../../../services';
+import {parseISO} from 'date-fns';
+import * as R from 'ramda';
+
+export interface ComplianceCaseModalData {
+  sdkCaseId: number;
+  templateId: number;
+  propertyId: number;
+  deadline: string;
+  complianceId: number;
+  workerId: number;
+}
+
+@Component({
+  selector: 'app-compliance-case-modal',
+  templateUrl: './compliance-case-modal.component.html',
+  styleUrls: ['./compliance-case-modal.component.scss'],
+  standalone: false,
+})
+export class ComplianceCaseModalComponent implements OnInit {
+  private dialogRef = inject(MatDialogRef<ComplianceCaseModalComponent>);
+  private backendConfigurationPnCompliancesService = inject(BackendConfigurationPnCompliancesService);
+  private eFormService = inject(EFormService);
+
+  @ViewChildren(CaseEditElementComponent)
+  editElements: QueryList<CaseEditElementComponent>;
+  @ViewChild('caseConfirmation', {static: false}) caseConfirmation;
+
+  id: number;
+  propertyId: number;
+  eFormId: number;
+  deadline: string;
+  complianceId: number;
+  workerId: number;
+  currenteForm: TemplateDto = new TemplateDto();
+  replyElement: ReplyElementDto = new ReplyElementDto();
+  requestModels: Array<CaseEditRequest> = [];
+  replyRequest: ReplyRequest = new ReplyRequest();
+  maxDate: Date;
+  isSaving = false;
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: ComplianceCaseModalData) {
+    this.id = data.sdkCaseId;
+    this.propertyId = data.propertyId;
+    this.eFormId = data.templateId;
+    this.deadline = data.deadline;
+    this.complianceId = data.complianceId;
+    this.workerId = data.workerId;
+  }
+
+  ngOnInit() {
+    this.loadTemplateInfo();
+    this.maxDate = new Date();
+  }
+
+  loadCase() {
+    if (!this.id || this.id === 0) {
+      return;
+    }
+    this.backendConfigurationPnCompliancesService
+      .getCase(this.id, this.currenteForm.id)
+      .subscribe((operation) => {
+        if (operation && operation.success) {
+          this.replyElement = operation.model;
+          this.replyElement.doneAt = parseISO(this.deadline);
+        }
+      });
+  }
+
+  loadTemplateInfo() {
+    if (this.eFormId) {
+      this.eFormService.getSingle(this.eFormId).subscribe((operation) => {
+        if (operation && operation.success) {
+          this.currenteForm = operation.model;
+          this.loadCase();
+        }
+      });
+    }
+  }
+
+  saveCase() {
+    this.requestModels = [];
+    this.editElements.forEach((x) => {
+      x.extractData();
+      this.requestModels.push(x.requestModel);
+    });
+    this.replyRequest.id = this.id;
+    this.replyRequest.label = this.replyElement.label;
+    this.replyRequest.elementList = this.requestModels;
+    this.replyRequest.doneAt = this.replyElement.doneAt;
+    this.replyRequest.extraId = this.complianceId;
+    this.replyRequest.siteId = this.workerId;
+    this.isSaving = true;
+    this.backendConfigurationPnCompliancesService
+      .updateCase(this.replyRequest, this.currenteForm.id)
+      .subscribe({
+        next: (operation) => {
+          this.isSaving = false;
+          if (operation && operation.success) {
+            this.dialogRef.close({saved: true});
+          }
+        },
+        error: () => {
+          this.isSaving = false;
+        },
+      });
+  }
+
+  cancel() {
+    this.dialogRef.close({saved: false});
+  }
+
+  goToSection(location: string): void {
+    setTimeout(() => {
+      const target = document.querySelector(location) as HTMLElement | null;
+      target?.parentElement?.scrollIntoView({behavior: 'smooth'});
+    });
+  }
+
+  partialLoadCase() {
+    if (!this.id || this.id === 0) {
+      return;
+    }
+    this.backendConfigurationPnCompliancesService
+      .getCase(this.id, this.currenteForm.id)
+      .subscribe((operation) => {
+        if (operation && operation.success) {
+          const fn = (pathForLens: Array<number | string>) => {
+            const lens = R.lensPath(pathForLens);
+            let dataItem: (ElementDto | DataItemDto) = R.view(lens, operation.model);
+            // @ts-ignore
+            if (dataItem.elementList !== undefined || dataItem.dataItemList !== undefined) {
+              dataItem = dataItem as ElementDto;
+              if (dataItem.elementList) {
+                for (let i = 0; i < dataItem.elementList.length; i++) {
+                  fn([...pathForLens, 'elementList', i]);
+                }
+              }
+              if (dataItem.dataItemList) {
+                for (let i = 0; i < dataItem.dataItemList.length; i++) {
+                  fn([...pathForLens, 'dataItemList', i]);
+                }
+              }
+            } else { // @ts-ignore
+              if (dataItem.fieldType !== undefined) {
+                dataItem = dataItem as DataItemDto;
+                if (dataItem.fieldType === 'FieldContainer') {
+                  for (let i = 0; i < dataItem.dataItemList.length; i++) {
+                    fn([...pathForLens, 'dataItemList', i]);
+                  }
+                }
+                if (dataItem.fieldType === 'Picture') {
+                  this.replyElement = R.set(lens, dataItem, this.replyElement);
+                }
+              }
+            }
+          };
+          for (let i = 0; i < operation.model.elementList.length; i++) {
+            fn(['elementList', i]);
+          }
+        }
+      });
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/index.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/index.ts
@@ -5,3 +5,4 @@ export * from './repeat-scope-modal/repeat-scope-modal.component';
 export * from './custom-repeat-modal/custom-repeat-modal.component';
 export * from './board-create-modal/board-create-modal.component';
 export * from './board-delete-modal/board-delete-modal.component';
+export * from './compliance-case-modal/compliance-case-modal.component';

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-calendar.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-calendar.service.ts
@@ -82,10 +82,11 @@ export class BackendConfigurationPnCalendarService {
     taskId: number,
     completed: boolean,
     complianceId: number | null | undefined,
+    occurrenceDate: string | null | undefined,
   ): Observable<OperationDataResult<CalendarToggleCompleteResult>> {
     return this.apiBaseService.put(
       `${BackendConfigurationPnCalendarMethods.Tasks}/${taskId}/complete`,
-      {completed, complianceId: complianceId ?? null}
+      {completed, complianceId: complianceId ?? null, occurrenceDate: occurrenceDate ?? null}
     );
   }
 


### PR DESCRIPTION
## Summary

When a user clicks the calendar completion indicator on a recurring compliance event whose nightly deployment batch hasn't yet materialised the backing `Compliance` row, the click currently fails with `TaskHasNoComplianceCase`. This PR extends `ToggleComplete` to materialise the `Compliance` row + SDK case on demand, mirroring the existing `EnsureComplianceRowAsync` chain, then continues with PR #842's mandatory-field check + complete-or-route logic.

Genuine non-compliance events (no `EformId` on the AreaRule) keep returning `TaskHasNoComplianceCase`; events with no live `PlanningSites` now surface the new `NoAssignedWorker` key.

### Backend
- Extract `EventDeployService.DeployForRotationAsync` as the single source of truth for the per-rotation deploy chain (PlanningCase + PlanningCaseSite + SDK Case + Compliance row). The nightly loop in `EnsureDeployedAsync` and the new on-demand path both go through it, so the nightly path's write order / fault isolation is preserved.
- Add `IEventDeployService.EnsureComplianceForOccurrenceAsync(arp, deadline, sdkSiteId)` with an up-front idempotence guard (`PlanningId + Deadline.Date + MicrotingSdkCaseId > 0`) so concurrent / mid-flight callers don't double-create rows.
- Inject `IEventDeployService` into `BackendConfigurationCalendarService`; rewrite the "no Compliance row" branch of `ToggleComplete` to:
  1. Gate on `arp.AreaRule.EformId` → return `TaskHasNoComplianceCase` for genuine non-compliance events.
  2. Pick a live `PlanningSites` entry → return new `NoAssignedWorker` when none exists.
  3. Parse `occurrenceDate` strictly (`YYYY-MM-DD`).
  4. Call `EnsureComplianceForOccurrenceAsync`; re-fetch the resulting Compliance row and fall through to the existing PR #842 SDK case lookup + mandatoriness logic.
- `ToggleComplete` now `Include`s `AreaRule` and `PlanningSites` on the `AreaRulePlanning` query.
- **Drive-by safety fixes** surfaced by code review:
  - `await using var sdkDbContext` in `ToggleComplete` (was leaking the SDK DbContext on every call).
  - `EnsureComplianceRowAsync` now returns the winning row on duplicate-key races instead of `null`, so on-demand callers can hand a usable `ComplianceId` back to the UI when racing with the nightly batch.
  - Defensive `eformId <= 0` guard in `EnsureComplianceForOccurrenceAsync`.

### Frontend
- Add `OccurrenceDate` to `CalendarToggleCompleteModel`.
- Extend `BackendConfigurationPnCalendarService.toggleComplete(...)` with `occurrenceDate`.
- Pass `task.taskDate` at the call site in `calendar-week-grid.component.ts:onTaskToggleComplete`.

### Localization
- New `NoAssignedWorker` key in `Resources/localization.json` (26 locales; en-US authored, others auto-translated via `translatePlugins.py`).

Spec: `docs/superpowers/specs/2026-05-21-calendar-ensure-compliance-on-complete-design.md`.

No DB migration. No `-base` repo touch. No SDK change. gRPC `CompleteEvent` flow untouched.

## Test plan

- [ ] **Future-occurrence first click.** Find a recurring compliance event whose next-future occurrence hasn't been deployed yet (e.g. a Monday event clicked on the Thursday before). Click the completion indicator. Either (a) auto-completes if no mandatory fields, or (b) navigates to the compliance-case form. In both cases, on next calendar reload the event renders with `IsFromCompliance = true` and `ComplianceId` set.
- [ ] **Click again on the same now-existing row.** Works through the existing PR #842 path with no Ensure call (the Compliance lookup succeeds).
- [ ] **Non-compliance event** (no `EformId` on the AreaRule) — click returns `TaskHasNoComplianceCase`; frontend silently no-ops.
- [ ] **No assigned worker** — click returns `NoAssignedWorker`; frontend silently no-ops.
- [ ] **Race with nightly batch.** Re-click quickly twice and confirm only one Compliance row exists (deduped via the new ensure-method idempotence guard + the duplicate-key catch returning the winner).
- [ ] CI `pn-playwright-test (l)` shard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)