### PR TITLE
Fix: refresh eForm dropdown each time the calendar event modal opens

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -2,7 +2,7 @@ import {Component, Injector, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {Overlay, OverlayRef, ConnectedPosition} from '@angular/cdk/overlay';
 import {ComponentPortal} from '@angular/cdk/portal';
 import {Router} from '@angular/router';
-import {Subject} from 'rxjs';
+import {BehaviorSubject, Observable, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {Store} from '@ngrx/store';
 import {selectCurrentUserIsAdmin} from 'src/app/state/auth/auth.selector';
@@ -55,7 +55,8 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
   tasksByDay: CalendarTaskLayoutModel[][] = Array.from({length: 7}, () => []);
   allDayTasksByDay: CalendarTaskModel[][] = Array.from({length: 7}, () => []);
 
-  eforms: {id: number; label: string}[] = [];
+  private eformsSubject = new BehaviorSubject<{id: number; label: string}[]>([]);
+  eforms$: Observable<{id: number; label: string}[]> = this.eformsSubject.asObservable();
   logboegerFolderId: number | null = null;
 
   get tagNames(): string[] { return this.tags.map(t => t.name); }
@@ -136,7 +137,7 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
     req.pageSize = 1000;
     this.eformService.getAll(req).subscribe(res => {
       if (res && res.success && res.model) {
-        this.eforms = res.model.templates.map(t => ({id: t.id, label: t.label}));
+        this.eformsSubject.next(res.model.templates.map(t => ({id: t.id, label: t.label})));
       }
     });
   }
@@ -317,6 +318,8 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       this.createOverlayRef = null;
     }
 
+    this.loadEforms();
+
     const positions = this.buildPopoverPositions(event.cellLeft, event.cellRight);
     const anchorX = this.pickAnchorX(event.cellLeft, event.cellRight);
 
@@ -346,7 +349,7 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       tags: this.tags.map(t => t.name),
       propertyId: this.currentPropertyId!,
       properties: this.properties,
-      eforms: this.eforms,
+      eforms: this.eforms$,
       folderId: this.logboegerFolderId,
       planningTags: this.tags.map(t => ({id: t.id, name: t.name})),
     };
@@ -666,6 +669,8 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       this.createOverlayRef = null;
     }
 
+    this.loadEforms();
+
     const positions = this.buildPopoverPositions(event.cellLeft, event.cellRight);
     const anchorX = this.pickAnchorX(event.cellLeft, event.cellRight);
 
@@ -695,7 +700,7 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       tags: this.tags.map(t => t.name),
       propertyId: task.propertyId,
       properties: this.properties,
-      eforms: this.eforms,
+      eforms: this.eforms$,
       folderId: this.logboegerFolderId,
       planningTags: this.tags.map(t => ({id: t.id, name: t.name})),
     };
@@ -735,6 +740,8 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       this.createOverlayRef = null;
     }
 
+    this.loadEforms();
+
     const positions = this.buildPopoverPositions(event.cellLeft, event.cellRight);
     const anchorX = this.pickAnchorX(event.cellLeft, event.cellRight);
 
@@ -765,7 +772,7 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       tags: this.tags.map(t => t.name),
       propertyId: sourceTask.propertyId,
       properties: this.properties,
-      eforms: this.eforms,
+      eforms: this.eforms$,
       folderId: this.logboegerFolderId,
       planningTags: this.tags.map(t => ({id: t.id, name: t.name})),
     };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
@@ -186,7 +186,7 @@
           <mtx-select
             id="calendarEventEform"
             [formControl]="eformControl"
-            [items]="data.eforms"
+            [items]="data.eforms | async"
             bindValue="id"
             bindLabel="label"
             [clearable]="false"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -33,7 +33,7 @@ import {CustomRepeatModalComponent} from '../custom-repeat-modal/custom-repeat-m
 import {RepeatScopeModalComponent} from '../repeat-scope-modal/repeat-scope-modal.component';
 import {TranslateService} from '@ngx-translate/core';
 import {ToastrService} from 'ngx-toastr';
-import {firstValueFrom, of} from 'rxjs';
+import {firstValueFrom, Observable, of} from 'rxjs';
 import {switchMap, take} from 'rxjs/operators';
 import {OperationDataResult} from 'src/app/common/models';
 
@@ -47,7 +47,7 @@ export interface TaskCreateEditModalData {
   tags: string[];
   propertyId: number;
   properties: CommonDictionaryModel[];
-  eforms: {id: number; label: string}[];
+  eforms: Observable<{id: number; label: string}[]>;
   folderId: number | null;
   planningTags: {id: number; name: string}[];
   sourceTask?: CalendarTaskModel | null;  // present in copy mode
@@ -290,8 +290,11 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
         : null;
       const initialBoard = sidebarSelected ?? fallbackBoard;
       this.boardControl.setValue(initialBoard?.id ?? null);
-      const kvittering = this.data.eforms?.find(e => e.label === 'Kvittering');
-      this.eformControl.setValue(kvittering?.id ?? this.data.eforms?.[0]?.id ?? null);
+      // take(1): seed default once; later refresh emissions must not overwrite the user's selection.
+      this.data.eforms.pipe(take(1)).subscribe(list => {
+        const kvittering = list.find(e => e.label === 'Kvittering');
+        this.eformControl.setValue(kvittering?.id ?? list[0]?.id ?? null);
+      });
     }
 
     // Disable all controls for past tasks


### PR DESCRIPTION
## Summary

- Backend-configuration calendar's event create/edit/copy modal cached the eForm list at page load and never refreshed, so newly created eForms only appeared after a hard page reload.
- Container now exposes the eForm list as a `BehaviorSubject<{id; label}[]>` and calls `loadEforms()` at the top of `openCreateModal` / `openEditModal` / `openCopyModal`.
- Modal binds via `data.eforms | async` and seeds the create-mode default ("Kvittering" or first) with `pipe(take(1))` so refresh emissions can update the items list without overriding the user's later selection.
- `mtx-select`'s `bindValue="id"` keeps the selected id stable across the swap.
- No backend / SDK / NgRx changes — confirmed `EFormService.Index` has no date filter and `DbContextHelper.GetDbContext()` returns a fresh `MicrotingDbContext` per request, ruling out server-side filtering and EF Core change-tracking caching.

## Test plan

- [x] Open `/plugins/backend-configuration-pn/calendar`, click an empty cell — dropdown lists current eForms, defaults to "Kvittering"
- [x] Create a new eForm in another tab via `/plugins/eform-pn/eforms`; return to the calendar tab **without reloading**, open a create-event modal — new eForm appears
- [x] Open an existing event — dropdown still shows previously saved eForm
- [x] Copy an existing event — copy modal carries the source's eForm forward
- [x] DevTools Network — `POST /api/templates/index` fires on page load **and** on each modal open

🤖 Generated with [Claude Code](https://claude.com/claude-code)