### PR TITLE
feat(calendar): default Case.DoneAt to event.start on web complete

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarToggleCompleteResult.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarToggleCompleteResult.cs
@@ -22,4 +22,13 @@ public class CalendarToggleCompleteResult
     public int? ComplianceId { get; set; }
     public int? WorkerId { get; set; }
     public string? Deadline { get; set; }
+
+    /// <summary>
+    /// Calendar event start — Compliance.Deadline day + CalendarConfiguration.StartHour
+    /// (or any per-occurrence exception override), UTC, ISO 8601 with millisecond
+    /// precision. The compliance modal defaults Case.DoneAt /
+    /// Case.DoneAtUserModifiable to this value so the completion timestamp reflects
+    /// when the work was scheduled rather than when the user happened to click.
+    /// </summary>
+    public string? EventStart { get; set; }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -1736,6 +1736,31 @@ public class BackendConfigurationCalendarService(
                     localizationService.GetString("SdkCaseNotFound"));
             }
 
+            // Canonical event start (UTC) for this occurrence — Compliance.Deadline
+            // gives the calendar day (Kind=Unspecified, semantically UTC midnight
+            // per the rest of this file's convention); CalendarConfiguration.StartHour
+            // gives the hour-of-day the calendar shows for the ARP, and any "this"-
+            // scope CalendarOccurrenceException overrides per-rotation. Same triple
+            // the read path uses to project StartHour at line 703.
+            //
+            // We default to 9.0 (matches the read path's calConfig?.StartHour ?? 9.0
+            // fallback) when no CalendarConfiguration exists for the ARP.
+            var calConfig = await backendConfigurationPnDbContext.CalendarConfigurations
+                .Where(x => x.AreaRulePlanningId == arp.Id)
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .FirstOrDefaultAsync();
+            var complianceException = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
+                .Where(x => x.AreaRulePlanningId == arp.Id)
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Where(x => x.OriginalDate.Date == compliance.Deadline.Date)
+                .FirstOrDefaultAsync();
+            var effectiveStartHour = complianceException?.StartHour ?? calConfig?.StartHour ?? 9.0;
+            var startHourWhole = (int)Math.Floor(effectiveStartHour);
+            var startMinuteWhole = (int)Math.Round((effectiveStartHour - startHourWhole) * 60);
+            var deadlineDayUtc = DateTime.SpecifyKind(compliance.Deadline.Date, DateTimeKind.Utc);
+            var eventStart = deadlineDayUtc.AddHours(startHourWhole).AddMinutes(startMinuteWhole);
+            var eventStartIso = eventStart.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+
             var hasMandatory = await HasMandatoryFields(sdkCore, sdkCase.CheckListId.Value)
                 .ConfigureAwait(false);
 
@@ -1763,18 +1788,25 @@ public class BackendConfigurationCalendarService(
                         // offset; SpecifyKind(..., Utc) re-tags without shifting,
                         // then ToString("…Z") just emits the raw clock value as UTC.
                         Deadline = DateTime.SpecifyKind(compliance.Deadline, DateTimeKind.Utc)
-                            .ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture)
+                            .ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture),
+                        // event.start (Deadline day + calendar-config StartHour, UTC) so the
+                        // modal can default Case.DoneAt / DoneAtUserModifiable to the scheduled
+                        // moment rather than "now".
+                        EventStart = eventStartIso
                     });
             }
 
             // No mandatory fields → complete the SDK case in place. Mirrors
             // CompliancesGrpcService:159-174 (the form-submit path) — set
             // Status=100 + done-at timestamps so subsequent reads of the SDK
-            // case report the case as fully completed.
+            // case report the case as fully completed. DoneAt mirrors the
+            // calendar's scheduled event-start moment (Deadline day + StartHour)
+            // rather than "now" so reports reflect when the work was scheduled,
+            // not when the user happened to tap Complete.
             sdkCase.Status = 100;
             sdkCase.WorkflowState = Constants.WorkflowStates.Created;
