### PR TITLE
Fix: keep calendar events below sticky day-header on scroll

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationCalendarServiceTaskTrackerListTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationCalendarServiceTaskTrackerListTest.cs
@@ -24,6 +24,7 @@ SOFTWARE.
 
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -52,6 +53,7 @@ public class BackendConfigurationCalendarServiceTaskTrackerListTest : TestBaseSe
 {
     private IUserService _userService = null!;
     private IBackendConfigurationTaskWizardService _taskWizardService = null!;
+    private IEventDeployService _eventDeployService = null!;
     private BackendConfigurationCalendarService _calendarService = null!;
 
     [SetUp]
@@ -96,11 +98,14 @@ public class BackendConfigurationCalendarServiceTaskTrackerListTest : TestBaseSe
         _taskWizardService.DeleteTask(Arg.Any<int>())
             .Returns(Task.FromResult(new OperationResult(true)));
 
+        _eventDeployService = Substitute.For<IEventDeployService>();
+
         _calendarService = new BackendConfigurationCalendarService(
             new BackendConfigurationLocalizationService(),
             _userService,
             BackendConfigurationPnDbContext!,
             new EFormCoreService(sdkConnectionString),
+            _eventDeployService,
             ItemsPlanningPnDbContext!,
             _taskWizardService,
             NullLogger<BackendConfigurationCalendarService>.Instance

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
@@ -130,15 +130,16 @@
     overflow: visible !important;
   }
 
-  // z-index 11 wins over task blocks (z 2/3), the now-line current-time
-  // indicator (z 10), and the all-day chips. Drag-ghost-task (z 20) still
-  // draws on top so a moving event doesn't disappear under the header.
-  // The top-left corner cell (time-axis header) sticky-stacks at z 100
-  // via Material's .mat-mdc-table-sticky class.
+  // z-index 50 sits well above the overlapping-events stacking range
+  // (events get `_zIndex = 10 + i` per the calendar-layout service; conflict
+  // groups of 2+ would otherwise land at 11/12/13 and bleed through the
+  // header). Drag-ghost-task (z 100) still draws on top so a moving event
+  // doesn't disappear under the header. The top-left corner cell (time-axis
+  // header) sticky-stacks at z 100 via Material's .mat-mdc-table-sticky.
   .mat-mdc-header-row {
     position: sticky;
     top: 0;
-    z-index: 11;
+    z-index: 50;
     background: var(--md-surface-container);
     box-shadow: 0 1px 0 var(--border, #e0e0e0);
   }
@@ -250,7 +251,7 @@
   padding: 2px 4px;
   opacity: 0.55;
   pointer-events: none;
-  z-index: 20;
+  z-index: 100;
   color: white;
   font-size: 12px;
   overflow: hidden;


### PR DESCRIPTION
## Summary
Overlapping events get \`_zIndex = 10 + i\` (where \`i\` is the position in the conflict group) from the calendar-layout service. The sticky day-header row was at \`z-index: 11\`, so any conflict group with 2+ events had at least one tile at \`z >= 11\` and would bleed through the header when the user scrolled down.

This bumps the header to \`z 50\` (well above realistic event stacks — up to ~40 overlapping events before they reach it) and the drag-ghost to \`z 100\` so a dragged tile still floats over the header during cross-row drags. Past-slot, now-line, time-axis labels, and resize handles are unchanged.

## Test plan
- [x] Scroll down in week view with 2+ overlapping events → events disappear cleanly under the day-header row
- [x] Drag an event vertically across many rows → drag-ghost remains visible over the header
- [x] Now-line, past-slot, time labels render unchanged

Generated with [Claude Code](https://claude.com/claude-code)