### PR TITLE
Fix: adaptive layout for short calendar event cards (port to stable)

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-event-card-layout.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-event-card-layout.spec.ts
@@ -1,0 +1,358 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../../Page objects/Login.page';
+import { generateRandmString } from '../../../helper-functions';
+import { CalendarUiEnhancementsPage } from './calendar-ui-enhancements.page';
+import {
+  BackendConfigurationPropertiesPage,
+  PropertyCreateUpdate,
+} from '../BackendConfigurationProperties.page';
+import {
+  BackendConfigurationPropertyWorkersPage,
+  PropertyWorker,
+} from '../BackendConfigurationPropertyWorkers.page';
+
+/**
+ * Adaptive event-card layout regression suite. Verifies the compact (heightPx
+ * < 40) vs. tall (heightPx >= 40) rendering modes added to
+ * CalendarTaskBlockComponent — see the design doc
+ * docs/superpowers/specs/2026-06-01-calendar-event-card-adaptive-layout-design.md
+ *
+ * Each test creates its own event on a distinct day-of-week slot so cards
+ * don't collide on the week grid. Shared property/worker seed pattern
+ * matches calendar-ui-enhancements.spec.ts.
+ */
+
+const property: PropertyCreateUpdate = {
+  name: generateRandmString(5),
+  chrNumber: generateRandmString(5),
+  address: generateRandmString(5),
+  cvrNumber: '1111111',
+};
+
+const worker: PropertyWorker = {
+  name: generateRandmString(5),
+  surname: generateRandmString(5),
+  language: 'Dansk',
+  properties: [property.name],
+  workerEmail: generateRandmString(5) + '@test.com',
+};
+
+let seeded = false;
+
+test.describe.serial('Calendar event card — adaptive layout', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4200');
+    await new LoginPage(page).login();
+    await page.waitForTimeout(2000);
+
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    await calendarPage.goToCalendar();
+    await calendarPage.ensureSidebarOpen();
+
+    if (seeded) {
+      const folderResp = page.waitForResponse(
+        r => r.url().includes('/api/backend-configuration-pn/properties/get-folder-dtos'),
+        { timeout: 60000 }
+      );
+      await calendarPage.selectProperty(property.name);
+      await folderResp.catch(() => undefined);
+      await page.waitForTimeout(1000);
+    }
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    const cleanup = async () => {
+      await page.goto('http://localhost:4200');
+      await new LoginPage(page).login();
+
+      const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+      await workersPage.goToPropertyWorkers();
+      await page.waitForTimeout(1000);
+      await workersPage.clearTable();
+
+      const propertiesPage = new BackendConfigurationPropertiesPage(page);
+      await propertiesPage.goToProperties();
+      await page.waitForTimeout(1000);
+      await propertiesPage.clearTable();
+    };
+    try {
+      await Promise.race([
+        cleanup(),
+        new Promise(resolve => setTimeout(resolve, 60000)),
+      ]);
+    } catch (err: any) {
+      console.log(`afterAll cleanup failed (non-fatal): ${err?.message ?? err}`);
+    }
+    try { await page.close(); } catch {}
+  });
+
+  // -----------------------------------------------------------------------
+  // Seed test — create property + worker. Runs first via describe.serial.
+  // -----------------------------------------------------------------------
+  test('seed property and worker', async ({ page }) => {
+    test.setTimeout(600000);
+
+    const propertiesPage = new BackendConfigurationPropertiesPage(page);
+    const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+
+    await propertiesPage.goToProperties();
+    await propertiesPage.createProperty(property);
+    await workersPage.goToPropertyWorkers();
+    await workersPage.create(worker);
+
+    seeded = true;
+  });
+
+  // =======================================================================
+  // L1. 30-min event renders in compact mode with title + time on the
+  //     same baseline.
+  // =======================================================================
+  test('L1: 30-min event renders compact with title+time inline', async ({ page }) => {
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    const title = `L1-${generateRandmString(5)}`;
+
+    // Open the modal at Monday 08:00. Default duration is 1h; shrink the end
+    // to 08:30 so we get a 30-min event (~22px tall at HOUR_HEIGHT=52 → compact).
+    await calendarPage.openCreateModalAtSlot(0, 8);
+    await calendarPage.fillAndSaveEvent(title, { endTime: '08:30' });
+
+    const block = calendarPage.findEventBlock(title);
+    await expect(block).toHaveClass(/(^|\s)compact(\s|$)/);
+
+    const titleEl = block.locator('.task-title');
+    const timeEl = block.locator('.task-time');
+    await expect(titleEl).toBeVisible();
+    await expect(timeEl).toBeVisible();
+
+    const titleBox = await titleEl.boundingBox();
+    const timeBox = await timeEl.boundingBox();
+    expect(titleBox).not.toBeNull();
+    expect(timeBox).not.toBeNull();
+    // Compact mode: title + time on the same line, tops within 2 px.
+    expect(Math.abs(titleBox!.y - timeBox!.y)).toBeLessThanOrEqual(2);
+  });
+
+  // =======================================================================
+  // L2. 90-min event renders in tall mode — time row sits below the title.
+  // =======================================================================
+  test('L2: 90-min event renders tall with time stacked below title', async ({ page }) => {
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    const title = `L2-${generateRandmString(5)}`;
+
+    // Tuesday 09:00 – 10:30 (90 min ~ 74 px tall → not compact).
+    await calendarPage.openCreateModalAtSlot(1, 9);
+    await calendarPage.fillAndSaveEvent(title, { endTime: '10:30' });
+
+    const block = calendarPage.findEventBlock(title);
+    // Should NOT have the .compact class on the outer task-block.
+    const cls = (await block.getAttribute('class')) ?? '';
+    expect(cls.split(/\s+/).includes('compact')).toBe(false);
+
+    const titleEl = block.locator('.task-title');
+    const timeEl = block.locator('.task-time');
+    await expect(titleEl).toBeVisible();
+    await expect(timeEl).toBeVisible();
+
+    const titleBox = await titleEl.boundingBox();
+    const timeBox = await timeEl.boundingBox();
+    expect(titleBox).not.toBeNull();
+    expect(timeBox).not.toBeNull();
+    // Tall mode: time row is below the title; tops differ by > 8 px.
+    expect(timeBox!.y - titleBox!.y).toBeGreaterThan(8);
+  });
+
+  // =======================================================================
+  // L3. Time never wraps — single line in both compact and tall mode.
+  //     Inspects the cards created in L1 (compact) and L2 (tall).
+  // =======================================================================
+  test('L3: .task-time renders on a single line in both modes', async ({ page }) => {
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    const title = `L3-${generateRandmString(5)}`;
+
+    // Wednesday: create one compact (30 min) and one tall (90 min) event so
+    // this test is independent of L1/L2's state (each test logs in fresh).
+    // First call advances the week; the second stays on the same week.
+    await calendarPage.openCreateModalAtSlot(2, 8);
+    await calendarPage.fillAndSaveEvent(`${title}-compact`, { endTime: '08:30' });
+
+    await calendarPage.openCreateModalOnCurrentWeek(2, 10);
+    await calendarPage.fillAndSaveEvent(`${title}-tall`, { endTime: '11:30' });
+
+    // Title is known to be one line (it has nowrap + ellipsis). Time on the
+    // same single-line rule should be ≈ one line tall. We compare against
+    // the title's box rather than a hard pixel bound because the line-height
+    // inheritance differs between local dev (~14 px) and CI (~22 px) — a
+    // 22 px tall .task-time is still one line if the title beside it is
+    // also 22 px tall (both inherit the same "normal" line-height from the
+    // parent). A wrap would push .task-time to ≥ 1.6 × the title height.
+    const compactBlock = calendarPage.findEventBlock(`${title}-compact`);
+    const tallBlock = calendarPage.findEventBlock(`${title}-tall`);
+
+    const compactTimeBox = await compactBlock.locator('.task-time').boundingBox();
+    const compactTitleBox = await compactBlock.locator('.task-title').boundingBox();
+    const tallTimeBox = await tallBlock.locator('.task-time').boundingBox();
+    const tallTitleBox = await tallBlock.locator('.task-title').boundingBox();
+
+    expect(compactTimeBox).not.toBeNull();
+    expect(compactTitleBox).not.toBeNull();
+    expect(tallTimeBox).not.toBeNull();
+    expect(tallTitleBox).not.toBeNull();
+
+    expect(compactTimeBox!.height).toBeLessThanOrEqual(compactTitleBox!.height * 1.6);
+    expect(tallTimeBox!.height).toBeLessThanOrEqual(tallTitleBox!.height * 1.6);
+  });
+
+  // =======================================================================
+  // L4. Long title in compact mode ellipsises; time stays visible (not
+  //     squeezed to 0 width).
+  // =======================================================================
+  test('L4: long title ellipsises in compact mode, time still visible', async ({ page }) => {
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    // 60+ characters — guaranteed to overflow a narrow compact card.
+    const title =
+      `L4-${generateRandmString(5)}-` +
+      'this-title-is-deliberately-very-long-to-force-ellipsis-overflow';
+
+    await calendarPage.openCreateModalAtSlot(3, 8);
+    await calendarPage.fillAndSaveEvent(title, { endTime: '08:30' });
+
+    const block = calendarPage.findEventBlock(title);
+    await expect(block).toHaveClass(/(^|\s)compact(\s|$)/);
+
+    const titleEl = block.locator('.task-title');
+    const titleMetrics = await titleEl.evaluate((el: Element) => ({
+      scrollWidth: (el as HTMLElement).scrollWidth,
+      clientWidth: (el as HTMLElement).clientWidth,
+    }));
+    // Title overflowed its allocated box → ellipsis kicked in.
+    expect(titleMetrics.scrollWidth).toBeGreaterThan(titleMetrics.clientWidth);
+
+    const timeEl = block.locator('.task-time');
+    await expect(timeEl).toBeVisible();
+    const timeBox = await timeEl.boundingBox();
+    expect(timeBox).not.toBeNull();
+    // Time row must keep a non-zero width — `flex: 0 0 auto` guarantees it
+    // never gets squeezed away by an oversized title.
+    expect(timeBox!.width).toBeGreaterThan(0);
+  });
+
+  // =======================================================================
+  // L5. 15-min event still renders the time string. Pre-change the
+  //     `*ngIf="task.duration >= 0.5"` gate hid it; now isCompact forces it.
+  // =======================================================================
+  test('L5: 15-min event still renders formatted time text', async ({ page }) => {
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    const title = `L5-${generateRandmString(5)}`;
+
+    // Thursday 08:00 – 08:15 (15 min ~ 9 px tall → compact).
+    await calendarPage.openCreateModalAtSlot(4, 8);
+    await calendarPage.fillAndSaveEvent(title, { endTime: '08:15' });
+
+    const block = calendarPage.findEventBlock(title);
+    const timeEl = block.locator('.task-time');
+    await expect(timeEl).toHaveCount(1);
+    const text = ((await timeEl.textContent()) ?? '').trim();
+    // Match HH:MM – HH:MM. The en-dash separator comes from the template
+    // (calendar-task-block.component.html line 40).
+    expect(text).toMatch(/\d{2}:\d{2}\s*[–-]\s*\d{2}:\d{2}/);
+    expect(text).toContain('08:00');
+    expect(text).toContain('08:15');
+  });
+
+  // =======================================================================
+  // L6. The 12-px completion circle on a compact card is still a reachable
+  //     click target. We assert the click triggers the completion flow —
+  //     PUT /tasks/{id}/complete fires and the eForm submission dialog
+  //     opens. The actual `completed` class transition requires submitting
+  //     that form (the seeded task has an associated eForm template),
+  //     which is out of scope for the layout suite — what matters here is
+  //     that the shrunken hit target still receives the click.
+  // =======================================================================
+  test('L6: completion button is clickable on compact card', async ({ page }) => {
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    const title = `L6-${generateRandmString(5)}`;
+
+    // Saturday 08:00 – 08:30 (30 min → compact). dayOffset 5 = Saturday
+    // (matches the convention used in calendar-resize.spec.ts E2).
+    await calendarPage.openCreateModalAtSlot(5, 8);
+    await calendarPage.fillAndSaveEvent(title, { endTime: '08:30' });
+
+    const block = calendarPage.findEventBlock(title);
+    await expect(block).toHaveClass(/(^|\s)compact(\s|$)/);
+
+    const completionWait = page.waitForResponse(
+      r => /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/complete/.test(r.url())
+        && r.request().method() === 'PUT',
+      { timeout: 30000 }
+    );
+    await block.locator('.completion-btn').click();
+    await completionWait;
+
+    // The eForm submission dialog opens in response to the PUT (the seeded
+    // task carries an eForm template). The dialog's mere appearance proves
+    // the click landed and the completion workflow kicked off; we don't
+    // need to submit the form here.
+    await expect(page.locator('mat-dialog-container').first())
+      .toBeVisible({ timeout: 10000 });
+
+    // Cancel so the dialog doesn't leak into the next test.
+    const cancelBtn = page
+      .locator('mat-dialog-container button')
+      .filter({ hasText: /Annuller|Cancel/i })
+      .first();
+    if ((await cancelBtn.count()) > 0) {
+      await cancelBtn.click();
+      await page
+        .locator('mat-dialog-container')
+        .waitFor({ state: 'detached', timeout: 5000 })
+        .catch(() => undefined);
+    }
+  });
+
+  // =======================================================================
+  // L7. Overlapping events cascade — both cards render, at least one has
+  //     a narrower computed width than the day column (cascade applied).
+  // =======================================================================
+  test('L7: cascade overlap still renders both events', async ({ page }) => {
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    const titleA = `L7a-${generateRandmString(5)}`;
+    const titleB = `L7b-${generateRandmString(5)}`;
+
+    // Sunday at 11:00–12:00 and 11:30–12:30 overlap by 30 min. dayOffset 6
+    // = Sunday (mirrors F1 in calendar-resize.spec.ts). First call advances
+    // the week; the second stays on the same week so both events land on
+    // the SAME Sunday and overlap.
+    await calendarPage.openCreateModalAtSlot(6, 11);
+    await calendarPage.fillAndSaveEvent(titleA, { endTime: '12:00' });
+
+    // Open the modal at a fresh slot on the same Sunday — clickEmptyTimeSlot
+    // aims 5 px into the H:00 band. We click 13:00 to avoid landing on the
+    // existing 11:00–12:00 block, then set start=11:30 and end=12:30 via
+    // the time fields so the second event overlaps the first by 30 min.
+    await calendarPage.openCreateModalOnCurrentWeek(6, 13);
+    await calendarPage.fillAndSaveEvent(titleB, {
+      startTime: '11:30',
+      endTime: '12:30',
+    });
+
+    const blockA = calendarPage.findEventBlock(titleA);
+    const blockB = calendarPage.findEventBlock(titleB);
+    await expect(blockA).toBeVisible();
+    await expect(blockB).toBeVisible();
+
+    // Read the day column width — both events live on Sunday (data-day=6).
+    const dayCell = page.locator('.day-cell-content[data-day="6"]');
+    const dayBox = await dayCell.boundingBox();
+    const boxA = await blockA.boundingBox();
+    const boxB = await blockB.boundingBox();
+    expect(dayBox).not.toBeNull();
+    expect(boxA).not.toBeNull();
+    expect(boxB).not.toBeNull();
+
+    // Cascade narrows at least one of the overlapping cards' computed width
+    // to below the full day-column width.
+    const narrower = Math.min(boxA!.width, boxB!.width);
+    expect(narrower).toBeLessThan(dayBox!.width);
+  });
+});

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.page.ts
@@ -73,6 +73,20 @@ export class CalendarUiEnhancementsPage {
     await this.page.waitForTimeout(300);
   }
 
