### PR TITLE
Fix: weekday-repeat preset emits valid wire payload

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.page.ts
@@ -382,14 +382,12 @@ export class CalendarUiEnhancementsPage {
   }
 
   /**
-   * Set the event-modal Repeat dropdown to "Weekly on {weekday}". The
-   * repeat options have stable order (calendar-repeat.service:245+):
-   * 0:none, 1:daily, 2:weeklyOne, 3:weeklyAll, 4:monthlyDom, 5:yearlyOne,
-   * 6:custom. Index 2 is what we want. Pick by position to avoid
-   * locale-dependent label matching.
-   *
-   * The repeat select is [searchable]="false", so click .ng-select-container
-   * (the inner combobox input is non-interactive at opacity 0).
+   * Set the event-modal Repeat dropdown to "Weekly on {weekday}". Picks by
+   * position to avoid locale-dependent label matching; option order is the
+   * same table documented on `selectRepeatPreset` below (index 2 is
+   * weeklyOne). The repeat select is `[searchable]="false"`, so click
+   * `.ng-select-container` directly — the inner combobox input is
+   * non-interactive at opacity 0.
    */
   async setRepeatToWeekly(): Promise<void> {
     const repeatRow = this.page
@@ -399,6 +397,48 @@ export class CalendarUiEnhancementsPage {
     await this.page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
     await this.page.locator('.ng-dropdown-panel .ng-option').nth(2).click();
     await this.page.waitForTimeout(300);
+  }
+
+  /**
+   * Set the event-modal Repeat dropdown to a built-in preset by its `value`
+   * attribute. Mirrors the option order from calendar-repeat.service.ts
+   * `buildRepeatSelectOptions` (without customCurrent):
+   *   0:none, 1:daily, 2:weeklyOne, 3:monthlyByDay, 4:yearlyOne,
+   *   5:weekdays, 6:custom
+   *
+   * Positional .nth() picking is locale-independent (the visible labels are
+   * translated) and matches the existing pattern used by setRepeatToWeekly.
+   */
+  async selectRepeatPreset(
+    value: 'none' | 'daily' | 'weeklyOne' | 'monthlyByDay' | 'yearlyOne' | 'weekdays' | 'custom',
+  ): Promise<void> {
+    const indexByValue: Record<string, number> = {
+      none: 0,
+      daily: 1,
+      weeklyOne: 2,
+      monthlyByDay: 3,
+      yearlyOne: 4,
+      weekdays: 5,
+      custom: 6,
+    };
+    const repeatRow = this.page
+      .locator('.gcal-row')
+      .filter({ has: this.page.locator('mat-icon.gcal-icon:has-text("sync")') });
+    await repeatRow.locator('.ng-select-container').first().click();
+    await this.page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await this.page.locator('.ng-dropdown-panel .ng-option').nth(indexByValue[value]).click();
+    await this.page.waitForTimeout(300);
+  }
+
+  /**
+   * Returns `.task-block` locators inside the day column for `dayIndex`
+   * (0=Mon..6=Sun, matching the `data-day` attribute set by the week-grid
+   * template), filtered by a substring of the title.
+   */
+  getDayColumnTaskBlocks(dayIndex: number, titleSubstring: string): Locator {
+    return this.page
+      .locator(`.day-cell-content[data-day="${dayIndex}"] .task-block`)
+      .filter({ hasText: titleSubstring });
   }
 
   /**

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-weekdays-repeat.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-weekdays-repeat.spec.ts
@@ -1,0 +1,260 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../../Page objects/Login.page';
+import { generateRandmString } from '../../../helper-functions';
+import { CalendarUiEnhancementsPage } from './calendar-ui-enhancements.page';
+import {
+  BackendConfigurationPropertiesPage,
+  PropertyCreateUpdate,
+} from '../BackendConfigurationProperties.page';
+import {
+  BackendConfigurationPropertyWorkersPage,
+  PropertyWorker,
+} from '../BackendConfigurationPropertyWorkers.page';
+
+/**
+ * Regression suite for the "Alle hverdage (mandag til fredag)" repeat option.
+ *
+ * BUG GUARDED AGAINST
+ * -------------------
+ * The built-in `weekdays` repeat preset (value `'weekdays'` in
+ * calendar-repeat.service.buildRepeatSelectOptions) used to ship
+ * RepeatType=5 + repeatWeekdaysCsv=null on the create payload, which made
+ * the backend persist the planning as a single Monday event — Tue–Fri (and
+ * subsequent weeks) never materialised.
+ *
+ * After the fix, the modal now ships RepeatType=2 (Week) +
+ * repeatWeekdaysCsv="1,2,3,4,5" so the recurring planning expands to
+ * Mon-Fri of every week, starting from the event's start date.
+ *
+ * The three test cases below assert the post-fix behaviour from a black-box
+ * angle: a single Monday-anchored weekdays-repeat event must produce
+ * `.task-block`s on Mon–Fri of the seeded week AND of the following week,
+ * and must NOT produce any blocks on Saturday or Sunday of either week.
+ */
+
+const property: PropertyCreateUpdate = {
+  name: generateRandmString(5),
+  chrNumber: generateRandmString(5),
+  address: generateRandmString(5),
+  cvrNumber: '1111111',
+};
+
+const worker: PropertyWorker = {
+  name: generateRandmString(5),
+  surname: generateRandmString(5),
+  language: 'Dansk',
+  properties: [property.name],
+  workerEmail: generateRandmString(5) + '@test.com',
+};
+
+let seeded = false;
+
+// Unique title for the single event created by the weekdays-repeat test.
+// Declared at module scope so the second visibility test (next week) and
+// the weekend-exclusion test can locate the same recurring series.
+const weekdaysTitle = `WK-${generateRandmString(8)}`;
+
+test.describe.serial('Calendar weekdays repeat — Mon-Fri visibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4200');
+    await new LoginPage(page).login();
+    await page.waitForTimeout(2000);
+
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    await calendarPage.goToCalendar();
+    await calendarPage.ensureSidebarOpen();
+
+    if (seeded) {
+      const folderResp = page.waitForResponse(
+        r => r.url().includes('/api/backend-configuration-pn/properties/get-folder-dtos'),
+        { timeout: 60000 }
+      );
+      await calendarPage.selectProperty(property.name);
+      await folderResp.catch(() => undefined);
+      await page.waitForTimeout(1000);
+    }
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    const cleanup = async () => {
+      await page.goto('http://localhost:4200');
+      await new LoginPage(page).login();
+
+      const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+      await workersPage.goToPropertyWorkers();
+      await page.waitForTimeout(1000);
+      await workersPage.clearTable();
+
+      const propertiesPage = new BackendConfigurationPropertiesPage(page);
+      await propertiesPage.goToProperties();
+      await page.waitForTimeout(1000);
+      await propertiesPage.clearTable();
+    };
+    try {
+      await Promise.race([
+        cleanup(),
+        new Promise(resolve => setTimeout(resolve, 60000)),
+      ]);
+    } catch (err: any) {
+      console.log(`afterAll cleanup failed (non-fatal): ${err?.message ?? err}`);
+    }
+    try { await page.close(); } catch {}
+  });
+
+  // -----------------------------------------------------------------------
+  // Seed test — create property + worker. Runs first via describe.serial.
+  // -----------------------------------------------------------------------
+  test('seed property and worker', async ({ page }) => {
+    test.setTimeout(600000);
+
+    const propertiesPage = new BackendConfigurationPropertiesPage(page);
+    const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+
+    await propertiesPage.goToProperties();
+    await propertiesPage.createProperty(property);
+    await workersPage.goToPropertyWorkers();
+    await workersPage.create(worker);
+
+    seeded = true;
+  });
+
+  // =======================================================================
+  // W1. Create one event on Monday of next week with the "Alle hverdage"
+  //     repeat preset, and assert task-blocks appear on Mon-Fri of that
+  //     same week.
+  //
+  //     openCreateModalAtSlot(0, 9) advances the calendar by one week and
+  //     then clicks Monday@9AM — so the event's start date lands on the
+  //     Monday of the displayed (next) week. The weekdays preset has
+  //     endMode='never' so every subsequent weekday in that week is also
+  //     materialised.
+  // =======================================================================
+  test('weekdays repeat creates events on Mon-Fri of the current week', async ({ page }) => {
+    expect(seeded, 'seed property + worker must have completed').toBe(true);
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+
+    await calendarPage.openCreateModalAtSlot(0, 9);
+
+    // Fill title + eForm + planning tag + assignee + save. We need to set
+    // the repeat preset BEFORE the save flow inside fillAndSaveEvent fires
+    // the create POST, so we do the field-fill steps manually here rather
+    // than reusing fillAndSaveEvent verbatim. Mirrors the I1 test pattern
+    // in calendar-ui-enhancements.spec.ts.
+    await page.locator('#calendarEventTitle').fill(weekdaysTitle);
+
+    const eform = page.locator('#calendarEventEform');
+    await eform.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+
+    const planningTag = page.locator('#calendarEventPlanningTag');
+    await planningTag.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+
+    const assignee = page.locator('#calendarEventAssignee');
+    await assignee.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.locator('#calendarEventTitle').click();
+    await page.waitForTimeout(300);
+
+    // Pick the "Alle hverdage (mandag til fredag)" preset. Locator goes by
+    // positional index (5) inside the repeat ng-select to stay locale-
+    // independent — same convention as setRepeatToWeekly / setRepeat-
+    // ToCustom usage elsewhere in this suite.
+    await calendarPage.selectRepeatPreset('weekdays');
+
+    // Save. Pre-register the POST waiter so the listener can't miss the
+    // response on a fast machine.
+    const createResp = page.waitForResponse(
+      r => r.url().includes('/api/backend-configuration-pn/calendar/tasks')
+        && !r.url().includes('/tasks/week')
+        && !r.url().includes('/tasks/move')
+        && !r.url().includes('/tasks/resize')
+        && r.request().method() === 'POST',
+      { timeout: 30000 }
+    );
+    await page.locator('#calendarEventSaveBtn').click();
+    await createResp;
+    // Allow the post-save tasksReload → /tasks/week round-trip + grid
+    // re-render to settle before reading per-day DOM state.
+    await page.waitForTimeout(2000);
+
+    // Mon-Fri (data-day 0..4) of the displayed (next) week must each have
+    // at least one .task-block carrying our unique title.
+    for (let day = 0; day <= 4; day++) {
+      const blocks = calendarPage.getDayColumnTaskBlocks(day, weekdaysTitle);
+      const count = await blocks.count();
+      expect(
+        count,
+        `Expected weekdays-repeat block on day-of-week index ${day} (Mon=0..Fri=4) ` +
+        `for "${weekdaysTitle}", but found ${count}.`
+      ).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  // =======================================================================
+  // W2. After advancing one more week via chevron_right, the same Mon-Fri
+  //     presence must hold (the weekdays preset has endMode='never').
+  //
+  //     Relies on W1 having created the seed event. describe.serial keeps
+  //     the test order deterministic. The beforeEach already navigates to
+  //     the calendar at the current week — so a single navigateToNextWeek
+  //     lands on (today's-week + 7d), which is the SAME week W1 created
+  //     events in. A second navigateToNextWeek lands on the week AFTER
+  //     that (today's-week + 14d), which is what this test asserts.
+  // =======================================================================
+  test('weekdays repeat creates events on Mon-Fri of next week (one week after)', async ({ page }) => {
+    expect(seeded, 'seed property + worker must have completed').toBe(true);
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+
+    // beforeEach already opened the calendar at today's week with the
+    // seeded property selected. Two chevron-right clicks → week containing
+    // (Monday+14d). Each click awaits its /tasks/week POST so the new
+    // week's data is loaded before we assert.
+    await calendarPage.navigateToNextWeek();
+    await calendarPage.navigateToNextWeek();
+
+    for (let day = 0; day <= 4; day++) {
+      const blocks = calendarPage.getDayColumnTaskBlocks(day, weekdaysTitle);
+      const count = await blocks.count();
+      expect(
+        count,
+        `Expected weekdays-repeat block on day-of-week index ${day} (Mon=0..Fri=4) ` +
+        `in the week after the seed week for "${weekdaysTitle}", but found ${count}.`
+      ).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  // =======================================================================
+  // W3. Saturday + Sunday in the seed week must have NO .task-block
+  //     matching the weekdays-repeat series. This guards against a
+  //     symmetric regression where the fix flips too far the other way
+  //     (e.g. ships repeatWeekdaysCsv="1,2,3,4,5,6,7" by accident).
+  //
+  //     This test re-navigates to the seed week from today (one
+  //     navigateToNextWeek) so it's independent of W2's state.
+  // =======================================================================
+  test('weekdays repeat does NOT create events on Saturday or Sunday', async ({ page }) => {
+    expect(seeded, 'seed property + worker must have completed').toBe(true);
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+
+    // Land on the same week W1 created events in (today + 7d).
+    await calendarPage.navigateToNextWeek();
+
+    for (const day of [5, 6]) {
+      const blocks = calendarPage.getDayColumnTaskBlocks(day, weekdaysTitle);
+      const count = await blocks.count();
+      expect(
+        count,
+        `Expected NO weekdays-repeat block on day-of-week index ${day} ` +
+        `(Sat=5/Sun=6) for "${weekdaysTitle}", but found ${count}. ` +
+        `The "weekdays" preset must only materialise Mon-Fri.`
+      ).toBe(0);
+    }
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -703,18 +703,23 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
       repeatEndMode,
       repeatOccurrences,
       repeatUntilDate,
-      // CSV of JS getDay() weekday indices for weekly rules. Single-weekday
-      // rules (weeklyOne / everyNWeekOne) live in meta.weekday (singular);
-      // multi-day rules in meta.weekdays (plural). The service helper
-      // collapses both shapes into the wire format. Built-in options carry
-      // their own meta (e.g. the "Alle hverdage" option ships
-      // weekdays=[1..5]) — read from there for non-custom rules so the
-      // weekday list reaches the backend. metaToWeekdaysCsv returns null
-      // for non-weekly metas, so daily/monthly/yearly built-ins still ship
-      // null and any stale CSV from a prior custom selection is cleared.
+      // CSV of JS getDay() weekday indices. Custom rules use whichever shape
+      // metaToWeekdaysCsv supports (single via meta.weekday, multi via
+      // meta.weekdays). For built-in non-custom rules we ONLY emit a CSV
+      // when the option's embedded meta is a multi-day pattern
+      // (meta.weekdays?.length > 0) — that's how the "Alle hverdage" preset
+      // ships its [1..5] payload. Single-day built-ins like 'weeklyOne'
+      // intentionally keep the legacy null payload so the backend's
+      // Week-case takes its 7-day stride path (CalendarService
+      // GetOccurrencesInWeek:2326) rather than the multi-day anchor path —
+      // the two paths are not identical under edit/move flows that
+      // calendar-resize.spec.ts depends on.
       repeatWeekdaysCsv: isCustomRule
         ? this.repeatService.metaToWeekdaysCsv(this.customRepeatMeta)
-        : this.repeatService.metaToWeekdaysCsv(
+        : ((meta) =>
+            meta?.weekdays?.length
+              ? this.repeatService.metaToWeekdaysCsv(meta)
+              : null)(
             this.repeatOptions.find(o => o.value === repeatRuleValue)?.meta ?? null,
           ),
       // Day-of-month for monthly + yearly rules. Pre-fix the modal didn't

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -642,7 +642,13 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
       'weekly': 2, 'weeklyOne': 2, 'weeklyAll': 2,
       'monthly': 3, 'monthlyDom': 3, 'monthlyByDay': 3,
       'yearly': 4, 'yearlyOne': 4,
-      'weekdays': 5,
+      // "Alle hverdage (mandag til fredag)" is wire-encoded as a weekly
+      // rule whose weekday CSV is "1,2,3,4,5" — the backend's
+      // GetOccurrencesInWeek already loops the multi-day weekly branch.
+      // A dedicated RepeatType value (e.g. 5) would have no matching enum
+      // member on the server and the entire planning falls through to the
+      // default case, emitting zero occurrences for the week.
+      'weekdays': 2,
       'custom': 6,
       'customCurrent': 6,
     };
@@ -697,19 +703,20 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
       repeatEndMode,
       repeatOccurrences,
       repeatUntilDate,
-      // CSV of JS getDay() weekday indices for weekly custom rules.
-      // Single-weekday rules (weeklyOne / everyNWeekOne) live in
-      // meta.weekday (singular); multi-day rules in meta.weekdays (plural).
-      // The service helper collapses both shapes into the wire format so
-      // a Tuesday-only pick doesn't ship as null (which would otherwise let
-      // the server-stored DayOfWeek default of 0 win on reload, showing
-      // "Sunday" instead of the picked weekday). Sent as null for any
-      // non-custom rule (isCustomRule=false), which unconditionally clears
-      // any stale CSV the row may carry from a prior custom selection.
-      // See spec — Layer 3 / "explicit clearing rule".
+      // CSV of JS getDay() weekday indices for weekly rules. Single-weekday
+      // rules (weeklyOne / everyNWeekOne) live in meta.weekday (singular);
+      // multi-day rules in meta.weekdays (plural). The service helper
+      // collapses both shapes into the wire format. Built-in options carry
+      // their own meta (e.g. the "Alle hverdage" option ships
+      // weekdays=[1..5]) — read from there for non-custom rules so the
+      // weekday list reaches the backend. metaToWeekdaysCsv returns null
+      // for non-weekly metas, so daily/monthly/yearly built-ins still ship
+      // null and any stale CSV from a prior custom selection is cleared.
       repeatWeekdaysCsv: isCustomRule
         ? this.repeatService.metaToWeekdaysCsv(this.customRepeatMeta)
-        : null,
+        : this.repeatService.metaToWeekdaysCsv(
+            this.repeatOptions.find(o => o.value === repeatRuleValue)?.meta ?? null,
+          ),
       // Day-of-month for monthly + yearly rules. Pre-fix the modal didn't
       // ship this field at all, the request model had no DayOfMonth
       // property, and AreaRulePlanning.DayOfMonth defaulted to its int 0

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
@@ -186,6 +186,20 @@ describe('CalendarRepeatService', () => {
       opts.filter(o => o.value !== 'none' && o.value !== 'custom')
         .forEach(o => expect(o.meta).toBeDefined());
     });
+
+    // Guard for the "Alle hverdage (mandag til fredag)" save bug: the
+    // modal's save path emits repeatWeekdaysCsv by passing this option's
+    // meta to metaToWeekdaysCsv. If the meta drifts (e.g. someone changes
+    // weekdays:[1..5] to a different shape), the backend reverts to
+    // emitting zero Mon-Fri occurrences for the week.
+    it('weekdays option carries weeklyMulti meta with weekdays [1..5]', () => {
+      const opts = service.buildRepeatSelectOptions(monday);
+      const wkOpt = opts.find(o => o.value === 'weekdays');
+      expect(wkOpt).toBeDefined();
+      expect(wkOpt!.meta!.kind).toBe('weeklyMulti');
+      expect(wkOpt!.meta!.weekdays).toEqual([1, 2, 3, 4, 5]);
+      expect(service.metaToWeekdaysCsv(wkOpt!.meta!)).toBe('1,2,3,4,5');
+    });
   });
 
   // ─── buildMetaFromCustomConfig ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The built-in "Alle hverdage (mandag til fredag)" repeat preset was mapped to `RepeatType=5` in the modal's save path. The plugin's `RepeatType` enum only defines `Day=1, Week=2, Month=3, Year=4` — there is no `5`. The backend `GetOccurrencesInWeek` switch-on-`RepeatType` fell through to its `default` branch and returned zero occurrences for the week. The preset's `repeatWeekdaysCsv` was also dropped as `null` because the save path only emitted a CSV for custom rules, so even fixing the enum value would still produce no Mon-Fri data.

This PR makes two surgical changes in `task-create-edit-modal.component.ts`:

1. **`repeatRuleMap`**: `'weekdays': 5` → `'weekdays': 2` (encode as `RepeatType.Week`).
2. **`repeatWeekdaysCsv` emission**: non-custom branch now falls back to the selected option's embedded `meta`, mirroring how `dayOfMonth` and `repeatOrdinalWeek` already behave at lines 725-734 of the same file.

`metaToWeekdaysCsv` returns `null` for non-weekly metas (verified at `calendar-repeat.service.ts:768-773`), so the daily / monthlyByDay / yearlyOne built-ins still ship `null`. The backend's Week-case at `BackendConfigurationCalendarService.cs:2320-2358` already loops through a multi-day weekday CSV — the same code path that custom `weeklyMulti` rules use today.

## Files

- `eform-angular-frontend` → modal mapping fix
- `eform-angular-frontend` → unit guard in `calendar-repeat.service.spec.ts` pinning the option's meta and CSV output
- plugin repo → new Playwright spec `calendar-weekdays-repeat.spec.ts` (3 tests + seed)
- plugin repo → 2 new helpers in `calendar-ui-enhancements.page.ts` (`selectRepeatPreset`, `getDayColumnTaskBlocks`) plus a tightened comment on the existing `setRepeatToWeekly`

## Test plan

- [x] Visual check: created an event with "Alle hverdage", confirmed it now renders on Mon, Tue, Wed, Thu, Fri of the current week and the following week, and NOT on Sat/Sun.
- [ ] CI runs the new `calendar-weekdays-repeat.spec.ts` end-to-end on a fresh stack.
- [ ] Existing `calendar-ui-enhancements.spec.ts` / `calendar-resize.spec.ts` unaffected (no shared selectors touched).
- [ ] The new unit test `weekdays option carries weeklyMulti meta with weekdays [1..5]` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)