### PR TITLE
fix(calendar-grpc): suppress recurrence re-emit on completed events

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarActionableOnlyTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarActionableOnlyTests.cs
@@ -1,0 +1,248 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+*/
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+using System.Globalization;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarActionableOnlyTests : TestBaseSetup
+{
+    private static string IsoUtc(DateTime d) =>
+        DateTime.SpecifyKind(d, DateTimeKind.Utc)
+            .ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+    private static DateTime GetNextMonday()
+    {
+        var today = DateTime.UtcNow.Date;
+        var daysUntilMonday = ((int)DayOfWeek.Monday - (int)today.DayOfWeek + 7) % 7;
+        if (daysUntilMonday == 0) daysUntilMonday = 7;
+        return DateTime.SpecifyKind(today.AddDays(daysUntilMonday), DateTimeKind.Utc);
+    }
+
+    /// <summary>
+    /// PR #847 regression coverage: a removed-completed Compliance (the shape
+    /// the canonical complete paths leave behind — WorkflowState=Removed +
+    /// backing SDK Case Status=100) must suppress recurrence-expansion re-emit
+    /// for that same date on the ActionableOnly (mobile-worker gRPC) read path,
+    /// without rendering the completed event as an actionable task.
+    /// </summary>
+    [Test]
+    public async Task GetTasksForWeek_ActionableOnly_RemovedCompletedCompliance_SuppressesRecurrenceReEmit()
+    {
+        // Arrange — boot a real SDK Core so IsComplianceActionable can read
+        // the backing Case row from the SDK schema testcontainer.
+        var core = await GetCore();
+
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        var sdkSite = new Site
+        {
+            Name = "actionable-only-test-site",
+            MicrotingUid = 4242,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(sdkSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        // The SDK Case the just-completed Compliance points at — Status=100
+        // is the canonical "done" marker that IsComplianceActionable strips
+        // and that the new dedup filter keys off.
+        var sdkCase = new Microting.eForm.Infrastructure.Data.Entities.Case
+        {
+            SiteId = sdkSite.Id,
+            Status = 100,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Cases.AddAsync(sdkCase);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        // The recurring rotation that would otherwise re-emit a phantom task
+        // for the just-completed date. Weekly Monday with no end so the
+        // emitted week is part of the active recurrence series.
+        var monday = GetNextMonday();
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1,
+            ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"ActionableOnlyTest-{Guid.NewGuid()}",
+            ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id,
+            PropertyId = property.Id,
+            EformId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planning = new Planning
+        {
+            Enabled = true,
+            RepeatEvery = 1,
+            RepeatType = RepeatType.Week,
+            StartDate = monday,
+            RelatedEFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id,
+            PropertyId = property.Id,
+            AreaId = area.Id,
+            ItemPlanningId = planning.Id,
+            StartDate = monday,
+            Status = true,
+            RepeatType = 2,       // 2 = weekly
+            RepeatEvery = 1,      // every week
+            RepeatWeekdaysCsv = "1", // Monday only
+            DayOfWeek = 1,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id,
+            StartHour = 9.0,
+            Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // The just-completed Compliance row: canonical complete-path shape
+        // (WorkflowState=Removed + MicrotingSdkCaseId pointing at a Status=100
+        // case). Without the PR #847 fix the ActionableOnly read would skip
+        // this row entirely, miss the date from the dedup set, and the
+        // recurrence loop would re-emit a fresh uncompleted task for monday.
+        var compliance = new Compliance
+        {
+            PlanningId = planning.Id,
+            PropertyId = property.Id,
+            AreaId = area.Id,
+            Deadline = monday,
+            StartDate = monday.AddDays(-7),
+            MicrotingSdkCaseId = sdkCase.Id,
+            MicrotingSdkeFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Removed
+        };
+        await BackendConfigurationPnDbContext.Compliances.AddAsync(compliance);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        userService.GetCurrentUserLanguage().Returns(Task.FromResult(language));
+
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+
+        var taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        taskWizardService.DeleteTask(Arg.Any<int>())
+            .Returns(Task.FromResult(new OperationResult(true)));
+
+        var service = new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(),
+            userService,
+            BackendConfigurationPnDbContext,
+            coreHelper,
+            Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext,
+            taskWizardService,
+            NullLogger<BackendConfigurationCalendarService>.Instance);
+
+        // Act — ListEvents-style mobile-worker fetch (ActionableOnly=true) for
+        // the week containing the just-completed Monday.
+        var weekStart = monday;
+        var weekEnd = monday.AddDays(6).AddHours(23).AddMinutes(59);
+        var result = await service.GetTasksForWeek(new CalendarTaskRequestModel
+        {
+            PropertyId = property.Id,
+            WeekStart = IsoUtc(weekStart),
+            WeekEnd = IsoUtc(weekEnd),
+            ActionableOnly = true,
+            BoardIds = [],
+            TagNames = [],
+            SiteIds = []
+        });
+
+        // Assert — recurrence-expansion did NOT re-emit a phantom uncompleted
+        // task for the just-completed date. The mobile worker must see the
+        // event ABSENT (Status=100 ⇒ stripped by IsComplianceActionable AND
+        // the dedup set suppresses the recurrence emit). Without the PR #847
+        // dedup union, this test would see a single task on Monday with
+        // IsFromCompliance=false (the recurrence shape).
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model, Is.Not.Null);
+
+        var mondayKey = monday.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var tasksOnMonday = result.Model
+            .Where(t => t.TaskDate == mondayKey)
+            .ToList();
+        Assert.That(tasksOnMonday, Is.Empty,
+            "Removed-completed Compliance for that date must suppress recurrence re-emit; "
+            + "otherwise the mobile worker sees a phantom uncompleted task right after "
+            + "completing it. See PR #847 / BackendConfigurationCalendarService.cs "
+            + "compliancesForDedup construction in the ActionableOnly branch.");
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -250,9 +250,13 @@ public class BackendConfigurationCalendarService(
                             && removedSdkCase.Status == 100)
                     .ToList();
                 var removedCompletedIds = new HashSet<int>(removedCompletedInWeek.Select(c => c.Id));
+                // ID-based HashSet membership (vs `List.Contains` on the Compliance
+                // object) keeps the GroupBy filter below O(n) — addresses
+                // Copilot's L256 perf note on PR 847.
+                var compliancesInWeekIds = new HashSet<int>(compliancesInWeek.Select(c => c.Id));
 
                 nonActionableByPlanningDate = compliancesInWeekAll
-                    .Where(c => !compliancesInWeek.Contains(c) && !removedCompletedIds.Contains(c.Id))
+                    .Where(c => !compliancesInWeekIds.Contains(c.Id) && !removedCompletedIds.Contains(c.Id))
                     .GroupBy(c => (c.PlanningId, c.Deadline.Date))
                     // GroupBy + first-wins guards against the (unlikely) case of multiple
                     // non-actionable compliance rows sharing a (planning, day) tuple.

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -79,6 +79,17 @@ public class BackendConfigurationCalendarService(
             // the recurrence-emit lookup below tolerates that as a no-op.
             Dictionary<(int PlanningId, DateTime Date), (int ComplianceId, int SdkCaseId)> nonActionableByPlanningDate
                 = new();
+            // The set of compliances whose (PlanningId, Deadline) tuples should
+            // suppress recurrence-expansion emit for that date. Default branch
+            // populates this with compliancesInWeek (which already includes
+            // removed-but-completed rows, see line 100-104). The ActionableOnly
+            // branch builds the union of compliancesInWeek + removed-completed
+            // separately so the mobile worker doesn't see a phantom uncompleted
+            // task for a date they just completed (the canonical compliance
+            // Update + gRPC mobile complete both soft-delete Compliance after
+            // setting Status=100, so without this suppression the
+            // recurrence-expansion loop happily re-emits the date).
+            List<Compliance> compliancesForDedup;
             if (!requestModel.ActionableOnly)
             {
                 // Load both:
@@ -123,6 +134,9 @@ public class BackendConfigurationCalendarService(
                     .Where(c => c.WorkflowState != Constants.WorkflowStates.Removed
                             || (loadedCases.TryGetValue(c.MicrotingSdkCaseId, out var sdk) && sdk.Status == 100))
                     .ToList();
+                // Default branch already includes removed-completed rows in
+                // compliancesInWeek (filter above), so the dedup set is identical.
+                compliancesForDedup = compliancesInWeek;
             }
             else
             {
@@ -130,8 +144,20 @@ public class BackendConfigurationCalendarService(
                 // Treat WorkflowState NULL as "not removed" here (pre-existing project rule
                 // applied across this service); the default branch above keeps its original
                 // strict `!= Removed` semantics so non-mobile callers remain bit-identical.
+                //
+                // Include removed-but-deployed rows in the load so the post-load
+                // pass can pull out the removed-COMPLETED subset (Status=100 on
+                // backing SDK case) for recurrence-dedup. Without this, the
+                // recurrence-emit loop would happily re-emit a date the user
+                // just completed — the canonical complete path
+                // (CompliancesGrpcService.UpdateComplianceCase / web modal
+                // Save) soft-deletes the Compliance row after setting
+                // Status=100, leaving no live row in the actionable subset
+                // to seed the dedup set with.
                 var compliancesInWeekAll = await backendConfigurationPnDbContext.Compliances
-                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed || x.WorkflowState == null)
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed
+                                || x.WorkflowState == null
+                                || x.MicrotingSdkCaseId > 0)
                     .Where(x => x.PropertyId == requestModel.PropertyId)
                     .Where(x => x.Deadline >= weekStart && x.Deadline <= weekEnd)
                     .ToListAsync();
@@ -144,7 +170,7 @@ public class BackendConfigurationCalendarService(
                     .Distinct()
                     .ToList();
                 var sdkCore = await coreHelper.GetCore().ConfigureAwait(false);
-                var sdkDbContextForCalendar = sdkCore.DbContextHelper.GetDbContext();
+                await using var sdkDbContextForCalendar = sdkCore.DbContextHelper.GetDbContext();
                 var sdkCasesById = await sdkDbContextForCalendar.Cases
                     .Where(c => complianceSdkCaseIds.Contains(c.Id))
                     .ToDictionaryAsync(c => c.Id);
@@ -201,21 +227,56 @@ public class BackendConfigurationCalendarService(
                 // branch instead of the fuzzy fallback. See investigator notes for commit
                 // 47f20657 — root cause: ListOpgaver→Drift only ever sees the
                 // recurrence-emit model when actionability stripping removed the compliance.
+                // Compute the removed-COMPLETED subset (WorkflowState=Removed +
+                // backing case Status=100) up-front so we can both:
+                //  (a) use it to expand the recurrence-dedup set below
+                //      (`compliancesForDedup`), suppressing phantom uncompleted
+                //      re-emission for dates the worker just completed.
+                //  (b) EXCLUDE it from `nonActionableByPlanningDate` (the Bug A
+                //      device-write routing slot). A removed-completed row
+                //      points at a closed Status=100 SDK Case; if it shared a
+                //      (PlanningId, Deadline.Date) with a separately-retracted
+                //      row, GroupBy's first-wins ordering could non-
+                //      deterministically route a device write to the closed
+                //      case instead of the live retracted one. Keep
+                //      nonActionableByPlanningDate focused on the original
+                //      Bug A scope (retracted SDK case / soft-deleted /
+                //      Status==100 inline-rotation) by stripping removed-
+                //      completed before the GroupBy.
+                var removedCompletedInWeek = compliancesInWeekAll
+                    .Where(c => c.WorkflowState == Constants.WorkflowStates.Removed
+                            && c.MicrotingSdkCaseId > 0
+                            && sdkCasesById.TryGetValue(c.MicrotingSdkCaseId, out var removedSdkCase)
+                            && removedSdkCase.Status == 100)
+                    .ToList();
+                var removedCompletedIds = new HashSet<int>(removedCompletedInWeek.Select(c => c.Id));
+
                 nonActionableByPlanningDate = compliancesInWeekAll
-                    .Where(c => !compliancesInWeek.Contains(c))
+                    .Where(c => !compliancesInWeek.Contains(c) && !removedCompletedIds.Contains(c.Id))
                     .GroupBy(c => (c.PlanningId, c.Deadline.Date))
                     // GroupBy + first-wins guards against the (unlikely) case of multiple
                     // non-actionable compliance rows sharing a (planning, day) tuple.
                     .ToDictionary(g => g.Key, g => (ComplianceId: g.First().Id,
                         SdkCaseId: g.First().MicrotingSdkCaseId));
+
+                // Recurrence-dedup union: the actionable subset (compliancesInWeek)
+                // PLUS the removed-COMPLETED subset. The latter doesn't render to
+                // mobile workers (IsComplianceActionable strips them), but their
+                // (PlanningId, Deadline) tuples must still suppress recurrence-
+                // expansion emit for that date — otherwise the worker sees a
+                // phantom uncompleted task right after completing it.
+                compliancesForDedup = compliancesInWeek.Concat(removedCompletedInWeek).ToList();
             }
 
-            // Build sets for dedup: by exact date and by planningId (any in-week compliance,
-            // or — when ActionableOnly is set — any *actionable* in-week compliance).
+            // Build sets for dedup: by exact date and by planningId. compliancesForDedup
+            // is the actionable subset for non-ActionableOnly callers (already includes
+            // removed-completed rows per the broadened query at line 100-104), and for
+            // ActionableOnly callers is actionable ∪ removed-completed so the recurrence-
+            // emit loop doesn't double-fire a date the worker just completed.
             var complianceDateSet = new HashSet<string>(
-                compliancesInWeek.Select(c => $"{c.PlanningId}:{c.Deadline:yyyy-MM-dd}"));
+                compliancesForDedup.Select(c => $"{c.PlanningId}:{c.Deadline:yyyy-MM-dd}"));
             var compliancePlanningIdsInWeek = new HashSet<int>(
-                compliancesInWeek.Select(c => c.PlanningId));
+                compliancesForDedup.Select(c => c.PlanningId));
 
             // 1. Query AreaRulePlannings (future/active tasks)
             var areaRulePlannings = await backendConfigurationPnDbContext.AreaRulePlannings


### PR DESCRIPTION
## Summary

`ActionableOnly` branch of `GetTasksForWeek` (mobile-worker gRPC path) was loading only non-removed Compliance rows. The canonical complete paths (`CompliancesGrpcService.UpdateComplianceCase` mobile / web modal `Save` via `CompliancesController.Update`) soft-delete the Compliance row after setting `Case.Status=100`, so the next `ListEvents` saw the row gone from every internal set — including the dedup set that suppresses recurrence-expansion. The recurrence-emit loop then re-emitted a fresh uncompleted task for the date the worker just completed.

Default (admin REST) branch already had this fixed in PR #843 — it loads removed-completed rows and surfaces them as `Completed=true`. The mobile-worker intent differs: completed events should be **absent** from the actionable list, not rendered as completed. So this fix is narrower.

## Changes (`BackendConfigurationCalendarService.GetTasksForWeek`)

- Broaden the ActionableOnly `Compliances` query to also include removed-but-deployed rows (`MicrotingSdkCaseId > 0`). `IsComplianceActionable` keeps stripping them from `compliancesInWeek` so the mobile worker never sees them in the task list.
- Compute `removedCompletedInWeek` (`WorkflowState=Removed` + `Status=100` on backing SDK case) once.
- Introduce `compliancesForDedup = compliancesInWeek ∪ removedCompletedInWeek`; recurrence-dedup sets (`complianceDateSet` / `compliancePlanningIdsInWeek`) now use this union so recurrence-expansion no longer fires for completed dates.
- Explicitly **exclude** removed-completed rows from `nonActionableByPlanningDate`. That dict is the Bug A device-write routing slot — a removed-completed row's `SdkCaseId` points at a closed `Status=100` case and could non-deterministically take precedence under `GroupBy` first-wins. Keeping the routing focused on the original Bug A scope (retracted SDK case / soft-deleted / `Status==100` inline-rotation).
- Drive-by: `sdkDbContextForCalendar` now opens with `await using` — matches every other SDK context obtained in this method.

gRPC handlers themselves intentionally untouched.

## Test plan

- [ ] Mobile worker completes a compliance event on today's deadline. Next `ListEvents` does NOT re-emit a phantom uncompleted task for that date.
- [ ] Mobile worker completes a compliance event on a deadline that has a recurring rotation pattern → recurrence emits for the *next* live rotation, but not for the just-completed date.
- [ ] Admin REST calendar: no behavioural change (default branch already loads removed-completed; `compliancesForDedup = compliancesInWeek` preserves the existing render).
- [ ] Bug A coverage: a planning-day with a retracted (non-completed) compliance row + a separate removed-completed row → device write routes to the retracted row's case (via `nonActionableByPlanningDate`), not the closed Status=100 case.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)