### PR TITLE
Fix: weeklyMulti repeat emits Sunday at end of Mon-Sun week

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -2340,16 +2340,32 @@ public class BackendConfigurationCalendarService(
                     // Multi-day path: only emit occurrences in this week if
                     // the requested week is a multiple of repeatEvery weeks
                     // past the anchor week (Sunday-based, matches JS getDay).
+                    //
+                    // The stride check still uses Sunday-aligned weeks so the
+                    // bucket math is independent of the caller's week-start
+                    // convention. But the per-day projection MUST be relative
+                    // to the caller's weekStart, because the caller's week
+                    // may be Mon-Sun while wd uses JS getDay() (Sun=0..Sat=6).
+                    // Old code wrote `weekStartAligned.AddDays(wd)` which for
+                    // a Mon-Sun week with weekStart=Mon and weekStartAligned=
+                    // the prior Sun produced wd=0 → the Sun BEFORE the week,
+                    // then filtered it out — so Sunday at the END of the week
+                    // was never emitted. Project from weekStart instead.
                     var anchorWeekStart = startDate.AddDays(-(int)startDate.DayOfWeek);
                     var weekStartAligned = weekStart.Date.AddDays(-(int)weekStart.Date.DayOfWeek);
                     var weeksFromAnchor = (weekStartAligned - anchorWeekStart).Days / 7;
                     if (weeksFromAnchor >= 0 && weeksFromAnchor % repeatEvery == 0)
                     {
+                        var weekStartDow = (int)weekStart.Date.DayOfWeek;
                         foreach (var wd in weekdays)
                         {
-                            var candidate = weekStartAligned.AddDays(wd);
+                            // Days from weekStart to the date in the same
+                            // 7-day window with DayOfWeek == wd.
+                            var offset = ((wd - weekStartDow) % 7 + 7) % 7;
+                            var candidate = weekStart.Date.AddDays(offset);
                             if (candidate < startDate) continue;
-                            if (candidate < weekStart || candidate > weekEnd) continue;
+                            // candidate is by construction in [weekStart,
+                            // weekStart+6] — no further bounds guard needed.
                             occurrences.Add(candidate);
                         }
                     }


### PR DESCRIPTION
## Summary

A calendar event with a `weeklyMulti` repeat that includes Sunday (e.g., "hver onsdag og søndag" = every Wednesday and Sunday) renders on Wednesday but NOT on Sunday of the user's current Mon-Sun week.

**Concrete repro:** event with `RepeatType=Week`, `repeatEvery=1`, `RepeatWeekdaysCsv="0,3"`, startDate=Wed June 10 2026, viewed in week 24 (Mon June 8 – Sun June 14): only Wed Jun 10 was emitted. Sun Jun 14 was missing.

## Root cause

In `BackendConfigurationCalendarService.GetOccurrencesInWeek` (the multi-day `RepeatType.Week` branch around line 2348), the per-day projection was:

```csharp
var weekStartAligned = weekStart.Date.AddDays(-(int)weekStart.Date.DayOfWeek); // = the prior Sunday
foreach (var wd in weekdays) {
    var candidate = weekStartAligned.AddDays(wd);          // Sun-anchored
    if (candidate < weekStart || candidate > weekEnd) continue;  // wd=0 → Sun before week → filtered
    occurrences.Add(candidate);
}
```

For Mon-Sun weeks, `weekStartAligned` lands on the **Sunday before** the displayed week. Iterating `wd = 0..6` only produces `weekStartAligned + 0..6 = Sun..Sat` — Sun at the END of the user's week (`weekStart + 6`) is never generated.

`EnumerateOccurrences` (edit/move flow) iterates whole weeks via a `weekCursor` loop, so it does reach the next Sunday on its second iteration — verified, no fix needed there.

## Fix

Project each weekday relative to `weekStart` (the caller's actual week start), not `weekStartAligned`:

```csharp
var weekStartDow = (int)weekStart.Date.DayOfWeek;
foreach (var wd in weekdays) {
    var offset = ((wd - weekStartDow) % 7 + 7) % 7;       // 0..6 days from weekStart
    var candidate = weekStart.Date.AddDays(offset);
    if (candidate < startDate) continue;
    occurrences.Add(candidate);  // by construction in [weekStart, weekStart+6]
}
```

The stride check (`weeksFromAnchor % repeatEvery == 0`) still uses Sunday-aligned weeks — bucket math unchanged. Single-day legacy path (`weekdays.Length == 0`) is a separate branch, also unchanged.

## Test plan

- [x] Local visual check: event "hver onsdag og søndag" now appears on both Wed Jun 10 AND Sun Jun 14 in week 24.
- [ ] CI runs the existing playwright suites including the new `calendar-weekdays-repeat.spec.ts` (asserts Mon-Fri visibility for the "Alle hverdage" preset — equivalent multi-day projection, same code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)