-            sdkCase.DoneAt = DateTime.UtcNow;
-            sdkCase.DoneAtUserModifiable = DateTime.UtcNow;
+            sdkCase.DoneAt = eventStart;
+            sdkCase.DoneAtUserModifiable = eventStart;
             await sdkCase.Update(sdkDbContext).ConfigureAwait(false);
 
             return new OperationDataResult<CalendarToggleCompleteResult>(true,

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCompliancesService/BackendConfigurationCompliancesService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCompliancesService/BackendConfigurationCompliancesService.cs
@@ -230,10 +230,16 @@ public class BackendConfigurationCompliancesService : IBackendConfigurationCompl
                 .FirstOrDefaultAsync().ConfigureAwait(false);
 
             if(foundCase != null) {
-                // var now = DateTime.UtcNow;
-                var newDoneAt = new DateTime(model.DoneAt.Year, model.DoneAt.Month,
-                    model.DoneAt.Day, 0, 0,
-                    0, DateTimeKind.Utc);
+                // Preserve the caller-supplied time-of-day so calendar
+                // event.start (Deadline day + CalendarConfiguration.StartHour)
+                // survives the round-trip. Existing consumers (task-tracker,
+                // compliance-list) keep submitting their previous values —
+                // task-tracker uses `task.deadlineTask.toISOString()` and
+                // Compliance.Deadline is stored as midnight UTC, so their
+                // observable behaviour is unchanged. SpecifyKind re-tags
+                // without shifting (model.DoneAt arrives as Unspecified-kind
+                // from the JSON binder).
+                var newDoneAt = DateTime.SpecifyKind(model.DoneAt, DateTimeKind.Utc);
                 foundCase.DoneAtUserModifiable = newDoneAt;
                 foundCase.DoneAt = newDoneAt;
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
@@ -118,4 +118,11 @@ export interface CalendarToggleCompleteResult {
   complianceId?: number;
   workerId?: number;
   deadline?: string;
+  /**
+   * Calendar event start (Compliance.Deadline day + CalendarConfiguration.StartHour),
+   * ISO 8601 UTC with millisecond precision. The compliance modal defaults its
+   * doneAt picker to this value so Case.DoneAt records the scheduled moment
+   * rather than when the user happened to click Save.
+   */
+  eventStart?: string;
 }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -571,6 +571,11 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
         deadline: p.deadline,
         complianceId: p.complianceId,
         workerId: p.workerId,
+        // Optional — backend supplies Compliance.Deadline day + the calendar's
+        // configured StartHour so the modal can default the doneAt picker to
+        // the scheduled event-start moment rather than the deadline's
+        // midnight or "now".
+        eventStart: p.eventStart,
       },
       width: 'min(90vw, 1080px)',
       maxWidth: '95vw',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/compliance-case-modal/compliance-case-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/compliance-case-modal/compliance-case-modal.component.ts
@@ -98,9 +98,21 @@ export class ComplianceCaseModalComponent implements OnInit {
           // moment rather than midnight. Fall back to `deadline` (midnight UTC)
           // when the backend didn't supply an eventStart — older response
           // shapes or non-compliance flows.
-          this.replyElement.doneAt = parseISO(this.eventStart ?? this.deadline);
+          //
+          // The HTTP layer auto-parses ISO strings in response bodies into
+          // Date instances, so `eventStart` / `deadline` arrive as Date
+          // objects despite the `string` typing on the interface — handle
+          // both shapes defensively.
+          this.replyElement.doneAt = this.toDate(this.eventStart) ?? this.toDate(this.deadline) ?? new Date();
         }
       });
