### PR TITLE
style(filter-cards): align 6 page headers with property-workers pattern

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/components/properties/properties-page/properties-container/properties-container.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/components/properties/properties-page/properties-container/properties-container.component.html
@@ -1,5 +1,6 @@
-<eform-new-subheader>
-  <div class="d-flex flex-row align-items-center gap-12">
+<mat-card class="eform-sub-header d-flex flex-column gap-12 mb-3 p-3" style="align-items: stretch;">
+  <h2 style="margin: 0">{{ pageTitle | translate }}</h2>
+  <div class="d-flex flex-row flex-wrap align-items-end justify-content-end gap-12">
     <div class="text-field--rounded mt-4">
       <mat-form-field>
         <mat-label>{{ 'Search' | translate }}</mat-label>
@@ -13,7 +14,6 @@
         <mat-icon matSuffix>search</mat-icon>
       </mat-form-field>
     </div>
-    <div class="line-vert"></div>
     <button
       *ngIf="authStateService.checkClaim('properties_create')"
       class="btn-primary btn-primary--icon-left"
@@ -26,7 +26,7 @@
       <span>{{ 'New property' | translate }}</span>
     </button>
   </div>
-</eform-new-subheader>
+</mat-card>
 
 <app-properties-table
   [propertiesModel]="propertiesModel"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/components/properties/properties-page/properties-container/properties-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/components/properties/properties-page/properties-container/properties-container.component.ts
