### PR TITLE
Fix: make entire calendar task block clickable, not just text area

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
@@ -7,7 +7,7 @@
   cursor: pointer;
   padding: 2px 4px;
   display: flex;
-  align-items: flex-start;
+  align-items: stretch;
   gap: 4px;
   border: 2px solid white;
   transition:


### PR DESCRIPTION
## Summary

A tall calendar event (e.g. 08:00–12:00) had a large empty area below its title/time text that didn't open the event modal — the body element only filled the vertical space its content needed, leaving the rest of the block out of the body's hit area.

Single-line CSS fix: change \`.task-block\` from \`align-items: flex-start\` to \`align-items: stretch\` so the body fills the full block height. The body's own internal flex still aligns its children at the top, so the visual is identical — only the click target grows.

## Test plan

- [ ] Create a multi-hour event (e.g. 08:00–12:00). Click anywhere in the colored block — modal opens.
- [ ] Click the completion-circle button — still toggles completion (stops propagation as before).
- [ ] Resize handles at top/bottom still drag the edges.
- [ ] Drag the block from any in-block area — still moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)