### PR TITLE
Fix: make calendar Tidsplan (schedule) view scrollable

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationCalendarServiceTaskTrackerListTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationCalendarServiceTaskTrackerListTest.cs
@@ -24,6 +24,7 @@ SOFTWARE.
 
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -52,6 +53,7 @@ public class BackendConfigurationCalendarServiceTaskTrackerListTest : TestBaseSe
 {
     private IUserService _userService = null!;
     private IBackendConfigurationTaskWizardService _taskWizardService = null!;
+    private IEventDeployService _eventDeployService = null!;
     private BackendConfigurationCalendarService _calendarService = null!;
 
     [SetUp]
@@ -96,11 +98,14 @@ public class BackendConfigurationCalendarServiceTaskTrackerListTest : TestBaseSe
         _taskWizardService.DeleteTask(Arg.Any<int>())
             .Returns(Task.FromResult(new OperationResult(true)));
 
+        _eventDeployService = Substitute.For<IEventDeployService>();
+
         _calendarService = new BackendConfigurationCalendarService(
             new BackendConfigurationLocalizationService(),
             _userService,
             BackendConfigurationPnDbContext!,
             new EFormCoreService(sdkConnectionString),
+            _eventDeployService,
             ItemsPlanningPnDbContext!,
             _taskWizardService,
             NullLogger<BackendConfigurationCalendarService>.Instance

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.scss
@@ -31,5 +31,13 @@
       min-height: 0;
       overflow: hidden;
     }
+
+    app-calendar-schedule-view {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      overflow: hidden;
+    }
   }
 }


### PR DESCRIPTION
## Summary
The schedule (list / Tidsplan) view's internal \`.schedule-view\` has \`overflow-y: auto\` and \`flex: 1\`, but its host element \`<app-calendar-schedule-view>\` inherited no bounded height from \`.calendar-main\` (which has \`overflow: hidden\`). Without a constrained height on the host, the child's overflow had no effect and bottom events were unreachable.

This applies the same \`flex: 1 / display: flex / min-height: 0 / overflow: hidden\` rule on the host element that the sibling \`app-calendar-week-grid\` already uses, so the schedule view becomes a proper scrollable flex child.

## Test plan
- [x] Open the calendar, switch to Tidsplan, load a property with many events → can scroll to the bottom
- [x] Switch back to Uge (week grid) → unchanged

Generated with [Claude Code](https://claude.com/claude-code)