+  }
+
+  private toDate(value: string | Date | undefined | null): Date | null {
+    if (value == null) return null;
+    if (value instanceof Date) return value;
+    if (typeof value === 'string' && value.length > 0) return parseISO(value);
+    return null;
   }
 
   loadTemplateInfo() {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/compliance-case-modal/compliance-case-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/compliance-case-modal/compliance-case-modal.component.ts
@@ -29,6 +29,14 @@ export interface ComplianceCaseModalData {
   deadline: string;
   complianceId: number;
   workerId: number;
+  /**
+   * Optional event-start ISO string (Compliance.Deadline day +
+   * CalendarConfiguration.StartHour, UTC). When supplied the modal pre-fills
+   * the doneAt picker with this moment so Case.DoneAt records the scheduled
+   * event-start rather than the deadline's midnight. Falls back to
+   * `deadline` when absent.
+   */
+  eventStart?: string;
 }
 
 @Component({
@@ -50,6 +58,7 @@ export class ComplianceCaseModalComponent implements OnInit {
   propertyId: number;
   eFormId: number;
   deadline: string;
+  eventStart?: string;
   complianceId: number;
   workerId: number;
   currenteForm: TemplateDto = new TemplateDto();
@@ -64,6 +73,7 @@ export class ComplianceCaseModalComponent implements OnInit {
     this.propertyId = data.propertyId;
     this.eFormId = data.templateId;
     this.deadline = data.deadline;
+    this.eventStart = data.eventStart;
     this.complianceId = data.complianceId;
     this.workerId = data.workerId;
   }
@@ -82,7 +92,13 @@ export class ComplianceCaseModalComponent implements OnInit {
       .subscribe((operation) => {
         if (operation && operation.success) {
           this.replyElement = operation.model;
-          this.replyElement.doneAt = parseISO(this.deadline);
+          // Default the doneAt picker to the calendar event start
+          // (Compliance.Deadline + CalendarConfiguration.StartHour) so the
+          // submitted Case.DoneAt / DoneAtUserModifiable reflect the scheduled
+          // moment rather than midnight. Fall back to `deadline` (midnight UTC)
+          // when the backend didn't supply an eventStart — older response
+          // shapes or non-compliance flows.
+          this.replyElement.doneAt = parseISO(this.eventStart ?? this.deadline);
         }
       });
   }


### PR DESCRIPTION
## Summary

When a calendar event is completed from the web — either via the auto-complete indicator (no mandatory fields) or via the compliance modal — `Case.DoneAt` / `Case.DoneAtUserModifiable` now record the scheduled **event-start** moment (`Compliance.Deadline` day + `CalendarConfiguration.StartHour`, UTC), not `DateTime.UtcNow` or midnight UTC.

This matches the intent of the gRPC `EventsGrpcService.CompleteOpgave` path which already composes DoneAt from `Compliance.Deadline + wall-clock time`. Reports / dashboards keyed on DoneAt now reflect when the work was scheduled instead of when the user happened to click.

### Out of scope

gRPC services (`CompliancesGrpcService.cs`, `EventsGrpcService.cs`) are intentionally untouched — flutter-eform owns its own DoneAt composition.

### Backend

- **`BackendConfigurationCalendarService.ToggleComplete`** — load `CalendarConfiguration` + any per-occurrence `CalendarOccurrenceException` for the ARP, compose `eventStart = compliance.Deadline.Date.SpecifyKind(Utc) + StartHour` (default `9.0` — same fallback the read path at line 703 uses). The auto-complete branch sets `sdkCase.DoneAt = sdkCase.DoneAtUserModifiable = eventStart`; the `RequiresForm` branch returns it as `CalendarToggleCompleteResult.EventStart` so the modal can default its picker to the same moment.
- **`BackendConfigurationCompliancesService.Update`** (HTTP `PUT /compliances/cases`, called by the calendar modal Save **and** by task-tracker / compliance-list form Saves) — replace the midnight truncation with `DateTime.SpecifyKind(model.DoneAt, DateTimeKind.Utc)` so the modal's `event.start` round-trips intact. Task-tracker + compliance-list both submit `Compliance.Deadline`-derived ISO strings whose time component is already midnight UTC, so their observable behaviour is unchanged.

### Frontend

- `CalendarToggleCompleteResult` gains `eventStart?: string`.
- `CalendarContainerComponent.onCompleteRequiresForm` passes `eventStart` into `MAT_DIALOG_DATA`.
- `ComplianceCaseModalComponent.loadCase` defaults `replyElement.doneAt = parseISO(this.eventStart ?? this.deadline)`. The deadline fallback covers responses that predate the `EventStart` field.

## Test plan

- [ ] Click the auto-complete indicator on a compliance event with **no** mandatory fields. Confirm in the DB that `Case.DoneAt` / `DoneAtUserModifiable` equal `Compliance.Deadline + StartHour` (not the moment of the click).
- [ ] Click the auto-complete indicator on a compliance event with mandatory fields → modal opens with the doneAt picker showing the event's start date. Save → `Case.DoneAt` records the event-start moment (the time portion is preserved, no midnight truncation).
- [ ] Repeat from the **Tidsplan** (schedule) view — same outcome.
- [ ] Task-tracker form Save: submit a compliance — `Case.DoneAt` still lands at midnight UTC (its caller's submitted shape is unchanged, no regression).
- [ ] Compliance-list form Save: same as above.
- [ ] CI `pn-playwright-test` shard `l` and `r` fail on stable independently of this PR (test bugs from upstream commit `8aaf09bb`); not blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)