### PR TITLE
Fix: replace 'Every weekday' with Mon-Fri 'All weekdays' option

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -460,4 +460,7 @@ export const bgBG = {
   'Last refreshed': 'Последно обновяване',
   'Google Drive disconnected': 'Google Диск е прекъснат',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive е прекъснат — свържете го отново, за да възобновите синхронизирането',
+  'Ad hoc': 'Специално',
+  Time: 'Време',
+  'All weekdays (Monday to Friday)': 'Всички делнични дни (от понеделник до петък)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -460,4 +460,7 @@ export const csCZ = {
   'Last refreshed': 'Naposledy aktualizováno',
   'Google Drive disconnected': 'Disk Google odpojen',
   'Google Drive disconnected — reconnect to resume sync': 'Disk Google odpojen – pro obnovení synchronizace znovu připojte zařízení',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Čas',
+  'All weekdays (Monday to Friday)': 'Všechny všední dny (pondělí až pátek)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -360,6 +360,7 @@ export const da = {
   'Weekly on {{day}}': 'Ugentligt hver {{day}}',
   'Monthly on day {{day}}': 'Månedligt på dag {{day}}',
   'Yearly on {{day}} {{month}}': 'Årligt den {{day}}. {{month}}',
+  'All weekdays (Monday to Friday)': 'Alle hverdage (mandag til fredag)',
   Mon: 'man',
   Tue: 'Tirsdag',
   Wed: 'Ons',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -514,4 +514,7 @@ export const deDE = {
   'Last refreshed': 'Zuletzt aktualisiert',
   'Google Drive disconnected': 'Google Drive-Verbindung getrennt',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive-Verbindung unterbrochen – stellen Sie die Verbindung wieder her, um die Synchronisierung fortzusetzen.',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Zeit',
+  'All weekdays (Monday to Friday)': 'An allen Wochentagen (Montag bis Freitag)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -460,4 +460,7 @@ export const elGR = {
   'Last refreshed': 'Τελευταία ανανέωση',
   'Google Drive disconnected': 'Το Google Drive αποσυνδέθηκε',
   'Google Drive disconnected — reconnect to resume sync': 'Το Google Drive αποσυνδέθηκε — επανασυνδεθείτε για να συνεχίσετε τον συγχρονισμό.',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Φορά',
+  'All weekdays (Monday to Friday)': 'Όλες τις καθημερινές (Δευτέρα έως Παρασκευή)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -379,6 +379,7 @@ export const enUS= {
   'Weekly on {{day}}': 'Weekly on {{day}}',
   'Monthly on day {{day}}': 'Monthly on day {{day}}',
   'Yearly on {{day}} {{month}}': 'Yearly on {{day}} {{month}}',
+  'All weekdays (Monday to Friday)': 'All weekdays (Monday to Friday)',
   'Weekly every {{days}}': 'Weekly every {{days}}',
   'Weekly on all days': 'Weekly on all days',
   'Every {{n}} weeks: {{days}}': 'Every {{n}} weeks: {{days}}',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -460,4 +460,7 @@ export const esES = {
   'Last refreshed': 'Última actualización',
   'Google Drive disconnected': 'Google Drive desconectado',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive se ha desconectado; vuelva a conectarse para reanudar la sincronización.',
+  'Ad hoc': 'A propósito',
+  Time: 'Tiempo',
+  'All weekdays (Monday to Friday)': 'Todos los días laborables (de lunes a viernes)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -460,4 +460,7 @@ export const etET = {
   'Last refreshed': 'Viimati värskendatud',
   'Google Drive disconnected': 'Google Drive&#39;i ühendus katkes',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive&#39;i ühendus katkes – sünkroonimise jätkamiseks looge uuesti ühendus.',
+  'Ad hoc': 'Juhuslik',
+  Time: 'Aeg',
+  'All weekdays (Monday to Friday)': 'Kõik nädalapäevad (esmaspäevast reedeni)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -460,4 +460,7 @@ export const fiFI = {
   'Last refreshed': 'Viimeksi päivitetty',
   'Google Drive disconnected': 'Google Driven yhteys katkaistu',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive katkaistu – yhdistä uudelleen jatkaaksesi synkronointia',
+  'Ad hoc': 'Ad hoc -palvelu',
+  Time: 'Aika',
+  'All weekdays (Monday to Friday)': 'Kaikki arkipäivät (maanantaista perjantaihin)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -459,4 +459,7 @@ export const frFR = {
   'Last refreshed': 'Dernière mise à jour',
   'Google Drive disconnected': 'Google Drive déconnecté',
   'Google Drive disconnected — reconnect to resume sync': 'Déconnexion de Google Drive — reconnectez-vous pour reprendre la synchronisation',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Temps',
+  'All weekdays (Monday to Friday)': 'Tous les jours de la semaine (du lundi au vendredi)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -460,4 +460,7 @@ export const hrHR = {
   'Last refreshed': 'Zadnje osvježeno',
   'Google Drive disconnected': 'Google disk je isključen',
   'Google Drive disconnected — reconnect to resume sync': 'Google disk je isključen — ponovno se povežite da biste nastavili sinkronizaciju',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Vrijeme',
+  'All weekdays (Monday to Friday)': 'Svi radni dani (od ponedjeljka do petka)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -460,4 +460,7 @@ export const huHU = {
   'Last refreshed': 'Utolsó frissítés',
   'Google Drive disconnected': 'A Google Drive le van választva',
   'Google Drive disconnected — reconnect to resume sync': 'A Google Drive le van választva – a szinkronizálás folytatásához újra kell csatlakoztatni',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Idő',
+  'All weekdays (Monday to Friday)': 'Minden hétköznap (hétfőtől péntekig)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -460,4 +460,7 @@ export const isIS = {
   'Last refreshed': 'Síðast endurnýjað',
   'Google Drive disconnected': 'Google Drive ótengdur',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive aftengdur — endurtengdu aftur til að halda samstillingu áfram',
+  'Ad hoc': 'Sérstakt',
+  Time: 'Tími',
+  'All weekdays (Monday to Friday)': 'Alla virka daga (mánudaga til föstudaga)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -460,4 +460,7 @@ export const itIT = {
   'Last refreshed': 'Ultimo aggiornamento',
   'Google Drive disconnected': 'Google Drive disconnesso',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive disconnesso: riconnettiti per riprendere la sincronizzazione.',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Tempo',
+  'All weekdays (Monday to Friday)': 'Tutti i giorni feriali (dal lunedì al venerdì)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -460,4 +460,7 @@ export const ltLT = {
   'Last refreshed': 'Paskutinį kartą atnaujinta',
   'Google Drive disconnected': '„Google“ diskas atjungtas',
   'Google Drive disconnected — reconnect to resume sync': '„Google“ diskas atjungtas – prijunkite dar kartą, kad tęstumėte sinchronizavimą.',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Laikas',
+  'All weekdays (Monday to Friday)': 'Visomis darbo dienomis (nuo pirmadienio iki penktadienio)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -460,4 +460,7 @@ export const lvLV = {
   'Last refreshed': 'Pēdējoreiz atsvaidzināts',
   'Google Drive disconnected': 'Google disks ir atvienots',
   'Google Drive disconnected — reconnect to resume sync': 'Google disks atvienots — atkārtoti izveidojiet savienojumu, lai atsāktu sinhronizāciju.',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Laiks',
+  'All weekdays (Monday to Friday)': 'Visas darba dienas (no pirmdienas līdz piektdienai)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -460,4 +460,7 @@ export const nlNL = {
   'Last refreshed': 'Laatst vernieuwd',
   'Google Drive disconnected': 'Google Drive is losgekoppeld',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive is losgekoppeld — maak opnieuw verbinding om de synchronisatie te hervatten.',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Tijd',
+  'All weekdays (Monday to Friday)': 'Alle werkdagen (maandag tot en met vrijdag)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -462,4 +462,5 @@ export const noNO = {
   'Last refreshed': 'Sist oppdatert',
   'Google Drive disconnected': 'Google Disk frakoblet',
   'Google Drive disconnected — reconnect to resume sync': 'Google Disk frakoblet – koble til på nytt for å gjenoppta synkroniseringen',
+  'All weekdays (Monday to Friday)': 'Alle hverdager (mandag til fredag)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -460,4 +460,7 @@ export const plPL = {
   'Last refreshed': 'Ostatnio odświeżono',
   'Google Drive disconnected': 'Dysk Google odłączony',
   'Google Drive disconnected — reconnect to resume sync': 'Dysk Google rozłączony — połącz ponownie, aby wznowić synchronizację',
+  'Ad hoc': 'Doraźnie',
+  Time: 'Czas',
+  'All weekdays (Monday to Friday)': 'Wszystkie dni powszednie (od poniedziałku do piątku)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -460,4 +460,7 @@ export const ptBR = {
   'Last refreshed': 'Última atualização',
   'Google Drive disconnected': 'Google Drive desconectado',
   'Google Drive disconnected — reconnect to resume sync': 'O Google Drive foi desconectado — reconecte para retomar a sincronização.',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Tempo',
+  'All weekdays (Monday to Friday)': 'Todos os dias da semana (de segunda a sexta-feira)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -460,4 +460,7 @@ export const ptPT = {
   'Last refreshed': 'Última atualização',
   'Google Drive disconnected': 'Google Drive desconectado',
   'Google Drive disconnected — reconnect to resume sync': 'O Google Drive foi desconectado — reconecte para retomar a sincronização.',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Tempo',
+  'All weekdays (Monday to Friday)': 'Todos os dias da semana (de segunda a sexta-feira)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -460,4 +460,7 @@ export const roRO = {
   'Last refreshed': 'Ultima actualizare',
   'Google Drive disconnected': 'Google Drive deconectat',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive deconectat — reconectați-vă pentru a relua sincronizarea',
+  'Ad hoc': 'Ad-hoc',
+  Time: 'Timp',
+  'All weekdays (Monday to Friday)': 'Toate zilele lucrătoare (luni până vineri)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -460,4 +460,7 @@ export const skSK = {
   'Last refreshed': 'Naposledy obnovené',
   'Google Drive disconnected': 'Disk Google sa odpojil',
   'Google Drive disconnected — reconnect to resume sync': 'Disk Google odpojený – znova pripojte, aby ste obnovili synchronizáciu',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Čas',
+  'All weekdays (Monday to Friday)': 'Všetky pracovné dni (pondelok až piatok)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -460,4 +460,7 @@ export const slSL = {
   'Last refreshed': 'Nazadnje osveženo',
   'Google Drive disconnected': 'Google Drive prekinjen',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive prekinjen – znova vzpostavite povezavo za nadaljevanje sinhronizacije',
+  'Ad hoc': 'Ad hoc',
+  Time: 'Čas',
+  'All weekdays (Monday to Friday)': 'Vse delavnike (od ponedeljka do petka)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -462,4 +462,5 @@ export const svSE = {
   'Last refreshed': 'Senast uppdaterad',
   'Google Drive disconnected': 'Google Drive frånkopplad',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive frånkopplad — återanslut för att återuppta synkroniseringen',
+  'All weekdays (Monday to Friday)': 'Alla vardagar (måndag till fredag)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -460,4 +460,7 @@ export const ukUA = {
   'Last refreshed': 'Останнє оновлення',
   'Google Drive disconnected': 'Google Диск відключено',
   'Google Drive disconnected — reconnect to resume sync': 'Диск Google відключено — підключіть його, щоб відновити синхронізацію',
+  'Ad hoc': 'Спеціально',
+  Time: 'Час',
+  'All weekdays (Monday to Friday)': 'Усі будні (з понеділка по п&#39;ятницю)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
@@ -3,6 +3,7 @@ export type CalendarRepeatRule =
   | 'daily'
   | 'weeklyOne'
   | 'weeklyAll'
+  | 'weekdays'
   | 'monthlyDom'
   | 'yearlyOne'
   | 'custom';

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
@@ -268,11 +268,6 @@ export class CalendarRepeatService {
         meta: {kind: 'weeklyOne', weekday, endMode: 'never'},
       },
       {
-        value: 'weeklyAll',
-        label: this.translate.instant('Every weekday'),
-        meta: {kind: 'weeklyAll', endMode: 'never'},
-      },
-      {
         value: 'monthlyDom',
         label: this.translate.instant('Monthly on day {{day}}', {day: dom}),
         meta: {kind: 'monthlyDom', dom, endMode: 'never'},
@@ -281,6 +276,11 @@ export class CalendarRepeatService {
         value: 'yearlyOne',
         label: this.translate.instant('Yearly on {{day}} {{month}}', {day: dom, month: monthName}),
         meta: {kind: 'yearlyOne', dom, month, endMode: 'never'},
+      },
+      {
+        value: 'weekdays',
+        label: this.translate.instant('All weekdays (Monday to Friday)'),
+        meta: {kind: 'weeklyMulti', weekdays: [1, 2, 3, 4, 5], endMode: 'never'},
       },
     ];
 
@@ -340,6 +340,16 @@ export class CalendarRepeatService {
           return isWeekly
             ? this.translate.instant('Weekly on all days')
             : this.translate.instant('Every {{n}} weeks: all days', {n});
+        }
+
+        // Recognise the Mon-Fri (1..5) shorthand so the customCurrent label
+        // matches the "All weekdays (Monday to Friday)" dropdown option a
+        // user picked, rather than expanding to the full weekday list.
+        const isMonFriOnly = isWeekly
+          && sortedDays.length === 5
+          && sortedDays[0] === 1 && sortedDays[4] === 5;
+        if (isMonFriOnly) {
+          return this.translate.instant('All weekdays (Monday to Friday)');
         }
 
         const days = this.formatWeekdayList(sortedDays, locale);
@@ -501,15 +511,7 @@ export class CalendarRepeatService {
    * rather than collapsing to "all days".
    */
   reconstructMetaFromTask(task: CalendarTaskModel): CalendarRepeatMeta | null {
-    // Cast to string so the switch can include `'weekdays'` even though it
-    // isn't currently in the CalendarRepeatRule union — the backend may
-    // start emitting it once the controller maps RepeatType=5 explicitly,
-    // and the helper stays forward-compatible.
-    // Cast to string so the switch can include `'weekdays'` even though it
-    // isn't currently in the CalendarRepeatRule union — the backend may
-    // start emitting it once the controller maps RepeatType=5 explicitly,
-    // and the helper stays forward-compatible.
-    const r = task.repeatRule as string | undefined;
+    const r = task.repeatRule;
     // Defensive coalesce: backend should never send 0 or negative, but guard
     // anyway so a bogus value doesn't cascade into an iterator with step=0.
     const n = (task.repeatEvery ?? 0) > 0 ? task.repeatEvery! : 1;
@@ -568,7 +570,11 @@ export class CalendarRepeatService {
       case 'weeklyAll':
         // Same promotion path: CSV wins if present.
         if (csvDays.length > 0) return weeklyFromCsv();
-        return {kind: n === 1 ? 'weeklyAll' : 'everyNWeekAll', n, endMode, afterCount, untilTs};
+        // Legacy weeklyAll (every week, all 7 days) is functionally identical to
+        // daily, so display as daily. The everyNWeekAll case (step > 1) is NOT
+        // equivalent to "every N days" and falls through to Custom on display.
+        if (n === 1) return {kind: 'daily', n: 1, endMode, afterCount, untilTs};
+        return {kind: 'everyNWeekAll', n, endMode, afterCount, untilTs};
 
       case 'weekdays':
         // Mon-Fri. Map to weeklyMulti so the formatter renders the explicit list


### PR DESCRIPTION
## Summary
Phase 2A of aligning the calendar recurrence dropdown with the design mockup.

The dropdown's `weeklyAll` option was labelled "Every weekday" / "Hver hverdag" but actually repeated all 7 days of the week (functionally identical to "Daily"). The design asks for a real Mon–Fri option; the backend already supports it via `RepeatType=5`.

## Changes
- **Dropdown**: `weeklyAll` option removed; new `weekdays` option added after `yearlyOne` (matching design order), backed by `RepeatType=5` with no CSV
- **Reconstruction**: legacy `weeklyAll(n=1)` data now maps to `daily` (functionally equivalent); `everyNWeekAll(n>1)` still falls through to Custom
- **Label round-trip**: `formatCustomRepeatLabel` recognises the Mon–Fri (1..5) shorthand so reopening a `weekdays` task displays "All weekdays (Monday to Friday)" instead of expanding to "Weekly every Monday, Tuesday, Wednesday, Thursday and Friday"
- **Type**: `'weekdays'` added to `CalendarRepeatRule` union; cast-to-string workaround removed
- **i18n**: new `'All weekdays (Monday to Friday)'` key added to `enUS` and `da` (`Alle hverdage (mandag til fredag)`); `translateTsFiles.py` auto-propagated to all other locales. `'Every weekday'` key preserved (may still be referenced)
- **Cleanup**: duplicate comment block removed in `reconstructMetaFromTask`

## Test plan
- [ ] Open create-event modal in Danish — `Alle hverdage (mandag til fredag)` appears in the dropdown after `Årligt`
- [ ] Pick the option, save, reopen — dropdown shows the same `Alle hverdage…` label
- [ ] Verify saved event fires on Mon–Fri only
- [ ] Open a legacy event saved with the old "Every weekday" (all-7) rule — dropdown shows `Dagligt` (the equivalent option)
- [ ] Custom-repeat modal still functions normally (it formats arbitrary multi-day rules)

## Out of scope
Phase 2B (Monthly day-of-month → Nth weekday-of-month) is deferred.

Generated with [Claude Code](https://claude.com/claude-code)