@@ -4,7 +4,8 @@ import {Component, OnDestroy, OnInit,
 import {AutoUnsubscribe} from 'ngx-auto-unsubscribe';
 import {Subject, Subscription} from 'rxjs';
 import {EntityItemModel, Paged} from 'src/app/common/models';
-import {AuthStateService} from 'src/app/common/store';
+import {AppMenuStateService, AuthStateService} from 'src/app/common/store';
+import {Router} from '@angular/router';
 import {
   PropertyCreateModalComponent,
   PropertyDeleteModalComponent,
@@ -45,7 +46,14 @@ export class PropertiesContainerComponent implements OnInit, OnDestroy {
   private translateService = inject(TranslateService);
   private dialog = inject(MatDialog);
   private overlay = inject(Overlay);
+  private router = inject(Router);
+  private appMenuStateService = inject(AppMenuStateService);
   public selectPropertiesNameFilters$ = this.store.select(selectPropertiesNameFilters);
+
+  // Resolved once in ngOnInit — getTitleByUrl subscribes to the menu store
+  // internally without unsubscribing, so calling it from the template would
+  // leak one subscription per change-detection tick.
+  public pageTitle: string = '';
 
   isFarms: boolean = false;
   tableHeaders: MtxGridColumn[] = [
@@ -140,14 +148,15 @@ export class PropertiesContainerComponent implements OnInit, OnDestroy {
   getEntitySelectableGroupSub$: Subscription;
   updateEntitySelectableGroupSub$: Subscription;
   nameSearchSubjectSub$: Subscription;
-
-
-
-  // get backendConfigurationPnClaims() {
-  //   return BackendConfigurationPnClaims;
-  // }
+  titleSub$: Subscription;
 
   ngOnInit() {
+    // Resolve the page title once menus hydrate; recompute when they emit.
+    // getTitleByUrl reads from the menu store internally — we drive it from
+    // the menu emission instead of calling it per template change-detection.
+    this.titleSub$ = this.appMenuStateService.leftAppMenus$.subscribe(() => {
+      this.pageTitle = this.appMenuStateService.getTitleByUrl(this.router.url);
+    });
     this.nameSearchSubjectSub$ = this.nameSearchSubject.pipe(debounceTime(500)).subscribe((val) => {
       this.propertiesStateService.updateNameFilter(val.toString());
       this.getProperties();

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-container/documents-container.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-container/documents-container.component.html
@@ -1,13 +1,20 @@
-<eform-new-subheader>
-  <ng-container *ngIf="folders !== undefined">
-    <div class="d-flex flex-row align-items-center gap-12">
+<mat-card class="eform-sub-header d-flex flex-column gap-12 mb-3 p-3" style="align-items: stretch;">
+  <h2 style="margin: 0">{{ pageTitle | translate }}</h2>
+  <div class="d-flex flex-row flex-wrap align-items-end justify-content-end gap-12">
+    <app-documents-filters
+      (updateTable)="updateTable()"
+      [properties]="properties"
+      [folders]="folders"
+      [documents]="simpleDocuments"
+    />
+    <ng-container *ngIf="folders !== undefined">
       <button
-        class="btn-secondary btn-secondary--icon-rounded-border"
+        class="btn-secondary btn-secondary--icon-left"
         id="manageFoldersBtn"
         matTooltip="{{ 'Manage folders' | translate }}"
         (click)="openManageFoldersModal()"
       >
-        <mat-icon class="icon-secondary">folder</mat-icon>
+        <mat-icon>folder</mat-icon>
         <span>{{ 'Manage folders' | translate }}</span>
       </button>
       <button *ngIf="folders.length > 0"
@@ -19,10 +26,9 @@
         <mat-icon>add</mat-icon>
         <span>{{ 'Create new document' | translate }}</span>
       </button>
-    </div>
-  </ng-container>
-</eform-new-subheader>
-
+    </ng-container>
+  </div>
+</mat-card>
 
 <app-document-updated-days
   *ngIf="showDiagram"
@@ -30,13 +36,6 @@
   [selectedPropertyName]="propertyName"
   [view]="view"
   class="mb-2 w-100"
-/>
-
-<app-documents-filters
-  (updateTable)="updateTable()"
-  [properties]="properties"
-  [folders]="folders"
-  [documents]="simpleDocuments"
 />
 
 <app-documents-table

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-container/documents-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-container/documents-container.component.ts
@@ -27,7 +27,8 @@ import {
 } from '../../../../services';
 import {TranslateService} from '@ngx-translate/core';
 import {skip, tap} from 'rxjs/operators';
-import {ActivatedRoute} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
+import {AppMenuStateService} from 'src/app/common/store';
 import {StatisticsStateService} from '../../../statistics/store';
 import {selectCurrentUserLanguageId} from 'src/app/state/auth/auth.selector';
 import {Store} from '@ngrx/store';
@@ -52,7 +53,14 @@ export class DocumentsContainerComponent implements OnInit, OnDestroy {
   public documentsStateService = inject(DocumentsStateService);
   public localeService = inject(LocaleService);
   private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private appMenuStateService = inject(AppMenuStateService);
   private statisticsStateService = inject(StatisticsStateService);
+
+  // Resolved once in ngOnInit — getTitleByUrl subscribes to the menu store
+  // internally without unsubscribing, so calling it from the template would
+  // leak one subscription per change-detection tick.
+  public pageTitle: string = '';
 
   folders: DocumentSimpleFolderModel[];
   documents: Paged<DocumentModel> = new Paged<DocumentModel>();
@@ -71,6 +79,7 @@ export class DocumentsContainerComponent implements OnInit, OnDestroy {
   getActiveSortDirectionSub$: Subscription;
   getFiltersAsyncSub$: Subscription;
   getDocumentUpdatedDaysSub$: Subscription;
+  titleSub$: Subscription;
   private selectCurrentUserLanguageId$ = this.store.select(selectCurrentUserLanguageId);
   private selectDocumentsFiltersPropertyId$ = this.store.select(selectDocumentsFiltersPropertyId);
   private selectDocumentsPaginationIsSortDsc$ = this.store.select(selectDocumentsPaginationIsSortDsc);
@@ -112,6 +121,12 @@ export class DocumentsContainerComponent implements OnInit, OnDestroy {
 
 
   ngOnInit(): void {
+    // Resolve the page title once menus hydrate; recompute when they emit.
+    // getTitleByUrl reads from the menu store internally — we drive it from
+    // the menu emission instead of calling it per template change-detection.
+    this.titleSub$ = this.appMenuStateService.leftAppMenus$.subscribe(() => {
+      this.pageTitle = this.appMenuStateService.getTitleByUrl(this.router.url);
+    });
     this.getProperties();
     this.getActiveSortDirectionSub$ = this.selectDocumentsPaginationIsSortDsc$
       .pipe(
@@ -135,6 +150,10 @@ export class DocumentsContainerComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    // Class has no @AutoUnsubscribe() decorator — explicit cleanup for the
+    // one subscription we own. Other Sub$ fields in this class predate this
+    // session and are out of scope.
+    this.titleSub$?.unsubscribe();
   }
 
   openCreateModal() {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-filters/documents-filters.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-filters/documents-filters.component.html
@@ -1,5 +1,4 @@
-<div [formGroup]="filtersForm">
-  <div class="align-items-center d-flex flex-row need-wrapper px-3">
+<div class="filters-inline" [formGroup]="filtersForm">
     <mat-form-field>
       <mat-label>{{'Property' | translate}}</mat-label>
       <mtx-select
@@ -24,8 +23,6 @@
       >
       </mtx-select>
     </mat-form-field>
-<!--  </div>-->
-<!--  <div class="align-items-center d-flex flex-row need-wrapper">-->
     <mat-form-field>
       <mat-label>{{'Document name' | translate}}</mat-label>
       <mtx-select
@@ -53,13 +50,10 @@
       </mtx-select>
     </mat-form-field>
     <button
-      class="btn-primary btn-primary--icon-left mb-4 ml-3"
+      class="btn-primary btn-primary--icon-left"
       id="showReportBtn"
       (click)="updateTable.emit()"
     >
       <span>{{ 'Show' | translate }}</span>
     </button>
-  </div>
-
-
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-filters/documents-filters.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-filters/documents-filters.component.scss
@@ -1,0 +1,14 @@
+// display:contents lets the filter controls join the parent toolbar's flex row
+// instead of forming a nested row (host + wrapper both bypass layout).
+:host,
+.filters-inline {
+  display: contents;
+}
+
+// Constrain field width so all 4 filters + action buttons fit on the toolbar
+// row beneath the title. Naming `.mat-mdc-form-field` in the selector outranks
+// the global `.mat-mdc-form-field { width: 100% }` rule in scss/components/_form.scss.
+:host ::ng-deep .filters-inline mat-form-field.mat-mdc-form-field {
+  width: 200px;
+  min-width: 200px;
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-container/files-container.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-container/files-container.component.html
@@ -1,38 +1,35 @@
-<eform-new-subheader>
-  <div class="d-flex flex-row justify-content-center align-items-center gap-12">
+<mat-card class="eform-sub-header d-flex flex-column gap-12 mb-3 p-3" style="align-items: stretch;">
+  <h2 style="margin: 0">{{ pageTitle | translate }}</h2>
+  <div class="d-flex flex-row flex-wrap align-items-end justify-content-end gap-12">
+    <app-files-filters [availableTags]="availableTags" (updateTable)="updateTable()"></app-files-filters>
     <button
-      matSuffix
-      class="btn-secondary btn-secondary--icon-rounded-border"
+      class="btn-primary btn-primary--icon-left"
+      [disabled]="selectedFileIds.length === 0"
+      (click)="downloadSelectedFiles()"
+    >
+      <mat-icon>download</mat-icon>
+      <span>{{ 'Download selected' | translate }}</span>
+    </button>
+    <button
+      class="btn-secondary btn-secondary--icon-left"
+      id="manageTagsBtn"
+      matTooltip="{{ 'Manage tags' | translate }}"
+      (click)="openTagsModal()"
+    >
+      <mat-icon>label</mat-icon>
+      <span>{{ 'Tags' | translate }}</span>
+    </button>
+    <button
+      class="btn-primary btn-primary--icon-left"
       id="addNewFileBtn"
       matTooltip="{{ 'Upload PDF' | translate }}"
       routerLink="./create"
     >
       <mat-icon>file_upload</mat-icon>
-    </button>
-    <button
-      matSuffix
-      class="btn-secondary btn-secondary--icon-rounded-border"
-      id="manageTagsBtn"
-      matTooltip="{{ 'Manage tags' | translate }}"
-      (click)="openTagsModal()"
-    >
-      <mat-icon>discount</mat-icon>
+      <span>{{ 'Upload PDF' | translate }}</span>
     </button>
   </div>
-</eform-new-subheader>
-
-<app-files-filters [availableTags]="availableTags" (updateTable)="updateTable()"></app-files-filters>
-
-<div class="d-flex flex-row justify-content-end mb-4 pr-3">
-  <button
-    class="btn-primary btn-primary--icon-left"
-    [disabled]="selectedFileIds.length === 0"
-    (click)="downloadSelectedFiles()"
-    >
-    <mat-icon>download</mat-icon>
-    <span>{{'Download selected' | translate}}</span>
-  </button>
-</div>
+</mat-card>
 <app-files-table
   [files]="files"
   [highlightedFileId]="highlightedFileId"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-container/files-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-container/files-container.component.ts
@@ -1,6 +1,4 @@
-import {Component, OnDestroy, OnInit, ViewChild,
-  inject
-} from '@angular/core';
+import {Component, OnDestroy, OnInit, ViewChild, inject} from '@angular/core';
 import {DownloadFilesNameArchiveComponent, FileNameEditComponent, FileTagsComponent, FileTagsEditComponent} from '../';
 import {FilesModel} from '../../../../models';
 import {
@@ -18,6 +16,8 @@ import {DeleteModalComponent} from 'src/app/common/modules/eform-shared/componen
 import {TranslateService} from '@ngx-translate/core';
 import {saveAs} from 'file-saver';
 import {AutoUnsubscribe} from 'ngx-auto-unsubscribe';
+import {AppMenuStateService} from 'src/app/common/store';
+import {Router} from '@angular/router';
 import {Store} from "@ngrx/store";
 
 @AutoUnsubscribe()
@@ -35,6 +35,13 @@ export class FilesContainerComponent implements OnInit, OnDestroy {
   private tagsService = inject(BackendConfigurationPnFileTagsService);
   private translateService = inject(TranslateService);
   private filesService = inject(BackendConfigurationPnFilesService);
+  private router = inject(Router);
+  private appMenuStateService = inject(AppMenuStateService);
+
+  // Resolved once in ngOnInit — getTitleByUrl subscribes to the menu store
+  // internally without unsubscribing, so calling it from the template would
+  // leak one subscription per change-detection tick.
+  public pageTitle: string = '';
 
   @ViewChild('tagsModal') tagsModal: FileTagsComponent;
   availableTags: SharedTagModel[] = [];
@@ -50,10 +57,15 @@ export class FilesContainerComponent implements OnInit, OnDestroy {
   fileTagsUpdatedSub$: Subscription;
   downloadFilesSub$: Subscription;
   clickDownloadFilesSub$: Subscription;
-
-
+  titleSub$: Subscription;
 
   ngOnInit(): void {
+    // Resolve the page title once menus hydrate; recompute when they emit.
+    // getTitleByUrl reads from the menu store internally — we drive it from
+    // the menu emission instead of calling it per template change-detection.
+    this.titleSub$ = this.appMenuStateService.leftAppMenus$.subscribe(() => {
+      this.pageTitle = this.appMenuStateService.getTitleByUrl(this.router.url);
+    });
     this.getTags();
     this.getFiles();
     // this.filesStateService.getFiltersAsync().subscribe(() => this.updateTable());

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-filters/files-filters.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-filters/files-filters.component.html
@@ -1,5 +1,4 @@
-<div [formGroup]="filtersForm">
-  <div class="align-items-center d-flex flex-row need-wrapper px-3">
+<div class="filters-inline" [formGroup]="filtersForm">
     <mat-form-field>
       <mat-label>{{'Property' | translate}}</mat-label>
       <mtx-select
@@ -30,8 +29,6 @@
         <mat-icon>close</mat-icon>
       </button>
     </mat-form-field>
-<!--  </div>-->
-<!--  <div class="align-items-center d-flex flex-row need-wrapper px-3">-->
     <mat-form-field>
       <mat-label>{{'File name' | translate}}</mat-label>
       <input
@@ -58,5 +55,4 @@
       >
       </mtx-select>
     </mat-form-field>
-  </div>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-filters/files-filters.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-filters/files-filters.component.scss
@@ -1,0 +1,21 @@
+// display:contents lets the filter controls join the parent toolbar's flex row
+// instead of forming a nested row (host + wrapper both bypass layout).
+:host,
+.filters-inline {
+  display: contents;
+}
+
+// Date-range and free-text inputs greedily expand to a full row; constrain each
+// field so all 4 filters + action buttons fit on the toolbar row beneath the
+// title. Naming `.mat-mdc-form-field` in the selector outranks the global
+// `.mat-mdc-form-field { width: 100% }` rule in scss/components/_form.scss.
+:host ::ng-deep .filters-inline mat-form-field.mat-mdc-form-field {
+  width: 200px;
+  min-width: 200px;
+
+  // Date range has two stacked inputs + datepicker icon — needs more room.
+  &[formGroupName='dateRange'] {
+    width: 240px;
+    min-width: 240px;
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-management/components/task-management-container/task-management-container.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-management/components/task-management-container/task-management-container.component.html
@@ -1,32 +1,7 @@
-<eform-new-subheader>
-  <button
-    class="btn-primary btn-primary--icon-left"
-    id="createNewTaskBtn"
-    matTooltip="{{ 'Create new task' | translate }}"
-    (click)="openCreateModal()"
-  >
-    <mat-icon>add</mat-icon>
-    <span>{{ 'Create new task' | translate }}</span>
-  </button>
-</eform-new-subheader>
-
-<div class="d-flex flex-column">
-  <app-ad-hoc-task-priorities
-    *ngIf="diagramForShow === 'ad-hoc-task-priorities'"
-    [adHocTaskPrioritiesModel]="adHocTaskPrioritiesModel"
-    [selectedPropertyName]="propertyName"
-    [view]="view"
-    class="mb-2 w-100"
-  />
-  <app-ad-hoc-task-workers
-    *ngIf="diagramForShow === 'ad-hoc-task-workers'"
-    [adHocTaskWorkers]="adHocTaskWorkers"
-    [selectedPropertyName]="propertyName"
-    [view]="view"
-    class="mb-2 w-100"
-  />
-  <app-task-management-filters/>
-  <div class="d-flex flex-row align-items-center pl-3 gap-12">
+<mat-card class="eform-sub-header d-flex flex-column gap-12 mb-3 p-3" style="align-items: stretch;">
+  <h2 style="margin: 0">{{ pageTitle | translate }}</h2>
+  <div class="d-flex flex-row flex-wrap align-items-end justify-content-end gap-12">
+    <app-task-management-filters/>
     <button
       class="btn-primary btn-primary--icon-left"
       id="showReportBtn"
@@ -35,7 +10,6 @@
     >
       {{ 'Show' | translate }}
     </button>
-    <div *ngIf="(selectTaskManagementPropertyId$ | async) !== null" class="line-vert"></div>
     <button
       *ngIf="(selectTaskManagementPropertyId$ | async) !== null"
       class="btn-secondary btn-secondary--icon-rounded-border"
@@ -55,8 +29,33 @@
     >
       <mat-icon svgIcon="file-excel"></mat-icon>
     </button>
+    <button
+      class="btn-primary btn-primary--icon-left"
+      id="createNewTaskBtn"
+      matTooltip="{{ 'Create new task' | translate }}"
+      (click)="openCreateModal()"
+    >
+      <mat-icon>add</mat-icon>
+      <span>{{ 'Create new task' | translate }}</span>
+    </button>
   </div>
-  <br>
+</mat-card>
+
+<div class="d-flex flex-column">
+  <app-ad-hoc-task-priorities
+    *ngIf="diagramForShow === 'ad-hoc-task-priorities'"
+    [adHocTaskPrioritiesModel]="adHocTaskPrioritiesModel"
+    [selectedPropertyName]="propertyName"
+    [view]="view"
+    class="mb-2 w-100"
+  />
+  <app-ad-hoc-task-workers
+    *ngIf="diagramForShow === 'ad-hoc-task-workers'"
+    [adHocTaskWorkers]="adHocTaskWorkers"
+    [selectedPropertyName]="propertyName"
+    [view]="view"
+    class="mb-2 w-100"
+  />
   <app-task-management-table
     [workOrderCases]="workOrderCases"
     [highlightedId]="highlightedId"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-management/components/task-management-container/task-management-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-management/components/task-management-container/task-management-container.component.ts
@@ -17,7 +17,8 @@ import {dialogConfigHelper} from 'src/app/common/helpers';
 import {LoaderService} from 'src/app/common/services';
 import {catchError, skip, tap} from 'rxjs/operators';
 import {StatisticsStateService} from '../../../statistics/store';
-import {ActivatedRoute} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
+import {AppMenuStateService} from 'src/app/common/store';
 import {Store} from '@ngrx/store';
 import {
   selectTaskManagementFilters,
@@ -42,6 +43,13 @@ export class TaskManagementContainerComponent implements OnInit, OnDestroy {
   private overlay = inject(Overlay);
   private statisticsStateService = inject(StatisticsStateService);
   private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private appMenuStateService = inject(AppMenuStateService);
+
+  // Resolved once in ngOnInit — getTitleByUrl subscribes to the menu store
+  // internally without unsubscribing, so calling it from the template would
+  // leak one subscription per change-detection tick.
+  public pageTitle: string = '';
 
   workOrderCases: WorkOrderCaseModel[] = [];
   properties: CommonDictionaryModel[] = [];
@@ -60,6 +68,7 @@ export class TaskManagementContainerComponent implements OnInit, OnDestroy {
   getAllWorkOrderCasesSub$: Subscription;
   taskCreatedSub$: Subscription;
   getPropertyIdAsyncSub$: Subscription;
+  titleSub$: Subscription;
 
   get propertyName(): string {
     if (this.properties && this.selectedPropertyId) {
@@ -76,6 +85,12 @@ export class TaskManagementContainerComponent implements OnInit, OnDestroy {
   private selectTaskManagementFilters$ = this.store.select(selectTaskManagementFilters);
 
   ngOnInit() {
+    // Resolve the page title once menus hydrate; recompute when they emit.
+    // getTitleByUrl reads from the menu store internally — we drive it from
+    // the menu emission instead of calling it per template change-detection.
+    this.titleSub$ = this.appMenuStateService.leftAppMenus$.subscribe(() => {
+      this.pageTitle = this.appMenuStateService.getTitleByUrl(this.router.url);
+    });
     this.route.queryParams.subscribe(x => {
       if (x && x.diagramForShow) {
         this.diagramForShow = x.diagramForShow;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-management/components/task-management-filters/task-management-filters.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-management/components/task-management-filters/task-management-filters.component.html
@@ -1,5 +1,4 @@
-<div class="d-flex flex-column" [formGroup]="filtersForm">
-  <div class="d-flex flex-row need-wrapper px-3">
+<div class="filters-inline" [formGroup]="filtersForm">
     <mat-form-field>
       <mat-label>{{'Property' | translate}}</mat-label>
       <mtx-select
@@ -36,8 +35,6 @@
       </button>
       </div>
     </ng-container>
-<!--  </div>-->
-<!--  <div class="d-flex flex-row need-wrapper">-->
     <mat-form-field>
       <mat-label>{{'Created by' | translate}}</mat-label>
       <mtx-select
@@ -101,5 +98,4 @@
       </mat-date-range-input>
       <mat-date-range-picker #picker></mat-date-range-picker>
     </mat-form-field>
-  </div>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-management/components/task-management-filters/task-management-filters.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-management/components/task-management-filters/task-management-filters.component.scss
@@ -1,0 +1,22 @@
+// display:contents lets the filter controls join the parent toolbar's flex row
+// instead of forming a nested row (host + wrapper both bypass layout).
+:host,
+.filters-inline {
+  display: contents;
+}
+
+// With 7 filter fields plus action buttons sharing the sub-header row, the
+// Material default ~320px width forces wrapping. Constrain each field so 5-6
+// fit per row alongside the buttons. Naming `.mat-mdc-form-field` in the
+// selector outranks the global `.mat-mdc-form-field { width: 100% }` rule in
+// scss/components/_form.scss.
+:host ::ng-deep .filters-inline mat-form-field.mat-mdc-form-field {
+  width: 180px;
+  min-width: 180px;
+
+  // Date range has two stacked inputs and needs slightly more room.
+  &[formGroupName='date'] {
+    width: 220px;
+    min-width: 220px;
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-container/task-tracker-container.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-container/task-tracker-container.component.html
@@ -1,5 +1,11 @@
-<eform-new-subheader>
-  <div class="d-flex flex-row align-items-center gap-24">
+<mat-card class="eform-sub-header d-flex flex-column gap-12 mb-3 p-3" style="align-items: stretch;">
+  <h2 style="margin: 0">{{ pageTitle | translate }}</h2>
+  <div class="d-flex flex-row flex-wrap align-items-end justify-content-end gap-12">
+    <app-task-tracker-filters
+      (updateTable)="updateTable()"
+      [properties]="properties"
+      [tags]="tags"
+    />
     <button
       class="btn-secondary btn-secondary--icon-rounded-border"
       id="excelReportBtn"
@@ -8,7 +14,6 @@
     >
       <mat-icon svgIcon="file-excel"></mat-icon>
     </button>
-    <div class="line-vert"></div>
     <button
       class="btn-primary btn-primary--icon-left"
       id="createNewTaskBtn"
@@ -19,7 +24,7 @@
       <span>{{ 'Create new task' | translate }}</span>
     </button>
   </div>
-</eform-new-subheader>
+</mat-card>
 
 <div class="d-flex flex-column">
   <div class="px-3 mb-4">
@@ -32,11 +37,6 @@
     />
   </div>
 
-  <app-task-tracker-filters
-    (updateTable)="updateTable()"
-    [properties]="properties"
-    [tags]="tags"
-  />
   <!--  <div class="d-flex flex-row justify-content-start mb-4 px-3">-->
   <!--    <button-->
   <!--      mat-raised-button-->

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-container/task-tracker-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-container/task-tracker-container.component.ts
@@ -46,6 +46,7 @@ import {ItemsPlanningPnTagsService} from '../../../../../items-planning-pn/servi
 import {PlanningTagsComponent} from '../../../../../items-planning-pn/modules/plannings/components';
 import {StatisticsStateService} from '../../../statistics/store';
 import {ActivatedRoute, Router} from '@angular/router';
+import {AppMenuStateService} from 'src/app/common/store';
 import {Store} from '@ngrx/store';
 import {
   selectTaskTrackerFilters,
@@ -78,7 +79,13 @@ export class TaskTrackerContainerComponent implements OnInit, AfterViewInit, Aft
   public statisticsStateService = inject(StatisticsStateService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private appMenuStateService = inject(AppMenuStateService);
   private ngZone = inject(NgZone);
+
+  // Resolved once in ngOnInit — getTitleByUrl subscribes to the menu store
+  // internally without unsubscribing, so calling it from the template would
+  // leak one subscription per change-detection tick.
+  public pageTitle: string = '';
 
 
 
@@ -126,6 +133,7 @@ export class TaskTrackerContainerComponent implements OnInit, AfterViewInit, Aft
   createTaskInModalSub$: Subscription;
   getPlannedTaskDaysSub$: Subscription;
   getPropertyIdAsyncSub$: Subscription;
+  titleSub$: Subscription;
   highlightIdFromRoute?: number;
 
   get propertyName(): string {
@@ -150,6 +158,12 @@ export class TaskTrackerContainerComponent implements OnInit, AfterViewInit, Aft
   }
 
   ngOnInit() {
+    // Resolve the page title once menus hydrate; recompute when they emit.
+    // getTitleByUrl reads from the menu store internally — we drive it from
+    // the menu emission instead of calling it per template change-detection.
+    this.titleSub$ = this.appMenuStateService.leftAppMenus$.subscribe(() => {
+      this.pageTitle = this.appMenuStateService.getTitleByUrl(this.router.url);
+    });
     // Subscribe to highlightId query param early (before first change detection)
     this.route.queryParamMap.subscribe(params => {
       const id = params.get('highlightId');

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-filters/task-tracker-filters.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-filters/task-tracker-filters.component.html
@@ -1,5 +1,4 @@
-<div class="d-flex flex-column px-3" [formGroup]="filtersForm">
-  <div class="d-flex flex-row need-wrapper">
+<div class="filters-inline" [formGroup]="filtersForm">
     <mat-form-field>
       <mat-label>{{'Property' | translate}}</mat-label>
       <mtx-select
@@ -40,9 +39,4 @@
       >
       </mtx-select>
     </mat-form-field>
-
-  </div>
-
 </div>
-
-

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-filters/task-tracker-filters.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-filters/task-tracker-filters.component.scss
@@ -1,3 +1,10 @@
+// display:contents lets the filter controls join the parent toolbar's flex row
+// instead of forming a nested row (host + wrapper both bypass layout).
+:host,
+.filters-inline {
+  display: contents;
+}
+
 .shownHiddenButton {
   width: 30px;
 }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-filters/task-wizard-filters.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-filters/task-wizard-filters.component.html
@@ -1,5 +1,4 @@
-<div class="d-flex flex-row align-items-center gap-12 px-3" [formGroup]="filtersForm">
-<!--  <div class="d-flex need-wrapper">-->
+<div class="filters-inline" [formGroup]="filtersForm">
     <mat-form-field>
       <mat-label>{{'Location' | translate}}</mat-label>
       <mtx-select
@@ -22,8 +21,6 @@
         [bindLabel]="'name'"
       />
     </mat-form-field>
-<!--  </div>-->
-<!--  <div class="d-flex need-wrapper">-->
     <mat-form-field>
       <mat-label>{{'Tags' | translate}}</mat-label>
       <mtx-select
@@ -57,5 +54,4 @@
         [bindLabel]="'name'"
       />
     </mat-form-field>
-  </div>
-<!--</div>-->
+</div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-filters/task-wizard-filters.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-filters/task-wizard-filters.component.scss
@@ -1,0 +1,6 @@
+// display:contents lets the filter controls join the parent toolbar's flex row
+// instead of forming a nested row (host + wrapper both bypass layout).
+:host,
+.filters-inline {
+  display: contents;
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-page/task-wizard-page.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-page/task-wizard-page.component.html
@@ -1,14 +1,45 @@
-<eform-new-subheader>
-  <button
-    class="btn-primary btn-primary--icon-left"
-    [matTooltip]="'Create new task' | translate"
-    (click)="onCreateTask()"
-    id="createNewTaskBtn"
-  >
-    <mat-icon>add</mat-icon>
-    <span>{{ 'Create new task' | translate }}</span>
-  </button>
-</eform-new-subheader>
+<mat-card class="eform-sub-header d-flex flex-column gap-12 mb-3 p-3" style="align-items: stretch;">
+  <h2 style="margin: 0">{{ pageTitle | translate }}</h2>
+  <div class="d-flex flex-row flex-wrap align-items-end justify-content-end gap-12">
+    <app-task-wizard-filters
+      [properties]="properties"
+      [folders]="folders"
+      [sites]="sites"
+      [tags]="tags"
+      (updateTable)="updateTable()"
+    />
+    <button
+      *ngIf="selectAuthIsAdmin$ | async;"
+      class="btn-warning"
+      [disabled]="
+      !selectedPlanningsCheckboxes || selectedPlanningsCheckboxes.length === 0
+    "
+      id="deleteMultiplePluginsBtn"
+      matTooltip="{{ 'Deactivate selected' | translate }}"
+      (click)="showDeactivateMultipleTasksModal()"
+    >
+      {{ 'Deactivate selected' | translate }}
+    </button>
+    <button
+      class="btn-primary btn-primary--icon-left"
+      (click)="exportCsv()"
+      id="exportTasksBtn"
+      matTooltip="{{ 'Export CSV' | translate }}"
+    >
+      <mat-icon>download</mat-icon>
+      <span>{{ 'Export CSV' | translate }}</span>
+    </button>
+    <button
+      class="btn-primary btn-primary--icon-left"
+      [matTooltip]="'Create new task' | translate"
+      (click)="onCreateTask()"
+      id="createNewTaskBtn"
+    >
+      <mat-icon>add</mat-icon>
+      <span>{{ 'Create new task' | translate }}</span>
+    </button>
+  </div>
+</mat-card>
 
 <app-planned-task-workers
   *ngIf="showDiagram"
@@ -17,37 +48,6 @@
   [view]="view"
   class="mb-2 w-100"
 />
-
-<app-task-wizard-filters
-  [properties]="properties"
-  [folders]="folders"
-  [sites]="sites"
-  [tags]="tags"
-  (updateTable)="updateTable()"
-/>
-<div class="d-flex flex-row align-items-center gap-12 mb-4 ml-3">
-  <button
-    *ngIf="selectAuthIsAdmin$ | async;"
-    class="btn-warning"
-    [disabled]="
-    !selectedPlanningsCheckboxes || selectedPlanningsCheckboxes.length === 0
-  "
-    id="deleteMultiplePluginsBtn"
-    matTooltip="{{ 'Deactivate selected' | translate }}"
-    (click)="showDeactivateMultipleTasksModal()"
-  >
-    {{ 'Deactivate selected' | translate }}
-  </button>
-
-  <button
-    class="btn-primary btn-primary--icon-left ml-2"
-    (click)="exportCsv()"
-    id="exportTasksBtn"
-  >
-    <mat-icon>download</mat-icon>
-    <span>Export CSV</span>
-  </button>
-</div>
 <app-task-wizard-table
   [tasks]="tasks"
   [highlightId]="highlightIdAfterEdit"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-page/task-wizard-page.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-page/task-wizard-page.component.ts
@@ -22,8 +22,8 @@ import {
   TaskWizardUpdateModalComponent
 } from '../../components';
 import {PlanningTagsComponent} from '../../../../../items-planning-pn/modules/plannings/components';
-import {AuthStateService} from 'src/app/common/store';
-import {ActivatedRoute} from '@angular/router';
+import {AppMenuStateService, AuthStateService} from 'src/app/common/store';
+import {ActivatedRoute, Router} from '@angular/router';
 import {StatisticsStateService} from '../../../statistics/store';
 import * as R from 'ramda';
 import {selectAuthIsAdmin, selectAuthIsAuth} from 'src/app/state';
@@ -53,7 +53,14 @@ export class TaskWizardPageComponent implements OnInit, OnDestroy, AfterViewInit
   private appSettingsStateService = inject(AppSettingsStateService);
   public authStateService = inject(AuthStateService);
   private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private appMenuStateService = inject(AppMenuStateService);
   private statisticsStateService = inject(StatisticsStateService);
+
+  // Resolved once in ngOnInit — getTitleByUrl subscribes to the menu store
+  // internally without unsubscribing, so calling it from the template would
+  // leak one subscription per change-detection tick.
+  public pageTitle: string = '';
 
   @ViewChild('planningTagsModal') planningTagsModal: PlanningTagsComponent;
   properties: CommonDictionaryModel[] = [];
@@ -86,6 +93,7 @@ export class TaskWizardPageComponent implements OnInit, OnDestroy, AfterViewInit
   getPropertyIdsAsyncSub$: Subscription;
   changePropertySub$: Subscription;
   getPlannedTaskWorkersSub$: Subscription;
+  titleSub$: Subscription;
   selectedPlanningsCheckboxes: number[] = [];
   public isAuth$ = this.store.select(selectAuthIsAuth);
   public selectAuthIsAdmin$ = this.store.select(selectAuthIsAdmin);
@@ -121,6 +129,12 @@ export class TaskWizardPageComponent implements OnInit, OnDestroy, AfterViewInit
 
 
   ngOnInit(): void {
+    // Resolve the page title once menus hydrate; recompute when they emit.
+    // getTitleByUrl reads from the menu store internally — we drive it from
+    // the menu emission instead of calling it per template change-detection.
+    this.titleSub$ = this.appMenuStateService.leftAppMenus$.subscribe(() => {
+      this.pageTitle = this.appMenuStateService.getTitleByUrl(this.router.url);
+    });
     let propertyIds: number[] = [];
     this.getProperties();
     this.getTags();


### PR DESCRIPTION
## Summary
- Aligns the header/filter region on **properties, task-wizard, task-tracker, task-management, files, documents** with the same `mat-card.eform-sub-header` pattern already shipped on `property-workers` (and recently on `reportsv2`).
- Each page now renders a single sub-header card with the page title (`pageTitle | translate`, resolved via `appMenuStateService.leftAppMenus$`), filter controls and action buttons in one right-aligned wrapping flex row.
- Filter sub-components were flattened into the parent toolbar row via `:host, .filters-inline { display: contents; }`, so form fields participate in the parent flex instead of forming a nested row.
- Pages with greedy date-range/text inputs (task-management, files, documents) constrain `mat-form-field` widths to 180–220 px so the toolbar fits in 1–2 rows.

## Test plan
- [ ] Visit `/plugins/backend-configuration-pn/properties` — title left, search + Create button right-aligned in one card.
- [ ] Visit `/plugins/backend-configuration-pn/task-wizard` — 5 filters + Deactivate selected/Export CSV/Create buttons in a single right-aligned wrapping row.
- [ ] Visit `/plugins/backend-configuration-pn/task-tracker` — 3 filters + Excel + Create buttons aligned.
- [ ] Visit `/plugins/backend-configuration-pn/task-management` — 7 filters compact to 2 rows; Vis/Word/Excel/Create buttons right-aligned.
- [ ] Visit `/plugins/backend-configuration-pn/files` — 4 filters + Download selected/Tags/Upload PDF buttons in a single card.
- [ ] Visit `/plugins/backend-configuration-pn/documents` — 4 filters + Vis/Manage folders/Create buttons; folders-guard still hides Manage/Create until folders load.
- [ ] Resize to 1024 px to confirm graceful wrapping with all 6 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)