### PR TITLE
test(calendar-ui): re-anchor H2 day-view assertion to new header

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.spec.ts
@@ -611,18 +611,26 @@ test.describe.serial('Calendar UI enhancements', () => {
       expect(actualHeader).toBe(expectedHeader);
 
       // The single day-grid column header should also show that Monday's date.
-      // Selector skips the time-axis column. Post-redesign the header is a
-      // two-line stack: uppercase short Danish weekday ("MAN.") on line 1 and
-      // the bare day-of-month on line 2 (see calendar-week-grid.component.html
-      // dayHeaderTpl). Asserting both the weekday token AND the day number is
-      // a tight anchor — Day view always renders Monday, and combined with
-      // the day number a neighbour-week off-by-one would not collide.
+      // Post-redesign the header is a two-line stack: uppercase locale short
+      // weekday in .day-header-weekday on line 1, bare day-of-month in
+      // .day-header-number on line 2 (see calendar-week-grid.component.html
+      // dayHeaderTpl). Query both sub-elements directly so the assertion
+      // isn't coupled to innerText line-break behaviour, and derive the
+      // expected weekday via toLocaleDateString({weekday: 'short'}) — same
+      // call production's getWeekdayShort uses — so a future Intl/locale
+      // change updates expected + actual in lockstep instead of failing
+      // here on a hard-coded "MAN.". Locale follows the rest of this suite
+      // (formatLongDate, line 575) which the test environment runs as 'da-DK'.
       const dayCol = page
         .locator('app-calendar-week-grid .mat-mdc-header-cell:not(.mat-column-time-axis)')
         .first();
-      const colText = (await dayCol.innerText()).trim();
-      expect(colText).toContain('MAN.');
-      expect(colText).toMatch(new RegExp(`(^|\\n)\\s*${expectedMonday.getDate()}\\s*(\\n|$)`));
+      const expectedWeekdayShort = expectedMonday
+        .toLocaleDateString('da-DK', { weekday: 'short' })
+        .toUpperCase();
+      await expect(dayCol.locator('.day-header-weekday')).toHaveText(expectedWeekdayShort);
+      await expect(dayCol.locator('.day-header-number')).toHaveText(
+        String(expectedMonday.getDate())
+      );
     });
 
     test('H3: schedule chevron advances one week per click', async ({ page }) => {

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.spec.ts
@@ -611,17 +611,18 @@ test.describe.serial('Calendar UI enhancements', () => {
       expect(actualHeader).toBe(expectedHeader);
 
       // The single day-grid column header should also show that Monday's date.
-      // Selector skips the time-axis column. The grid label format is
-      // "weekdayShort. dd/mm" (e.g. "man. 11/05"), so the dd/mm pair is a
-      // tighter anchor than the bare day number — a neighbour-week off-by-one
-      // would not collide.
+      // Selector skips the time-axis column. Post-redesign the header is a
+      // two-line stack: uppercase short Danish weekday ("MAN.") on line 1 and
+      // the bare day-of-month on line 2 (see calendar-week-grid.component.html
+      // dayHeaderTpl). Asserting both the weekday token AND the day number is
+      // a tight anchor — Day view always renders Monday, and combined with
+      // the day number a neighbour-week off-by-one would not collide.
       const dayCol = page
         .locator('app-calendar-week-grid .mat-mdc-header-cell:not(.mat-column-time-axis)')
         .first();
       const colText = (await dayCol.innerText()).trim();
-      const dd = String(expectedMonday.getDate()).padStart(2, '0');
-      const mm = String(expectedMonday.getMonth() + 1).padStart(2, '0');
-      expect(colText).toContain(`${dd}/${mm}`);
+      expect(colText).toContain('MAN.');
+      expect(colText).toMatch(new RegExp(`(^|\\n)\\s*${expectedMonday.getDate()}\\s*(\\n|$)`));
     });
 
     test('H3: schedule chevron advances one week per click', async ({ page }) => {


### PR DESCRIPTION
## Summary

Commit `8aaf09bb` (`style(calendar): align day-header with Design Manual two-line stack + today pill`) redesigned the day-column header from a single-line `"weekdayShort dd/mm"` format (e.g. `"man. 11/05"`) into a two-line stack: uppercase Danish short weekday on line 1 (`"MAN."`) and bare day-of-month on line 2 (`"1"`). The `dd/mm` slash format is gone from the visible DOM.

H2 (`Calendar — view-switch preserves navigated week › day view lands on Monday of the navigated week`) at `calendar-ui-enhancements.spec.ts:622-624` still asserts `colText.toContain("01/06")` and has been failing on every PR + on stable since `8aaf09bb`. H3 + I1 in the same `test.describe.serial` suite don't run because the first failure aborts.

## Fix

Re-anchor the assertion to the new visible DOM: assert the uppercase Danish short weekday (`"MAN."`) AND the day-of-month number on its own line. Day view always renders Monday, so the weekday is stable; combined with the day number a neighbour-week off-by-one would not collide — same intent as the original `dd/mm` anchor.

```diff
- expect(colText).toContain(`${dd}/${mm}`);
+ expect(colText).toContain('MAN.');
+ expect(colText).toMatch(new RegExp(`(^|\\n)\\s*${expectedMonday.getDate()}\\s*(\\n|$)`));
```

Production code untouched — the header redesign is intentional.

## Test plan

- [ ] `pn-playwright-test (r)` H2 passes.
- [ ] H3 + I1 (previously blocked by H2's failure aborting the serial suite) now run and pass.
- [ ] All other `pn-playwright-test` shards stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)