### PR TITLE
Fix: contain calendar task-blocks below sticky day-header

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
@@ -203,6 +203,15 @@
 .day-cell-content {
   display: block;
   position: relative;
+  // Establish a local stacking context so task-block z-indexes (10, 11,
+  // 12, …) stay contained below the sticky day-header row. Without this,
+  // task-blocks bubble up to the nearest ancestor stacking context — past
+  // the .mat-mdc-header-row (z-index: 11 in the workspace theme) — and a
+  // cascaded second/third card can tie with or exceed the header z, so
+  // events at the top of the visible scroll range draw over the header.
+  // Setting z-index here doesn't change ordering of cards within the day
+  // column (the cascade still works); it only re-parents the comparison.
+  z-index: 1;
   border-left: 1px solid #dadce0;
   overflow: visible;
 }


### PR DESCRIPTION
## Summary

In the backend-configuration calendar's workspace theme, cascaded event cards (2+ overlapping events on the same day) were drawing OVER the sticky day-of-week header row. Visible as: a 60-min event at 01:00 on Sunday would extend up into the "SØN. 7" header area.

## Root cause

- `body.theme-workspace .mat-mdc-header-row` is `position: sticky; z-index: 11` (in eform-angular-frontend's `_workspace-mat-overrides.scss`, where the body-class scope wins on specificity over the calendar's own `.mat-mdc-header-row { z-index: 50 }` rule).
- `calendar-layout.service.ts` assigns `_zIndex = 10 + i` per cascade card. For a 2-event group: z=10, 11. For 3+: z=10, 11, 12, …
- `.day-cell-content` had `position: relative` but **no** `z-index`, so it did NOT establish a stacking context. Task-block z-indexes bubbled up to the nearest ancestor stacking context, where they compete directly with the header at z=11.
- Same-z ties broke in DOM order — task-blocks are siblings rendered after the header, so they won.

## Fix

Add `z-index: 1` to `.day-cell-content` in `calendar-week-grid.component.scss`. This establishes a local stacking context so task-block z-indexes (10, 11, 12+, including the raised-card z=999) are bounded by `.day-cell-content`'s z=1 at the ancestor level — well below the header.

Internal stacking is preserved:
- Cascade ordering of cards within a cell: unchanged (z=10/11/12 still order relative to each other).
- Click-to-raise (`z-index: 999` inline): still wins inside the cell.
- `.drag-source-slot` (z: 1 inside `.day-body` inside `.day-cell-content`): still works.
- `.drag-ghost-task` (z: 100, SIBLING of `.day-cell-content` in the week-grid wrapper): unaffected — outside the new stacking context.
- `theme-eform` (legacy theme): doesn't have a sticky header at competing z; this change is a no-op there.

## Test plan

- [x] Visual check via runtime CSS injection in the live calendar — events at 01:00 on Sunday now sit cleanly UNDER the day-header. Cascade still works. No other visual regressions.
- [ ] CI runs the existing calendar Playwright suites (`calendar-ui-enhancements`, `calendar-resize`, `calendar-event-card-layout` once #880 merges, `calendar-attachments`) — none of these rely on header stacking, so green is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)