### PR TITLE
Fix: align calendar event modal field widths with Title

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
@@ -103,12 +103,6 @@
   min-width: 0;
 }
 
-.gcal-toggle-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
 // Date + Time row
 .gcal-datetime-row {
   display: flex;
@@ -130,6 +124,13 @@
   // datetime row's flex children.
   width: 90px !important;
   flex-shrink: 0;
+}
+
+// Lift the workspace 320px max-width cap on mtx-select fields marked
+// `w-100` so they align to Title's right edge. Scoped via `.w-100` so the
+// 90px `.gcal-time-field` pickers above are unaffected.
+mat-form-field.w-100.mat-mdc-form-field-type-mtx-select {
+  max-width: none !important;
 }
 
 .gcal-time-separator {


### PR DESCRIPTION
## Summary
- The calendar create/edit event modal renders all `w-100` `mtx-select` dropdowns (Repeat, Property, Assignee, Tags, Headline, eForm, Boards) at 320 px wide because the workspace theme caps `.mat-mdc-form-field-type-mtx-select` at `max-width: 320 px` (to keep them compact in toolbars).
- That cap leaves the dropdowns visibly narrower than the 449 px Title input on the same modal.
- This PR adds a scoped override in the modal's SCSS that lifts the cap on `w-100` mtx-select fields only. Time pickers (`.gcal-time-field`) and the Date input are unchanged — they don't use `w-100`.

## Test plan
- [x] Open `/plugins/backend-configuration-pn/calendar`, click an event, click Edit.
- [x] Verify Repeat / Property / Assignee / Tags / Headline / eForm / Boards dropdowns reach the same right edge as the Title input (449 px wide).
- [x] Verify the Date input (236 px) and the two time pickers (90 px each) on the Date row are unchanged.
- [x] Playwright `getBoundingClientRect` measured each field before and after — all `w-100` fields now report width 449 / right 1622, matching Title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)