### PR TITLE
Feat: expose Aktiv + Vis overskredet toggles on calendar event modal

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
@@ -26,6 +26,8 @@ public class CalendarTaskResponseModel
     public int? RepeatOrdinalWeek { get; set; }
     public string? RepeatWeekdaysCsv { get; set; }
     public bool Completed { get; set; }
+    public bool Status { get; set; }
+    public bool ComplianceEnabled { get; set; }
     public int PropertyId { get; set; }
     public int? ComplianceId { get; set; }
     public bool IsFromCompliance { get; set; }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -282,10 +282,11 @@ public class BackendConfigurationCalendarService(
             var compliancePlanningIdsInWeek = new HashSet<int>(
                 compliancesForDedup.Select(c => c.PlanningId));
 
-            // 1. Query AreaRulePlannings (future/active tasks)
+            // 1. Query AreaRulePlannings (future/active and inactive tasks).
+            // Inactive (Status=false) plannings are included so the calendar can
+            // render them dimmed; the frontend keys the dim style off Status.
             var areaRulePlannings = await backendConfigurationPnDbContext.AreaRulePlannings
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-                .Where(x => x.Status)
                 .Where(x => x.PropertyId == requestModel.PropertyId)
                 .Include(x => x.AreaRule)
                     .ThenInclude(x => x.AreaRuleTranslations)
@@ -454,6 +455,8 @@ public class BackendConfigurationCalendarService(
                         RepeatOrdinalWeek = arp.RepeatOrdinalWeek,
                         RepeatWeekdaysCsv = arp.RepeatWeekdaysCsv,
                         Completed = false,
+                        Status = arp.Status,
+                        ComplianceEnabled = arp.ComplianceEnabled,
                         PropertyId = arp.PropertyId,
                         IsFromCompliance = false,
                         NextExecutionTime = planning.NextExecutionTime,
@@ -532,6 +535,8 @@ public class BackendConfigurationCalendarService(
                             RepeatOrdinalWeek = arp.RepeatOrdinalWeek,
                             RepeatWeekdaysCsv = arp.RepeatWeekdaysCsv,
                             Completed = false,
+                            Status = arp.Status,
+                            ComplianceEnabled = arp.ComplianceEnabled,
                             PropertyId = arp.PropertyId,
                             IsFromCompliance = false,
                             NextExecutionTime = planning.NextExecutionTime,
@@ -606,6 +611,8 @@ public class BackendConfigurationCalendarService(
                     RepeatOrdinalWeek = arp.RepeatOrdinalWeek,
                     RepeatWeekdaysCsv = arp.RepeatWeekdaysCsv,
                     Completed = false,
+                    Status = arp.Status,
+                    ComplianceEnabled = arp.ComplianceEnabled,
                     PropertyId = arp.PropertyId,
                     IsFromCompliance = false,
                     NextExecutionTime = movedPlanning.NextExecutionTime,
@@ -648,10 +655,10 @@ public class BackendConfigurationCalendarService(
                 .ToDictionaryAsync(x => x.AreaRulePlanningId);
 
             // Top up exceptionsByArp with any exceptions for compliance ARPs not
-            // already covered. The earlier exceptionsInWeek query (line ~210) filtered
-            // by arpIds — which are only Status=true plannings. Compliance rows can
-            // exist for Status=false plannings too, and their move/resize exceptions
-            // must reach the compliance loop below.
+            // already covered. arpIds now contains all non-Removed plannings
+            // (Status filter dropped at line 288); this top-up therefore only
+            // fires for compliance rows whose ARP has WorkflowState=Removed —
+            // a narrow edge case kept for safety.
             var complianceOnlyArpIds = complianceArpIds.Except(arpIds).ToList();
             if (complianceOnlyArpIds.Count > 0)
             {
@@ -796,6 +803,10 @@ public class BackendConfigurationCalendarService(
                     RepeatOrdinalWeek = arp?.RepeatOrdinalWeek,
                     RepeatWeekdaysCsv = arp?.RepeatWeekdaysCsv,
                     Completed = complianceCompleted,
+                    // Orphan compliance rows (no live ARP) render as dimmed
+                    // inactive — visually distinct from a healthy active row.
+                    Status = arp?.Status ?? false,
+                    ComplianceEnabled = arp?.ComplianceEnabled ?? false,
                     PropertyId = compliance.PropertyId,
                     ComplianceId = compliance.Id,
                     IsFromCompliance = true,
@@ -843,9 +854,9 @@ public class BackendConfigurationCalendarService(
 
             // Validate: at least one worker must be assigned. Events without
             // an assignee would be downgraded to NotActive by task-wizard and
-            // vanish from the calendar view (GetTasksForWeek filters Status),
-            // so creation is rejected here with a clear error rather than
-            // silently producing an invisible event.
+            // render as a dimmed inactive task with no one to perform it.
+            // Reject here with a clear error rather than silently creating
+            // an orphan event.
             if (createModel.Sites is null || createModel.Sites.Count == 0)
             {
                 return new OperationDataResult<int>(false,
@@ -976,8 +987,9 @@ public class BackendConfigurationCalendarService(
             }
 
             // Validate: at least one worker must remain assigned. Clearing
-            // assignees would downgrade the task to NotActive and hide it
-            // from the calendar view (same as the Create path).
+            // assignees would downgrade the task to NotActive (same as the
+            // Create path); reject rather than silently producing an
+            // inactive task with no one to perform it.
             if (updateModel.Sites is null || updateModel.Sites.Count == 0)
             {
                 return new OperationResult(false,
@@ -3105,12 +3117,10 @@ public class BackendConfigurationCalendarService(
                 // Per-row Completed + TaskIsExpired derivation. Predicate
                 // matches the spec: completed = Case.Status==100;
                 // task_is_expired = (Case.WorkflowState=Removed AND
-                // Status=77) OR (compliance.Deadline.Date < UtcNow.Date AND
-                // Status != 100). Date-only so an event scheduled for today
-                // is not flagged expired once its time-of-day passes.
-                // Recurrence-only or missing-Case rows fall back to the
-                // deadline-only check (no Status to consult, so they are
-                // treated as not-completed).
+                // Status=77) OR (compliance.Deadline < UtcNow AND
+                // Status != 100). Recurrence-only or missing-Case rows fall
+                // back to the deadline-only check (no Status to consult, so
+                // they are treated as not-completed).
                 bool completed = false;
                 bool taskIsExpired;
                 if (compliance.MicrotingSdkCaseId > 0
@@ -3120,13 +3130,13 @@ public class BackendConfigurationCalendarService(
                     completed = sdkCase.Status == 100;
                     var retracted = sdkCase.WorkflowState == Constants.WorkflowStates.Removed
                                     && sdkCase.Status == 77;
-                    var pastDueIncomplete = compliance.Deadline.Date < dateTimeNow.Date
+                    var pastDueIncomplete = compliance.Deadline < dateTimeNow
                                             && sdkCase.Status != 100;
                     taskIsExpired = retracted || pastDueIncomplete;
                 }
                 else
                 {
-                    taskIsExpired = compliance.Deadline.Date < dateTimeNow.Date;
+                    taskIsExpired = compliance.Deadline < dateTimeNow;
                 }
 
                 var model = new CalendarTaskResponseModel
@@ -3153,6 +3163,8 @@ public class BackendConfigurationCalendarService(
                     RepeatOrdinalWeek = arp?.RepeatOrdinalWeek,
                     RepeatWeekdaysCsv = arp?.RepeatWeekdaysCsv,
                     Completed = completed,
+                    Status = arp?.Status ?? false,
+                    ComplianceEnabled = arp?.ComplianceEnabled ?? false,
                     PropertyId = compliance.PropertyId,
                     ComplianceId = compliance.Id,
                     IsFromCompliance = true,

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -3117,10 +3117,12 @@ public class BackendConfigurationCalendarService(
                 // Per-row Completed + TaskIsExpired derivation. Predicate
                 // matches the spec: completed = Case.Status==100;
                 // task_is_expired = (Case.WorkflowState=Removed AND
-                // Status=77) OR (compliance.Deadline < UtcNow AND
-                // Status != 100). Recurrence-only or missing-Case rows fall
-                // back to the deadline-only check (no Status to consult, so
-                // they are treated as not-completed).
+                // Status=77) OR (compliance.Deadline.Date < UtcNow.Date AND
+                // Status != 100). Date-only so an event scheduled for today
+                // is not flagged expired once its time-of-day passes.
+                // Recurrence-only or missing-Case rows fall back to the
+                // deadline-only check (no Status to consult, so they are
+                // treated as not-completed).
                 bool completed = false;
                 bool taskIsExpired;
                 if (compliance.MicrotingSdkCaseId > 0
@@ -3130,13 +3132,13 @@ public class BackendConfigurationCalendarService(
                     completed = sdkCase.Status == 100;
                     var retracted = sdkCase.WorkflowState == Constants.WorkflowStates.Removed
                                     && sdkCase.Status == 77;
-                    var pastDueIncomplete = compliance.Deadline < dateTimeNow
+                    var pastDueIncomplete = compliance.Deadline.Date < dateTimeNow.Date
                                             && sdkCase.Status != 100;
                     taskIsExpired = retracted || pastDueIncomplete;
                 }
                 else
                 {
-                    taskIsExpired = compliance.Deadline < dateTimeNow;
+                    taskIsExpired = compliance.Deadline.Date < dateTimeNow.Date;
                 }
 
                 var model = new CalendarTaskResponseModel

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -465,4 +465,8 @@ export const bgBG = {
   'All weekdays (Monday to Friday)': 'Всички делнични дни (от понеделник до петък)',
   'Monthly on the {{ordinal}} {{day}}': 'Месечно на {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'На всеки {{n}} месеца на {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Задачата е видима на борда и се показва в приложението',
+  'Task dimmed on board and not shown in app': 'Задачата е затъмнена на таблото и не се показва в приложението',
+  'Overdue task shown in app': 'Просрочена задача, показана в приложението',
+  'Overdue task not shown in app': 'Просрочената задача не се показва в приложението',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -465,4 +465,8 @@ export const csCZ = {
   'All weekdays (Monday to Friday)': 'Všechny všední dny (pondělí až pátek)',
   'Monthly on the {{ordinal}} {{day}}': 'Měsíčně v {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Každých {{n}} měsíců v {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Úkol viditelný na palubě a zobrazený v aplikaci',
+  'Task dimmed on board and not shown in app': 'Úkol je na tabuli zobrazen šedě a v aplikaci se nezobrazuje',
+  'Overdue task shown in app': 'V aplikaci se zobrazuje po termínu úkol',
+  'Overdue task not shown in app': 'Zpožděný úkol se v aplikaci nezobrazuje',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -466,4 +466,8 @@ export const da = {
   'Last refreshed': 'Sidst opdateret',
   'Google Drive disconnected': 'Google Drive afbrudt',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive afbrudt – genopret forbindelse for at genoptage synkronisering',
+  'Task visible on board and shown in app': 'Opgave synlig på tavlen og vist i appen',
+  'Task dimmed on board and not shown in app': 'Opgaven er nedtonet på tavlen og vises ikke i appen',
+  'Overdue task shown in app': 'Forfalden opgave vist i appen',
+  'Overdue task not shown in app': 'Forfalden opgave vises ikke i appen',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -519,4 +519,8 @@ export const deDE = {
   'All weekdays (Monday to Friday)': 'An allen Wochentagen (Montag bis Freitag)',
   'Monthly on the {{ordinal}} {{day}}': 'Monatlich am {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Alle {{n}} Monate am {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Aufgabe auf dem Board sichtbar und in der App angezeigt',
+  'Task dimmed on board and not shown in app': 'Die Aufgabe wird auf dem Board ausgegraut und in der App nicht angezeigt.',
+  'Overdue task shown in app': 'Überfällige Aufgabe wird in der App angezeigt',
+  'Overdue task not shown in app': 'Überfällige Aufgabe wird in der App nicht angezeigt.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -465,4 +465,8 @@ export const elGR = {
   'All weekdays (Monday to Friday)': 'Όλες τις καθημερινές (Δευτέρα έως Παρασκευή)',
   'Monthly on the {{ordinal}} {{day}}': 'Μηνιαίως την {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Κάθε {{n}} μήνες την {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Η εργασία είναι ορατή στον πίνακα και εμφανίζεται στην εφαρμογή',
+  'Task dimmed on board and not shown in app': 'Η εργασία είναι απενεργοποιημένη στην πλακέτα και δεν εμφανίζεται στην εφαρμογή',
+  'Overdue task shown in app': 'Η εκπρόθεσμη εργασία εμφανίζεται στην εφαρμογή',
+  'Overdue task not shown in app': 'Η εκπρόθεσμη εργασία δεν εμφανίζεται στην εφαρμογή.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -484,4 +484,8 @@ export const enUS= {
   'Last used': 'Last used',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive disconnected — reconnect to resume sync',
   'Last refreshed': 'Last refreshed',
+  'Task visible on board and shown in app': 'Task visible on board and shown in app',
+  'Task dimmed on board and not shown in app': 'Task dimmed on board and not shown in app',
+  'Overdue task shown in app': 'Overdue task shown in app',
+  'Overdue task not shown in app': 'Overdue task not shown in app',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -465,4 +465,8 @@ export const esES = {
   'All weekdays (Monday to Friday)': 'Todos los días laborables (de lunes a viernes)',
   'Monthly on the {{ordinal}} {{day}}': 'Mensualmente en el {{ordinal}} {{día}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Cada {{n}} meses en el {{ordinal}} {{día}}',
+  'Task visible on board and shown in app': 'La tarea es visible en el tablero y se muestra en la aplicación.',
+  'Task dimmed on board and not shown in app': 'La tarea aparece atenuada en el tablero y no se muestra en la aplicación.',
+  'Overdue task shown in app': 'Tarea vencida mostrada en la aplicación',
+  'Overdue task not shown in app': 'Las tareas vencidas no se muestran en la aplicación.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -465,4 +465,8 @@ export const etET = {
   'All weekdays (Monday to Friday)': 'Kõik nädalapäevad (esmaspäevast reedeni)',
   'Monthly on the {{ordinal}} {{day}}': 'Iga kuu {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Iga {{n}} kuu tagant {{ordinal}} {{day}}-l',
+  'Task visible on board and shown in app': 'Ülesanne on nähtav tahvlil ja rakenduses',
+  'Task dimmed on board and not shown in app': 'Ülesanne on tahvlil tuhm ja rakenduses seda ei kuvata',
+  'Overdue task shown in app': 'Rakenduses kuvatakse tähtaega ületanud ülesanne',
+  'Overdue task not shown in app': 'Rakenduses ei kuvata tähtaega ületanud ülesannet',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -465,4 +465,8 @@ export const fiFI = {
   'All weekdays (Monday to Friday)': 'Kaikki arkipäivät (maanantaista perjantaihin)',
   'Monthly on the {{ordinal}} {{day}}': 'Kuukausittain {{ordinal}} {{day}} -päivänä',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Joka {{n}} kuukausi {{ordinal}} {{day}} -päivänä',
+  'Task visible on board and shown in app': 'Tehtävä näkyy taululla ja sovelluksessa',
+  'Task dimmed on board and not shown in app': 'Tehtävä himmennettynä taululla eikä näy sovelluksessa',
+  'Overdue task shown in app': 'Myöhässä oleva tehtävä näkyy sovelluksessa',
+  'Overdue task not shown in app': 'Myöhässä oleva tehtävä ei näy sovelluksessa',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -464,4 +464,8 @@ export const frFR = {
   'All weekdays (Monday to Friday)': 'Tous les jours de la semaine (du lundi au vendredi)',
   'Monthly on the {{ordinal}} {{day}}': 'Mensuellement le {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Tous les {{n}} mois, le {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Tâche visible sur le tableau de bord et affichée dans l&#39;application',
+  'Task dimmed on board and not shown in app': 'Tâche désactivée sur le tableau de bord et non affichée dans l&#39;application',
+  'Overdue task shown in app': 'Tâche en retard affichée dans l&#39;application',
+  'Overdue task not shown in app': 'La tâche en retard n&#39;apparaît pas dans l&#39;application.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -465,4 +465,8 @@ export const hrHR = {
   'All weekdays (Monday to Friday)': 'Svi radni dani (od ponedjeljka do petka)',
   'Monthly on the {{ordinal}} {{day}}': 'Mjesečno na {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Svakih {{n}} mjeseci na {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Zadatak vidljiv na ploči i prikazan u aplikaciji',
+  'Task dimmed on board and not shown in app': 'Zadatak je zatamnjen na ploči i nije prikazan u aplikaciji',
+  'Overdue task shown in app': 'Zakašnjeli zadatak prikazan je u aplikaciji',
+  'Overdue task not shown in app': 'Zakašnjeli zadatak nije prikazan u aplikaciji',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -465,4 +465,8 @@ export const huHU = {
   'All weekdays (Monday to Friday)': 'Minden hétköznap (hétfőtől péntekig)',
   'Monthly on the {{ordinal}} {{day}}': 'Havonta a {{ordinal}} {{day}} napon',
   'Every {{n}} months on the {{ordinal}} {{day}}': '{{n}} havonta, a {{ordinal}} {{day}} napon',
+  'Task visible on board and shown in app': 'A feladat látható a táblán és az alkalmazásban is',
+  'Task dimmed on board and not shown in app': 'A feladat szürkén jelenik meg a táblán, és nem jelenik meg az alkalmazásban',
+  'Overdue task shown in app': 'Lejárt feladat látható az alkalmazásban',
+  'Overdue task not shown in app': 'A lejárt feladat nem jelenik meg az alkalmazásban',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -465,4 +465,8 @@ export const isIS = {
   'All weekdays (Monday to Friday)': 'Alla virka daga (mánudaga til föstudaga)',
   'Monthly on the {{ordinal}} {{day}}': 'Mánaðarlega á {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Á {{n}} mánaða fresti á {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Verkefni sýnilegt á borðinu og sýnt í appinu',
+  'Task dimmed on board and not shown in app': 'Verkefni dimmt á borðinu og birtist ekki í forritinu',
+  'Overdue task shown in app': 'Vanskilað verkefni birtist í appinu',
+  'Overdue task not shown in app': 'Vanskilaverkefni birtist ekki í appinu',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -465,4 +465,8 @@ export const itIT = {
   'All weekdays (Monday to Friday)': 'Tutti i giorni feriali (dal lunedì al venerdì)',
   'Monthly on the {{ordinal}} {{day}}': 'Mensilmente il {{ordinale}} {{giorno}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Ogni {{n}} mesi nel {{giorno}} ordinale',
+  'Task visible on board and shown in app': 'Attività visibile a bordo e mostrata nell&#39;app',
+  'Task dimmed on board and not shown in app': 'Attività disattivata sulla scheda e non visualizzata nell&#39;app',
+  'Overdue task shown in app': 'Attività scadute visualizzate nell&#39;app',
+  'Overdue task not shown in app': 'Attività scadute non visualizzate nell&#39;app',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -465,4 +465,8 @@ export const ltLT = {
   'All weekdays (Monday to Friday)': 'Visomis darbo dienomis (nuo pirmadienio iki penktadienio)',
   'Monthly on the {{ordinal}} {{day}}': 'Kas mėnesį {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Kas {{n}} mėnesius {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Užduotis matoma lentoje ir rodoma programėlėje',
+  'Task dimmed on board and not shown in app': 'Užduotis lentoje rodoma blankiai ir nerodoma programėlėje',
+  'Overdue task shown in app': 'Programėlėje rodoma vėluojanti užduotis',
+  'Overdue task not shown in app': 'Uždelsta užduotis nerodoma programėlėje',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -465,4 +465,8 @@ export const lvLV = {
   'All weekdays (Monday to Friday)': 'Visas darba dienas (no pirmdienas līdz piektdienai)',
   'Monthly on the {{ordinal}} {{day}}': 'Katru mēnesi {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Ik pēc {{n}} mēnešiem {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Uzdevums ir redzams uz tāfeles un lietotnē',
+  'Task dimmed on board and not shown in app': 'Uzdevums ir aptumšots uz tāfeles un netiek rādīts lietotnē',
+  'Overdue task shown in app': 'Nokavēts uzdevums tiek parādīts lietotnē',
+  'Overdue task not shown in app': 'Nokavēts uzdevums lietotnē netiek rādīts',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -465,4 +465,8 @@ export const nlNL = {
   'All weekdays (Monday to Friday)': 'Alle werkdagen (maandag tot en met vrijdag)',
   'Monthly on the {{ordinal}} {{day}}': 'Maandelijks op de {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Elke {{n}} maanden op de {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Taak zichtbaar op het bord en weergegeven in de app.',
+  'Task dimmed on board and not shown in app': 'Taak wordt op het bord weergegeven, maar niet in de app.',
+  'Overdue task shown in app': 'Achterstallige taak weergegeven in de app',
+  'Overdue task not shown in app': 'Achterstallige taak wordt niet weergegeven in de app.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -465,4 +465,8 @@ export const noNO = {
   'All weekdays (Monday to Friday)': 'Alle hverdager (mandag til fredag)',
   'Monthly on the {{ordinal}} {{day}}': 'Månedlig på den {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Hver {{n}} måned på den {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Oppgave synlig på tavlen og vist i appen',
+  'Task dimmed on board and not shown in app': 'Oppgaven er nedtonet på tavlen og vises ikke i appen',
+  'Overdue task shown in app': 'Forfalt oppgave vises i appen',
+  'Overdue task not shown in app': 'Forfalt oppgave vises ikke i appen',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -465,4 +465,8 @@ export const plPL = {
   'All weekdays (Monday to Friday)': 'Wszystkie dni powszednie (od poniedziałku do piątku)',
   'Monthly on the {{ordinal}} {{day}}': 'Miesięcznie w {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Co {{n}} miesięcy w {{porządkowym}} {{dniu}}',
+  'Task visible on board and shown in app': 'Zadanie widoczne na pokładzie i wyświetlane w aplikacji',
+  'Task dimmed on board and not shown in app': 'Zadanie jest przyciemnione na pokładzie i nie jest wyświetlane w aplikacji',
+  'Overdue task shown in app': 'Przeterminowane zadanie wyświetlane w aplikacji',
+  'Overdue task not shown in app': 'Przeterminowane zadanie nie jest wyświetlane w aplikacji',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -465,4 +465,8 @@ export const ptBR = {
   'All weekdays (Monday to Friday)': 'Todos os dias da semana (de segunda a sexta-feira)',
   'Monthly on the {{ordinal}} {{day}}': 'Mensalmente no {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'A cada {{n}} meses no {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Tarefa visível no quadro e exibida no aplicativo.',
+  'Task dimmed on board and not shown in app': 'A tarefa ficou esmaecida na tela e não é exibida no aplicativo.',
+  'Overdue task shown in app': 'Tarefa atrasada exibida no aplicativo',
+  'Overdue task not shown in app': 'Tarefa atrasada não exibida no aplicativo',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -465,4 +465,8 @@ export const ptPT = {
   'All weekdays (Monday to Friday)': 'Todos os dias da semana (de segunda a sexta-feira)',
   'Monthly on the {{ordinal}} {{day}}': 'Mensalmente no {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'A cada {{n}} meses no {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Tarefa visível no quadro e exibida no aplicativo.',
+  'Task dimmed on board and not shown in app': 'A tarefa ficou esmaecida na tela e não é exibida no aplicativo.',
+  'Overdue task shown in app': 'Tarefa atrasada exibida no aplicativo',
+  'Overdue task not shown in app': 'Tarefa atrasada não exibida no aplicativo',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -465,4 +465,8 @@ export const roRO = {
   'All weekdays (Monday to Friday)': 'Toate zilele lucrătoare (luni până vineri)',
   'Monthly on the {{ordinal}} {{day}}': 'Lunar în ziua {{ordinală}} {{zi}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'La fiecare {{n}} luni, în ziua {{ordinală}} {{zi}}',
+  'Task visible on board and shown in app': 'Sarcină vizibilă pe tablă și afișată în aplicație',
+  'Task dimmed on board and not shown in app': 'Sarcina este estompată pe tablă și nu este afișată în aplicație',
+  'Overdue task shown in app': 'Sarcina restantă este afișată în aplicație',
+  'Overdue task not shown in app': 'Sarcina restantă nu este afișată în aplicație',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -465,4 +465,8 @@ export const skSK = {
   'All weekdays (Monday to Friday)': 'Všetky pracovné dni (pondelok až piatok)',
   'Monthly on the {{ordinal}} {{day}}': 'Mesačne v {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Každých {{n}} mesiacov v {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Úloha viditeľná na palube a zobrazená v aplikácii',
+  'Task dimmed on board and not shown in app': 'Úloha je na tabuli zobrazená stmavená a nezobrazuje sa v aplikácii',
+  'Overdue task shown in app': 'V aplikácii sa zobrazuje oneskorená úloha',
+  'Overdue task not shown in app': 'Oneskorená úloha sa v aplikácii nezobrazuje',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -465,4 +465,8 @@ export const slSL = {
   'All weekdays (Monday to Friday)': 'Vse delavnike (od ponedeljka do petka)',
   'Monthly on the {{ordinal}} {{day}}': 'Mesečno na {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Vsakih {{n}} mesecev na {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Naloga je vidna na tabli in prikazana v aplikaciji',
+  'Task dimmed on board and not shown in app': 'Naloga je na tabli zatemnjena in ni prikazana v aplikaciji',
+  'Overdue task shown in app': 'Zamujena naloga prikazana v aplikaciji',
+  'Overdue task not shown in app': 'Zamujena naloga ni prikazana v aplikaciji',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -465,4 +465,8 @@ export const svSE = {
   'All weekdays (Monday to Friday)': 'Alla vardagar (måndag till fredag)',
   'Monthly on the {{ordinal}} {{day}}': 'Månadsvis på den {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Var {{n}} månad på den {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Uppgift synlig på tavlan och visas i appen',
+  'Task dimmed on board and not shown in app': 'Uppgiften är nedtonad på kortet och visas inte i appen',
+  'Overdue task shown in app': 'Försenad uppgift visas i appen',
+  'Overdue task not shown in app': 'Försenad uppgift visas inte i appen',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -465,4 +465,8 @@ export const ukUA = {
   'All weekdays (Monday to Friday)': 'Усі будні (з понеділка по п&#39;ятницю)',
   'Monthly on the {{ordinal}} {{day}}': 'Щомісяця {{ordinal}} {{day}}',
   'Every {{n}} months on the {{ordinal}} {{day}}': 'Кожні {{n}} місяців у {{ordinal}} {{day}}',
+  'Task visible on board and shown in app': 'Завдання відображається на дошці та в додатку',
+  'Task dimmed on board and not shown in app': 'Завдання затемнене на дошці та не відображається в додатку',
+  'Overdue task shown in app': 'Прострочене завдання відображається в додатку',
+  'Overdue task not shown in app': 'Прострочене завдання не відображається в додатку',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
@@ -26,6 +26,8 @@ export interface CalendarTaskModel {
   taskDate: string;          // ISO "YYYY-MM-DD"
   repeatSeriesId?: string;
   completed: boolean;
+  status: boolean;
+  complianceEnabled: boolean;
   driveLink?: string;
   propertyId: number;
   isFromCompliance?: boolean;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/calendar.module.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/calendar.module.ts
@@ -23,6 +23,7 @@ import {MatMenuModule} from '@angular/material/menu';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatRadioModule} from '@angular/material/radio';
 import {MatSelectModule} from '@angular/material/select';
+import {MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {MtxSelectModule} from '@ng-matero/extensions/select';
 import {MtxGridModule} from '@ng-matero/extensions/grid';
@@ -124,6 +125,7 @@ export {
     MatProgressSpinnerModule,
     MatRadioModule,
     MatSelectModule,
+    MatSlideToggleModule,
     MatTooltipModule,
     MtxSelectModule,
     MtxGridModule,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.html
@@ -1,6 +1,7 @@
 <div
   class="task-block"
   [class.completed]="task.completed"
+  [class.gcal-task--inactive]="!task.status"
   [class.resizing]="resizing"
   [class.raised]="raised"
   [style.top.px]="topPx"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
@@ -31,6 +31,11 @@
     text-decoration: line-through;
   }
 
+  &.gcal-task--inactive {
+    opacity: 0.45;
+    filter: grayscale(0.7);
+  }
+
   &.resizing {
     opacity: 0.85;
     cursor: ns-resize;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
@@ -347,6 +347,44 @@
     </div>
 
 
+    <!-- Active / inactive (paired view) -->
+    <div class="gcal-row">
+      <mat-icon class="gcal-icon">visibility</mat-icon>
+      <div class="gcal-row-content gcal-toggle-stack">
+        <mat-slide-toggle
+          id="calendarEventStatusActive"
+          [checked]="statusControl.value"
+          (change)="statusControl.setValue(true)">
+          {{ 'Task visible on board and shown in app' | translate }}
+        </mat-slide-toggle>
+        <mat-slide-toggle
+          id="calendarEventStatusInactive"
+          [checked]="!statusControl.value"
+          (change)="statusControl.setValue(false)">
+          {{ 'Task dimmed on board and not shown in app' | translate }}
+        </mat-slide-toggle>
+      </div>
+    </div>
+
+    <!-- Overdue visibility (paired view) -->
+    <div class="gcal-row">
+      <mat-icon class="gcal-icon">schedule</mat-icon>
+      <div class="gcal-row-content gcal-toggle-stack">
+        <mat-slide-toggle
+          id="calendarEventComplianceOn"
+          [checked]="complianceEnabledControl.value"
+          (change)="complianceEnabledControl.setValue(true)">
+          {{ 'Overdue task shown in app' | translate }}
+        </mat-slide-toggle>
+        <mat-slide-toggle
+          id="calendarEventComplianceOff"
+          [checked]="!complianceEnabledControl.value"
+          (change)="complianceEnabledControl.setValue(false)">
+          {{ 'Overdue task not shown in app' | translate }}
+        </mat-slide-toggle>
+      </div>
+    </div>
+
     <!-- Board row -->
     <div class="gcal-row" *ngIf="filteredBoards.length > 0">
       <mat-icon class="gcal-icon">calendar_today</mat-icon>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
@@ -103,6 +103,12 @@
   min-width: 0;
 }
 
+.gcal-toggle-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 // Date + Time row
 .gcal-datetime-row {
   display: flex;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -121,6 +121,8 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
   boardControl = new FormControl<number | null>(null);
   eformControl = new FormControl<number | null>(null);
   planningTagControl = new FormControl<number | null>(null);
+  statusControl = new FormControl<boolean>(true, {nonNullable: true});
+  complianceEnabledControl = new FormControl<boolean>(true, {nonNullable: true});
 
   constructor(
     @Optional() private dialogRef: MatDialogRef<TaskCreateEditModalComponent>,
@@ -244,6 +246,8 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
       this.propertyControl.setValue(task.propertyId ?? this.data.propertyId);
       this.eformControl.setValue(task['eformId'] ?? null);
       this.planningTagControl.setValue(task['itemPlanningTagId'] ?? null);
+      this.statusControl.setValue(task.status ?? true);
+      this.complianceEnabledControl.setValue(task.complianceEnabled ?? true);
       // Seed attachments from the task DTO. The backend mapper populates
       // `attachments` for every occurrence of a recurring rule (master-rule
       // scope) — copy mode intentionally does NOT carry attachments forward.
@@ -274,6 +278,8 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
       this.propertyControl.setValue(sourceTask.propertyId ?? this.data.propertyId);
       this.eformControl.setValue(sourceTask['eformId'] ?? null);
       this.planningTagControl.setValue(sourceTask['itemPlanningTagId'] ?? null);
+      this.statusControl.setValue(sourceTask.status ?? true);
+      this.complianceEnabledControl.setValue(sourceTask.complianceEnabled ?? true);
     } else {
       const startHour = this.data.startHour ?? 9;
       this.startTimeControl.setValue(this.hourToTimeStr(startHour));
@@ -316,6 +322,8 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
         this.boardControl.disable();
         this.eformControl.disable();
         this.planningTagControl.disable();
+        this.statusControl.disable();
+        this.complianceEnabledControl.disable();
       }
     }
 
@@ -706,8 +714,8 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
           ),
       driveLink: this.driveLinkControl.value ?? '',
       propertyId: this.propertyControl.value ?? this.data.propertyId,
-      status: 1,
-      complianceEnabled: true,
+      status: this.statusControl.value ? 1 : 2,
+      complianceEnabled: this.complianceEnabledControl.value,
       folderId: this.data.folderId,
       eformId: this.eformControl.value,
       itemPlanningTagId: this.planningTagControl.value,


### PR DESCRIPTION
## Summary

- Adds four labelled toggle rows (two mutually-exclusive pairs) to the calendar event modal so users can edit `AreaRulePlanning.Status` and `ComplianceEnabled` from the calendar without opening the task-wizard.
- Drops `.Where(x => x.Status)` in `GetTasksForWeek` — inactive plannings now appear on the tavle rendered dimmed (opacity 0.45 + grayscale 0.7) instead of disappearing entirely.
- Both toggles target the whole `AreaRulePlanning` series (same scope as the task-wizard). The existing planning-update helper handles the `CaseDelete` cascade on ON→OFF; OFF→ON only re-enables future occurrences (no retroactive redeploy).
- No DB migration. No destructive deletes — `Compliance` rows continue to be soft-deleted via `WorkflowState=Removed` when `ComplianceEnabled=false` + deadline passes.
- i18n: 4 new keys propagated to all 26 languages via `translateTsFiles.py`.
- Past-task readonly guard disables both new toggles to match the existing pattern.

## Behaviour table

| Status | ComplianceEnabled | Deadline state | Web calendar (tavle) | Mobile / tracker |
|---|---|---|---|---|
| true | true | any | normal | visible |
| true | false | future | normal | visible |
| true | false | past (overdue) | normal | compliance row soft-deleted → hidden |
| false | * | any | dimmed | not deployed; existing cases recalled |

## Test plan

- [x] Open an existing event → toggle pair reflects the task's current Status/ComplianceEnabled (matches the task-wizard for the same task).
- [x] Toggle A1→A2 → task block on calendar renders dimmed; task-wizard in another tab shows red "Ikke aktiv" badge; deployed case is recalled from mobile (existing helper cascade).
- [x] Toggle A2→A1 → task returns to normal styling; only future occurrences re-deploy.
- [x] Copy mode carries the source's `status` + `complianceEnabled` forward.
- [x] Create mode defaults to active+compliance-on (same as today's hard-coded values).
- [x] DevTools Network — `POST /api/backend-configuration-pn/calendar/tasks/week` response includes `status` and `complianceEnabled` per task.

Design spec: `docs/superpowers/specs/2026-05-29-calendar-active-overdue-toggles-design.md`
Implementation plan: `docs/superpowers/plans/2026-05-29-calendar-active-overdue-toggles.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)