### PR TITLE
Fix: pre-select sidebar board in calendar create-event modal

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -341,6 +341,7 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       date: event.date,
       startHour: event.startHour,
       boards: this.boards,
+      selectedBoardId: this.activeBoardIds.length === 1 ? this.activeBoardIds[0] : undefined,
       employees: this.employees,
       tags: this.tags.map(t => t.name),
       propertyId: this.currentPropertyId!,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -42,6 +42,7 @@ export interface TaskCreateEditModalData {
   date: string;
   startHour: number;
   boards: CalendarBoardModel[];
+  selectedBoardId?: number;
   employees: CommonDictionaryModel[];
   tags: string[];
   propertyId: number;
@@ -278,10 +279,17 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
       this.startTimeControl.setValue(this.hourToTimeStr(startHour));
       this.endTimeControl.setValue(this.hourToTimeStr(startHour + 1));
       this.propertyControl.setValue(this.data.propertyId);
-      const defaultBoard = this.data.boards.length > 0
+      // Prefer the sidebar-selected board when exactly one is active and it
+      // still exists in the available boards list; otherwise fall back to
+      // the smallest-ID board.
+      const sidebarSelected = this.data.selectedBoardId != null
+        ? this.data.boards.find(b => b.id === this.data.selectedBoardId) ?? null
+        : null;
+      const fallbackBoard = this.data.boards.length > 0
         ? this.data.boards.reduce((min, b) => b.id < min.id ? b : min)
         : null;
-      this.boardControl.setValue(defaultBoard?.id ?? null);
+      const initialBoard = sidebarSelected ?? fallbackBoard;
+      this.boardControl.setValue(initialBoard?.id ?? null);
       const kvittering = this.data.eforms?.find(e => e.label === 'Kvittering');
       this.eformControl.setValue(kvittering?.id ?? this.data.eforms?.[0]?.id ?? null);
     }


### PR DESCRIPTION
## Summary
- When exactly one board is toggled active in the calendar sidebar, the create-event modal now opens with that board pre-selected
- When zero or two-plus boards are active, the existing smallest-ID default fallback is preserved
- Edit and copy modals are untouched — they keep pre-filling from the source task

## How it works
- `CalendarContainerComponent.openCreateModal()` passes `selectedBoardId: activeBoardIds.length === 1 ? activeBoardIds[0] : undefined` into `TaskCreateEditModalData`
- `TaskCreateEditModalComponent.ngOnInit()` (create branch only) honors `data.selectedBoardId` when it resolves to a board in the list; otherwise falls back to the smallest-ID reduce

## Test plan
- [x] Only default board active → modal defaults to default board (unchanged)
- [x] Only one non-default board active → modal defaults to that non-default board (the fix)
- [x] Two or more boards active → modal defaults to smallest-ID board (fallback unchanged)
- [x] Zero boards active → modal defaults to smallest-ID board (fallback unchanged)
- [x] Edit modal on existing event → board pre-fills from the task (no regression)
- [x] Copy modal → board pre-fills from the source task (no regression)

Generated with [Claude Code](https://claude.com/claude-code)