+  /**
+   * Like `openCreateModalAtSlot` but does NOT advance the week first. Use
+   * after a previous `openCreateModalAtSlot` call when you want to create
+   * a second event on the same already-navigated week (e.g. testing
+   * cascade overlap with two events on the same day).
+   */
+  async openCreateModalOnCurrentWeek(dayOffset: number, hour: number): Promise<void> {
+    await this.clickEmptyTimeSlot(dayOffset, hour);
+    await this.page
+      .locator('#calendarEventTitle')
+      .waitFor({ state: 'visible', timeout: 15000 });
+    await this.page.waitForTimeout(300);
+  }
+
   async closeEventModal(): Promise<void> {
     // Mini-picker overlay (if open) has a CDK backdrop that intercepts
     // clicks aimed at elements behind it, including the cancel button.
@@ -379,6 +393,62 @@ export class CalendarUiEnhancementsPage {
     } else {
       await this.page.waitForTimeout(500);
     }
+  }
+
+  /**
+   * Create a single (non-recurring) event in the create-modal currently
+   * open, with the given title, start time, end time, and required dropdowns
+   * (first eForm + first planning tag + first assignee, mirroring
+   * createSimpleEvent in calendar-resize.spec.ts). Awaits the create POST
+   * and waits for the resulting `.task-block` to appear on the grid.
+   *
+   * The modal must already be open at the desired day slot — callers should
+   * pair this with `openCreateModalAtSlot(dayOffset, startHour)` first.
+   */
+  async fillAndSaveEvent(
+    title: string,
+    options: { endTime?: string; startTime?: string } = {},
+  ): Promise<void> {
+    await this.page.locator('#calendarEventTitle').fill(title);
+
+    if (options.startTime) {
+      await this.typeStartTime(options.startTime, 'Enter');
+    }
+    if (options.endTime) {
+      await this.typeEndTime(options.endTime, 'Enter');
+    }
+
+    const eform = this.page.locator('#calendarEventEform');
+    await eform.click();
+    await this.page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await this.page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await this.page.waitForTimeout(300);
+
+    const planningTag = this.page.locator('#calendarEventPlanningTag');
+    await planningTag.click();
+    await this.page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await this.page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await this.page.waitForTimeout(300);
+
+    const assignee = this.page.locator('#calendarEventAssignee');
+    await assignee.click();
+    await this.page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await this.page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await this.page.locator('#calendarEventTitle').click();
+    await this.page.waitForTimeout(300);
+
+    const createResp = this.page.waitForResponse(
+      r => r.url().includes('/api/backend-configuration-pn/calendar/tasks')
+        && !r.url().includes('/tasks/week')
+        && !r.url().includes('/tasks/move')
+        && !r.url().includes('/tasks/resize')
+        && r.request().method() === 'POST',
+      { timeout: 30000 }
+    );
+    await this.page.locator('#calendarEventSaveBtn').click();
+    await createResp;
+    await this.page.waitForTimeout(1500);
+    await this.findEventBlock(title).waitFor({ state: 'visible', timeout: 10000 });
   }
 
   /**

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.html
@@ -1,6 +1,7 @@
 <div
   class="task-block"
   [class.completed]="task.completed"
+  [class.compact]="isCompact"
   [class.gcal-task--inactive]="task.status === false"
   [class.resizing]="resizing"
   [class.raised]="raised"
@@ -36,7 +37,7 @@
 
     <div class="task-content">
       <div class="task-title"><span *ngIf="showId" class="task-id">{{ task.id }} </span>{{ task.title }}</div>
-      <div class="task-time" *ngIf="task.duration >= 0.5">{{ displayStartText }} – {{ displayEndText }}</div>
+      <div class="task-time" *ngIf="isCompact || task.duration >= 0.5">{{ displayStartText }} – {{ displayEndText }}</div>
     </div>
   </div>
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
@@ -144,6 +144,48 @@
     .task-time {
       font-size: 10px;
       opacity: 0.85;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  // Compact layout for cards under 40 px tall. Single inline row with the
+  // time sitting immediately after the title (left-aligned, not pinned
+  // right). Title shrinks to ellipsis first; the time stays whole.
+  //
+  // Vertical fit is the tight constraint here: a 15-min slot is clamped to
+  // 20 px tall, of which 4 px is border and 4 px is padding by default,
+  // leaving only 12 px for text. We trim padding to 1 px top/bottom,
+  // center-align the body, and force line-height to 1 so an 11 px line
+  // doesn't get clipped by a default 1.2-1.4 line-height box.
+  &.compact {
+    font-size: 11px;
+    line-height: 1;
+    padding-top: 1px;
+    padding-bottom: 1px;
+
+    .task-block-body { align-items: center; }
+
+    .task-content {
+      display: flex;
+      align-items: baseline;
+      gap: 6px;
+      line-height: 1;
+
+      .task-title { flex: 0 1 auto; min-width: 0; }
+      .task-time  { flex: 0 0 auto; font-variant-numeric: tabular-nums; }
+    }
+
+    // The completion disc shares the card's vertical space; a 16 px disc
+    // clips inside a ~14 px content area on a 15-min slot. Match the type
+    // and force a 1.0 line-height so Material's default leading doesn't
+    // re-introduce the same clipping.
+    .completion-btn mat-icon {
+      font-size: 12px;
+      width: 12px;
+      height: 12px;
+      line-height: 1;
     }
   }
 }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.ts
@@ -51,6 +51,16 @@ export class CalendarTaskBlockComponent {
     return Math.max(dur * this.hourHeight - 4, 20);
   }
 
+  // Cards shorter than 40 px can't fit the two-row stack without clipping
+  // the title or wrapping the time. Below the threshold, the template
+  // switches to a single inline row (title + time on the same baseline)
+  // and shrinks the type and the completion disc to match. 40 px lands
+  // between a 45-min slot (~35 px) and a 60-min slot (~48 px) at the
+  // default HOUR_HEIGHT, so it's a natural break.
+  get isCompact(): boolean {
+    return this.heightPx < 40;
+  }
+
   // Google-Calendar-style cascade-with-overlap. When raised, the card jumps
   // above all others in its conflict group and its right edge extends to
   // the column's right edge (the left edge stays put — see design spec


### PR DESCRIPTION
## Summary

Port of #878 (which was accidentally merged into \`master\` rather than the team's working branch \`stable\`). This PR cherry-picks the squashed commit \`27cfa773\` onto \`stable\` so users building from \`stable\` actually receive the fix.

Original PR description: https://github.com/microting/eform-backendconfiguration-plugin/pull/878

## What the change does

Short event cards in the backend-configuration calendar (\`/plugins/backend-configuration-pn/calendar\`) hid the start/stop time under 30 min, clipped the title, wrapped the time across two lines, and clipped the completion circle. Cards now adapt to their own height:

- **Compact (heightPx < 40, i.e. ≤ 45-min slots):** single inline row — title and start/stop time on the same baseline, left-aligned. Title shrinks to ellipsis first; the time never wraps. Font drops to 11px, line-height 1, vertical padding 1px, completion disc 12px.
- **Tall (heightPx ≥ 40):** unchanged two-row layout at 12px / 10px, with \`nowrap\` added to \`.task-time\`.

Cascade/overlap, drag, resize, completion, raised behaviour, and z-index are all untouched.

Includes a Playwright spec covering compact vs tall geometry, time no-wrap, long-title ellipsis, sub-30-min time visibility, completion click on a compact card, and cascade overlap rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)