### PR TITLE
fix(grpc): hide inactive events from mobile via Status filter

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventsGrpcServiceTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventsGrpcServiceTest.cs
@@ -193,7 +193,8 @@ public class EventsGrpcServiceTest : TestBaseSetup
             TaskDate = "2026-05-19",
             StartHour = 8.5,
             Completed = false,
-            Color = "#abcdef"
+            Color = "#abcdef",
+            Status = true
         };
 
         var service = MakeServiceWithTask(task);
@@ -234,7 +235,8 @@ public class EventsGrpcServiceTest : TestBaseSetup
             Title = "edge",
             PropertyId = PropertyIdInt,
             TaskDate = "2026-05-19",
-            StartHour = startHour
+            StartHour = startHour,
+            Status = true
         };
 
         var service = MakeServiceWithTask(task);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -251,6 +251,8 @@ public class EventsGrpcService(
 
         foreach (var task in result.Model)
         {
+            if (!task.Status) continue;
+
             envelopeByTaskId.TryGetValue(task.Id, out var envelope);
 
             var comment = envelope?.EventComment?.Text ?? string.Empty;
@@ -1006,6 +1008,8 @@ public class EventsGrpcService(
 
         foreach (var task in result.Model)
         {
+            if (!task.Status) continue;
+
             envelopeByTaskId.TryGetValue(task.Id, out var envelope);
             var comment = envelope?.EventComment?.Text ?? string.Empty;
 


### PR DESCRIPTION
## Summary
- The gRPC ListEvents / StreamEventChanges endpoints used by flutter-eform now filter out tasks where `AreaRulePlanning.Status == false` (the "Opgave nedtonet i tavle og vises ikke i app" / "task dimmed in board and not shown in app" calendar toggle).
- The Angular calendar REST path is intentionally unchanged so the web can still render these rows dimmed.
- Live toggles propagate to mobile via the existing `StreamEventChanges` diff loop, which emits `RemovedId` when an id drops out of the next poll (worst-case <=5 s staleness).

## Why
User-reported: an event with `Status=false` (dimmed in the web calendar, edit dialog confirms the "not shown in app" toggle is ON) was still appearing in the flutter-eform mobile list. Investigation showed the gRPC handler never consulted `Status` or `ComplianceEnabled`; the proto contract doesn't carry them either. Easiest fix is a server-side filter at the gRPC boundary, which keeps the wire contract narrow and avoids any client changes.

## Why this scope
- `Status=false` is the user-reported case and the one fixed here.
- The companion `Overskredet opgave vises ikke i app` (overdue not shown) toggle is *not* enforced in this PR. `CalendarTaskResponseModel.TaskIsExpired` is only populated on the task-tracker path, not the calendar-week path that serves these RPCs, so wiring that rule in would require non-trivial unrelated changes. Tracked for a follow-up.

## Test plan
- [ ] CI green
- [ ] Post-deploy: confirm on production that the dimmed event from the original report ("Gyllebeholder 2000 m3: Flydelagskontrol", `Status=false` on tenant 855) no longer appears in the flutter-eform event list, while events with `Status=true` continue to appear.
- [ ] Post-deploy: toggle a planning Status=true->false while a device is connected; confirm the event disappears from the mobile list within <=5 s (one `StreamPollInterval`).

Generated with [Claude Code](https://claude.com/claude-code)