### PR TITLE
Fix: default cursor on empty calendar areas

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-day-column/calendar-day-column.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-day-column/calendar-day-column.component.scss
@@ -2,7 +2,6 @@
   flex: 1;
   position: relative;
   border-left: 1px solid var(--border, #e0e0e0);
-  cursor: pointer;
   overflow: visible;
 
   &.today {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
@@ -201,7 +201,6 @@
 
 .day-cell-content {
   display: block;
-  cursor: pointer;
   position: relative;
   border-left: 1px solid #dadce0;
   overflow: visible;


### PR DESCRIPTION
## Summary
- Remove blanket `cursor: pointer` from `.day-column` and `.day-cell-content` in the backend-configuration calendar week-grid
- Empty calendar cells now show the default arrow cursor instead of the hand
- Event tiles (pointer), resize handles (`ns-resize`), and past empty slots (`not-allowed`) are unchanged
- Click-to-create-event on empty cells is unchanged — only the cursor changes

## Test plan
- [x] Hover empty future cell → default arrow cursor
- [x] Hover empty past cell → `not-allowed` cursor
- [x] Hover event tile body → pointer cursor
- [x] Hover event tile top/bottom edge → `ns-resize` cursor
- [x] Click empty future cell → create-event flow still fires

Spec: `docs/superpowers/specs/2026-05-26-calendar-empty-area-cursor-design.md`
Plan: `docs/superpowers/plans/2026-05-26-calendar-empty-area-cursor.md`

Generated with [Claude Code](https://claude.com/claude-code)