### PR TITLE
Fix: stack paired toggles vertically; hide Google Drive row

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
@@ -240,8 +240,9 @@
       </div>
     </div>
 
-    <!-- Google Drive file. Same gating as the local-file row below: only
-         enabled once the AreaRulePlanning has an id (i.e. event is saved). -->
+    <!-- Google Drive file row temporarily hidden — uncomment to restore.
+         Same gating as the local-file row below: only enabled once the
+         AreaRulePlanning has an id (i.e. event is saved).
     <div class="gcal-row">
       <mat-icon class="gcal-icon">add_to_drive</mat-icon>
       <div class="gcal-row-content">
@@ -263,6 +264,8 @@
         <div *ngIf="driveError" class="gcal-attachment-error">{{ driveError }}</div>
       </div>
     </div>
+    -->
+
 
     <!-- Local file attachments -->
     <div class="gcal-row">

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
@@ -103,6 +103,15 @@
   min-width: 0;
 }
 
+// Stack paired slide-toggles (e.g. Aktiv/Inaktiv, Vis/Skjul overskredet)
+// one per line. Without this they default to mat-slide-toggle's inline-flex
+// and pack side-by-side until the row wraps.
+.gcal-toggle-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 // Date + Time row
 .gcal-datetime-row {
   display: flex;


### PR DESCRIPTION
## Summary
- Restore `.gcal-toggle-stack` SCSS rule (`display: flex; flex-direction: column; gap: 8px`) so the two paired-toggle rows on the calendar event modal stack one toggle per line. The block was inadvertently removed in PR #871 just as PR #872 added a second consumer of the class; without it the Vis/Skjul overskredet pair packed side-by-side via mat-slide-toggle's default inline-flex.
- Wrap the Google Drive `.gcal-row` (Tilføj Google Drive-fil) in an HTML comment so the row no longer renders in the modal. Component-side Drive plumbing (Drive badges, refresh hints, deep links on existing Drive-mirrored attachments) is untouched — re-enabling is a pure HTML un-comment.

## Test plan
- [x] Open `/plugins/backend-configuration-pn/calendar`, click an event, click Edit.
- [x] Verify the "Tilføj Google Drive-fil" row is gone (the paperclip "Vedhæft fil" row remains).
- [x] Verify both Aktiv/Inaktiv and Vis/Skjul overskredet toggle pairs render one toggle per line.
- [x] Playwright `getComputedStyle` reports `flex-direction: column` on both `.gcal-toggle-stack` elements, and each toggle is at a distinct `top` (4 toggles, 4 different y-positions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)