### PR TITLE
i18n(da): exact Danish wording for calendar event modal toggles

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -466,8 +466,8 @@ export const da = {
   'Last refreshed': 'Sidst opdateret',
   'Google Drive disconnected': 'Google Drive afbrudt',
   'Google Drive disconnected — reconnect to resume sync': 'Google Drive afbrudt – genopret forbindelse for at genoptage synkronisering',
-  'Task visible on board and shown in app': 'Opgave synlig på tavlen og vist i appen',
-  'Task dimmed on board and not shown in app': 'Opgaven er nedtonet på tavlen og vises ikke i appen',
-  'Overdue task shown in app': 'Forfalden opgave vist i appen',
-  'Overdue task not shown in app': 'Forfalden opgave vises ikke i appen',
+  'Task visible on board and shown in app': 'Opgave synlig i tavle og vises i app',
+  'Task dimmed on board and not shown in app': 'Opgave nedtonet i tavle og vises ikke i app',
+  'Overdue task shown in app': 'Overskredet opgave vises i app',
+  'Overdue task not shown in app': 'Overskredet opgave vises ikke i app',
 };


### PR DESCRIPTION
## Summary

Replace the auto-translator output for the four calendar event modal toggles with the exact Danish wording from the feedback mockup (ticket #7630345):

| English key | Was (translator) | Now (mockup) |
|---|---|---|
| Task visible on board and shown in app | Opgave synlig på tavlen og vist i appen | **Opgave synlig i tavle og vises i app** |
| Task dimmed on board and not shown in app | Opgaven er nedtonet på tavlen og vises ikke i appen | **Opgave nedtonet i tavle og vises ikke i app** |
| Overdue task shown in app | Forfalden opgave vist i appen | **Overskredet opgave vises i app** |
| Overdue task not shown in app | Forfalden opgave vises ikke i appen | **Overskredet opgave vises ikke i app** |

English source keys are unchanged — they convey the same meaning, so other-language translations (which are derived from English) stay valid.

## Test plan

- [ ] Open the calendar event modal in Danish — confirm all four toggle labels match the mockup wording.
- [ ] Other languages unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)