### PR TITLE
Fix calendar occurrence visibility bugs + description UX

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarCompleteOccurrenceTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarCompleteOccurrenceTests.cs
@@ -1,0 +1,205 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+*/
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+using System.Globalization;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+
+/// <summary>
+/// Regression coverage for the bug where completing ONE occurrence of a
+/// multi-day recurring series (e.g. Mon–Fri) removed ALL the other
+/// (uncompleted) occurrences from the calendar week view.
+///
+/// Root cause was a per-PLANNING dedup gate in GetTasksForWeek's recurrence
+/// loop: the moment any compliance row existed for the planning in the week it
+/// skipped EVERY occurrence of that planning, not just the completed date. The
+/// fix keys the gate per (planning, date).
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarCompleteOccurrenceTests : TestBaseSetup
+{
+    private static string IsoUtc(DateTime d) =>
+        DateTime.SpecifyKind(d, DateTimeKind.Utc)
+            .ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+    private static DateTime GetNextMonday()
+    {
+        var today = DateTime.UtcNow.Date;
+        var daysUntilMonday = ((int)DayOfWeek.Monday - (int)today.DayOfWeek + 7) % 7;
+        if (daysUntilMonday == 0) daysUntilMonday = 7;
+        return DateTime.SpecifyKind(today.AddDays(daysUntilMonday), DateTimeKind.Utc);
+    }
+
+    [Test]
+    public async Task GetTasksForWeek_MultiDaySeries_CompleteOneDay_KeepsOtherDays()
+    {
+        // Boot a real SDK Core so the dedup path can read the backing Case.
+        var core = await GetCore();
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        var sdkSite = new Site
+        {
+            Name = "complete-occurrence-test-site",
+            MicrotingUid = 4343,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(sdkSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        // Status=100 backing case for the completed Tuesday occurrence.
+        var sdkCase = new Microting.eForm.Infrastructure.Data.Entities.Case
+        {
+            SiteId = sdkSite.Id,
+            Status = 100,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Cases.AddAsync(sdkCase);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var monday = GetNextMonday();
+
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"CompleteOccurrenceTest-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id, EformId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Week, StartDate = monday,
+            RelatedEFormId = 0, WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        // Mon–Fri multi-day weekly series.
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
+            ItemPlanningId = planning.Id, StartDate = monday, Status = true,
+            RepeatType = 2, RepeatEvery = 1, RepeatWeekdaysCsv = "1,2,3,4,5", DayOfWeek = 1,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // Complete only TUESDAY: one removed-completed Compliance for that date.
+        var tuesday = monday.AddDays(1);
+        var compliance = new Compliance
+        {
+            PlanningId = planning.Id, PropertyId = property.Id, AreaId = area.Id,
+            Deadline = tuesday, StartDate = monday.AddDays(-7),
+            MicrotingSdkCaseId = sdkCase.Id, MicrotingSdkeFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Removed
+        };
+        await BackendConfigurationPnDbContext.Compliances.AddAsync(compliance);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        userService.GetCurrentUserLanguage().Returns(Task.FromResult(language));
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+        var taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        taskWizardService.DeleteTask(Arg.Any<int>()).Returns(Task.FromResult(new OperationResult(true)));
+
+        var service = new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(), userService,
+            BackendConfigurationPnDbContext, coreHelper, Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext, taskWizardService,
+            NullLogger<BackendConfigurationCalendarService>.Instance);
+
+        // Calendar UI fetch (ActionableOnly=false) for the week of the series.
+        var result = await service.GetTasksForWeek(new CalendarTaskRequestModel
+        {
+            PropertyId = property.Id,
+            WeekStart = IsoUtc(monday),
+            WeekEnd = IsoUtc(monday.AddDays(6).AddHours(23).AddMinutes(59)),
+            ActionableOnly = false,
+            BoardIds = [], TagNames = [], SiteIds = []
+        });
+
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model, Is.Not.Null);
+
+        string Key(DateTime d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        bool HasTaskOn(DateTime d) => result.Model.Any(t => t.TaskDate == Key(d));
+
+        // The exact regression: the four UNCOMPLETED weekdays must still render.
+        // Pre-fix the per-planning gate dropped all of them, leaving only the
+        // completed Tuesday.
+        var tuesdayTasks = result.Model.Where(t => t.TaskDate == Key(tuesday)).ToList();
+        Assert.Multiple(() =>
+        {
+            Assert.That(HasTaskOn(monday), Is.True, "Monday (uncompleted) must remain visible");
+            Assert.That(HasTaskOn(monday.AddDays(2)), Is.True, "Wednesday (uncompleted) must remain visible");
+            Assert.That(HasTaskOn(monday.AddDays(3)), Is.True, "Thursday (uncompleted) must remain visible");
+            Assert.That(HasTaskOn(monday.AddDays(4)), Is.True, "Friday (uncompleted) must remain visible");
+
+            // The completed day itself must stay visible (rendered by the
+            // compliance loop) and must NOT be double-rendered (recurrence-emit
+            // suppressed for exactly that date).
+            Assert.That(tuesdayTasks, Has.Count.EqualTo(1), "Tuesday (completed) must render exactly once");
+            Assert.That(tuesdayTasks[0].IsFromCompliance, Is.True, "Tuesday must be the compliance row");
+            Assert.That(tuesdayTasks[0].Completed, Is.True, "Tuesday must show as completed");
+        });
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOccurrencesWeekTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOccurrencesWeekTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using NUnit.Framework;
+using ItemsPlanningRepeatType = Microting.ItemsPlanningBase.Infrastructure.Enums.RepeatType;
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+/// <summary>
+/// Pure-function unit tests for the private static
+/// <c>BackendConfigurationCalendarService.GetOccurrencesInWeek</c> occurrence
+/// generator (invoked via reflection — no DB / core needed).
+///
+/// Guards the "event disappears from the calendar after edit" regression: a
+/// weekly task whose StartDate landed on the trailing Sunday of a Mon-Sun
+/// caller week was dropped because the multi-day-weekly branch bucketed the
+/// whole caller week against a single Sunday-aligned week, computing
+/// weeksFromAnchor = -1. The fix gates the stride per-candidate on the
+/// candidate's own Sunday-aligned week.
+///
+/// June 2026 calendar reference: Mon 1st .. Sun 7th; Wed = 3rd, Thu = 4th.
+/// </summary>
+[TestFixture]
+public class CalendarOccurrencesWeekTests
+{
+    private static readonly DateTime Monday = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Wednesday = new(2026, 6, 3, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Thursday = new(2026, 6, 4, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Sunday = new(2026, 6, 7, 0, 0, 0, DateTimeKind.Utc);
+
+    private static List<DateTime> GetOccurrencesInWeek(
+        Planning planning, DateTime weekStart, DateTime weekEnd, string? repeatWeekdaysCsv)
+    {
+        var mi = typeof(BackendConfigurationCalendarService).GetMethod(
+            "GetOccurrencesInWeek", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.That(mi, Is.Not.Null, "GetOccurrencesInWeek(...) signature changed — update this test");
+        return (List<DateTime>)mi!.Invoke(null,
+            new object?[] { planning, weekStart, weekEnd, repeatWeekdaysCsv, null, null })!;
+    }
+
+    private static Planning Weekly(DateTime startDate, int repeatEvery = 1) => new()
+    {
+        StartDate = startDate,
+        RepeatType = ItemsPlanningRepeatType.Week,
+        RepeatEvery = repeatEvery,
+    };
+
+    // The exact regression: anchor on the trailing Sunday must render in its
+    // own Mon-Sun week. Pre-fix this returned empty and the event vanished.
+    [Test]
+    public void Weekly_SundayAnchor_RendersInOwnWeek()
+    {
+        var occ = GetOccurrencesInWeek(Weekly(Sunday), Monday, Sunday, "0");
+        Assert.That(occ, Does.Contain(Sunday));
+    }
+
+    // Sibling weekdays were never affected — assert they still render so the
+    // fix didn't change correct behaviour.
+    [Test]
+    public void Weekly_MondayAnchor_RendersInOwnWeek()
+    {
+        var occ = GetOccurrencesInWeek(Weekly(Monday), Monday, Sunday, "1");
+        Assert.That(occ, Does.Contain(Monday));
+    }
+
+    [Test]
+    public void Weekly_ThursdayAnchor_RendersInOwnWeek()
+    {
+        var occ = GetOccurrencesInWeek(Weekly(Thursday), Monday, Sunday, "4");
+        Assert.That(occ, Does.Contain(Thursday));
+    }
+
+    // Mixed multi-day CSV whose days fall in different Sunday-weeks within one
+    // Mon-Sun caller week (Wed in the 05-31 Sunday-week, Sun in the 06-07 one):
+    // both must render.
+    [Test]
+    public void Weekly_WedSundayCsv_RendersBothDays()
+    {
+        var occ = GetOccurrencesInWeek(Weekly(Wednesday), Monday, Sunday, "3,0");
+        Assert.That(occ, Does.Contain(Wednesday));
+        Assert.That(occ, Does.Contain(Sunday));
+    }
+
+    // Bi-weekly Sunday anchor: renders in week 0, skipped in week 1, renders in
+    // week 2 — proves the per-candidate stride still honours repeatEvery.
+    [Test]
+    public void Weekly_BiweeklySundayAnchor_RespectsStride()
+    {
+        var plan = Weekly(Sunday, repeatEvery: 2);
+
+        var week0 = GetOccurrencesInWeek(plan, Monday, Sunday, "0");
+        Assert.That(week0, Does.Contain(Sunday), "week 0 (anchor week) should render");
+
+        var nextMonday = Monday.AddDays(7);
+        var nextSunday = Sunday.AddDays(7);
+        var week1 = GetOccurrencesInWeek(plan, nextMonday, nextSunday, "0");
+        Assert.That(week1, Is.Empty, "week 1 is off-stride for a bi-weekly task");
+
+        var week2Monday = Monday.AddDays(14);
+        var week2Sunday = Sunday.AddDays(14);
+        var week2 = GetOccurrencesInWeek(plan, week2Monday, week2Sunday, "0");
+        Assert.That(week2, Does.Contain(week2Sunday), "week 2 is on-stride and should render");
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -211,7 +211,7 @@ public class BackendConfigurationCalendarService(
                 // Bug A fix (compliance 9810 / case 17701 retracted-rotation parity):
                 // when a compliance is filtered out by IsComplianceActionable (retracted SDK
                 // case, soft-deleted, or status==100), the recurrence-emit loop below STILL
-                // fires for that planning's occurrence date because compliancePlanningIdsInWeek
+                // fires for that planning's occurrence date because the compliance dedup set
                 // (built from the filtered actionable subset) no longer contains it. Without
                 // intervention the model emitted by that loop has ComplianceId=null /
                 // SdkCaseId=null, the device caches compliance_id=0 in Drift, and any
@@ -278,9 +278,7 @@ public class BackendConfigurationCalendarService(
             // ActionableOnly callers is actionable ∪ removed-completed so the recurrence-
             // emit loop doesn't double-fire a date the worker just completed.
             var complianceDateSet = new HashSet<string>(
-                compliancesForDedup.Select(c => $"{c.PlanningId}:{c.Deadline:yyyy-MM-dd}"));
-            var compliancePlanningIdsInWeek = new HashSet<int>(
-                compliancesForDedup.Select(c => c.PlanningId));
+                compliancesForDedup.Select(c => $"{c.PlanningId}:{c.Deadline.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}"));
 
             // 1. Query AreaRulePlannings (future/active and inactive tasks).
             // Inactive (Status=false) plannings are included so the calendar can
@@ -416,7 +414,14 @@ public class BackendConfigurationCalendarService(
 
                 foreach (var occurrenceDate in occurrences)
                 {
-                    if (compliancePlanningIdsInWeek.Contains(arp.ItemPlanningId))
+                    // Suppress recurrence-emit ONLY for the specific date(s) that
+                    // already have a compliance row (rendered by the compliance
+                    // loop below) — keyed per (planning, date). The previous gate
+                    // keyed per planningId, so completing ONE occurrence of a
+                    // multi-day series (e.g. Mon-Fri) created a compliance row
+                    // and then suppressed EVERY sibling occurrence, making the
+                    // other (uncompleted) days disappear from the week.
+                    if (complianceDateSet.Contains($"{arp.ItemPlanningId}:{occurrenceDate.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}"))
                         continue;
 
                     CalendarOccurrenceException exception = null;
@@ -2351,23 +2356,34 @@ public class BackendConfigurationCalendarService(
                     // the prior Sun produced wd=0 → the Sun BEFORE the week,
                     // then filtered it out — so Sunday at the END of the week
                     // was never emitted. Project from weekStart instead.
+                    // Sunday-aligned anchor week (matches JS getDay numbering),
+                    // consistent with EnumerateOccurrences above.
                     var anchorWeekStart = startDate.AddDays(-(int)startDate.DayOfWeek);
-                    var weekStartAligned = weekStart.Date.AddDays(-(int)weekStart.Date.DayOfWeek);
-                    var weeksFromAnchor = (weekStartAligned - anchorWeekStart).Days / 7;
-                    if (weeksFromAnchor >= 0 && weeksFromAnchor % repeatEvery == 0)
+                    var weekStartDow = (int)weekStart.Date.DayOfWeek;
+                    foreach (var wd in weekdays)
                     {
-                        var weekStartDow = (int)weekStart.Date.DayOfWeek;
-                        foreach (var wd in weekdays)
-                        {
-                            // Days from weekStart to the date in the same
-                            // 7-day window with DayOfWeek == wd.
-                            var offset = ((wd - weekStartDow) % 7 + 7) % 7;
-                            var candidate = weekStart.Date.AddDays(offset);
-                            if (candidate < startDate) continue;
-                            // candidate is by construction in [weekStart,
-                            // weekStart+6] — no further bounds guard needed.
+                        // Days from weekStart to the date in the same
+                        // 7-day window with DayOfWeek == wd. candidate is by
+                        // construction in [weekStart, weekStart+6].
+                        var offset = ((wd - weekStartDow) % 7 + 7) % 7;
+                        var candidate = weekStart.Date.AddDays(offset);
+                        if (candidate < startDate) continue;
+                        // Gate the stride PER CANDIDATE on the candidate's own
+                        // Sunday-aligned week. A Mon-Sun caller week straddles
+                        // TWO Sunday-aligned weeks (Mon-Sat in one, the trailing
+                        // Sunday in the next), so a single gate computed from
+                        // weekStart's Sunday-week wrongly rejected an occurrence
+                        // whose anchor landed on that trailing Sunday
+                        // (weeksFromAnchor = -1) — the event disappeared from
+                        // its own week after an edit moved the StartDate onto a
+                        // Sunday. Computing weeksFromAnchor from `candidate`
+                        // instead also fixes mixed multi-day CSVs (e.g. "3,0"
+                        // Wed+Sun) whose days fall in different Sunday-weeks
+                        // within one caller week.
+                        var candidateWeekStart = candidate.AddDays(-(int)candidate.DayOfWeek);
+                        var weeksFromAnchor = (candidateWeekStart - anchorWeekStart).Days / 7;
+                        if (weeksFromAnchor >= 0 && weeksFromAnchor % repeatEvery == 0)
                             occurrences.Add(candidate);
-                        }
                     }
                 }
                 break;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/repeat-scope-modal/repeat-scope-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/repeat-scope-modal/repeat-scope-modal.component.html
@@ -11,6 +11,6 @@
 </div>
 
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
-  <button class="btn-cancel" (click)="onCancel()">{{ 'Cancel' | translate }}</button>
-  <button class="btn-primary btn-primary--icon-left" (click)="onConfirm()">{{ 'Confirm' | translate }}</button>
+  <button id="repeatScopeCancelBtn" class="btn-cancel" (click)="onCancel()">{{ 'Cancel' | translate }}</button>
+  <button id="repeatScopeConfirmBtn" class="btn-primary btn-primary--icon-left" (click)="onConfirm()">{{ 'Confirm' | translate }}</button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
@@ -90,6 +90,7 @@
         <mat-form-field class="w-100">
           <mat-label>{{ 'Repeat' | translate }}</mat-label>
           <mtx-select
+            id="calendarEventRepeat"
             [formControl]="repeatControl"
             [items]="repeatOptions"
             bindValue="value"
@@ -233,9 +234,11 @@
     <div class="gcal-row">
       <mat-icon class="gcal-icon">notes</mat-icon>
       <div class="gcal-row-content">
-        <mat-form-field class="w-100">
+        <mat-form-field class="w-100 gcal-description-field">
           <mat-label>{{ 'Description' | translate }}</mat-label>
-          <textarea id="calendarEventDescription" matInput [formControl]="descriptionControl" rows="2"></textarea>
+          <textarea #descriptionTextarea id="calendarEventDescription" class="gcal-description-textarea" matInput
+                    [formControl]="descriptionControl" rows="2"
+                    (input)="autoGrowTextarea($event)"></textarea>
         </mat-form-field>
       </div>
     </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
@@ -103,6 +103,30 @@
   min-width: 0;
 }
 
+// Description box: auto-grows with content (see growTextarea) and stays
+// user-resizable via the native vertical drag handle. Capped so a very long
+// description scrolls internally instead of pushing the popover off-screen.
+.gcal-description-textarea {
+  resize: vertical;
+  min-height: 40px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+// The global theme locks EVERY .mat-mdc-text-field-wrapper to a fixed 40px
+// height with overflow:hidden (canonical 40px outlined box) via
+// `body.theme-workspace .mat-mdc-form-field .mat-mdc-text-field-wrapper`
+// [specificity (0,3,1)]. That clips the auto-growing description textarea.
+// Scope an exception to this one field so the wrapper grows with the textarea
+// (the infix already does). The `.gcal-description-field.mat-mdc-form-field`
+// compound lifts this to (0,4,0) so it beats the theme rule, and !important
+// beats MDC's own declarations.
+:host ::ng-deep .gcal-description-field.mat-mdc-form-field .mat-mdc-text-field-wrapper {
+  height: auto !important;
+  min-height: 40px !important;
+  overflow: visible !important;
+}
+
 // Stack paired slide-toggles (e.g. Aktiv/Inaktiv, Vis/Skjul overskredet)
 // one per line. Without this they default to mat-slide-toggle's inline-flex
 // and pack side-by-side until the row wraps.

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Inject, OnDestroy, OnInit, Optional, Output} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, EventEmitter, Inject, OnDestroy, OnInit, Optional, Output, ViewChild} from '@angular/core';
 import {FormControl, Validators} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {Overlay} from '@angular/cdk/overlay';
@@ -66,9 +66,10 @@ declare const google: any;
   templateUrl: './task-create-edit-modal.component.html',
   styleUrls: ['./task-create-edit-modal.component.scss'],
 })
-export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
+export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDestroy {
   @Output() popoverClose = new EventEmitter<boolean | null>();
   @Output() timeChanged = new EventEmitter<{startHour: number; endHour: number}>();
+  @ViewChild('descriptionTextarea') descriptionTextarea?: ElementRef<HTMLTextAreaElement>;
   usePopoverMode = false;
 
   isEditMode = false;
@@ -565,9 +566,33 @@ export class TaskCreateEditModalComponent implements OnInit, OnDestroy {
   };
 
   autoGrowTextarea(event: Event) {
-    const el = event.target as HTMLTextAreaElement;
+    this.growTextarea(event.target as HTMLTextAreaElement);
+  }
+
+  /**
+   * Auto-expand the description textarea to fit its content. Resetting to
+   * 'auto' first lets it both grow (typing more lines) and shrink (deleting
+   * lines) back to the content height. The `resize: vertical` handle (see
+   * SCSS) still lets the user drag it taller; the next keystroke re-fits to
+   * content, which is the conventional "autosize + resizable" behaviour.
+   */
+  private growTextarea(el: HTMLTextAreaElement | null) {
+    if (!el) return;
     el.style.height = 'auto';
     el.style.height = el.scrollHeight + 'px';
+  }
+
+  /**
+   * Size the description box to fit any pre-existing (edit/copy mode) text so
+   * a multi-line description opens fully expanded instead of clipped to two
+   * rows. Deferred a tick so the formControl value has rendered.
+   */
+  ngAfterViewInit() {
+    setTimeout(() => {
+      if (this.descriptionControl.value) {
+        this.growTextarea(this.descriptionTextarea?.nativeElement ?? null);
+      }
+    });
   }
 
   private emitTimeChanged() {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.html
@@ -48,9 +48,9 @@
     </div>
 
     <!-- Description -->
-    <div class="preview-row" *ngIf="data.task.descriptionHtml">
+    <div class="preview-row preview-row--description" *ngIf="data.task.descriptionHtml">
       <mat-icon class="preview-icon">notes</mat-icon>
-      <span [innerHTML]="data.task.descriptionHtml"></span>
+      <span class="preview-description">{{ data.task.descriptionHtml }}</span>
     </div>
 
     <!-- Drive link -->

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.scss
@@ -80,3 +80,19 @@
   margin-right: 16px;
   flex-shrink: 0;
 }
+
+// Description can span multiple lines: top-align the icon and preserve the
+// line breaks / whitespace the user typed in the Beskrivelse field so the
+// formatting is reflected here. Long words wrap instead of overflowing.
+.preview-row--description {
+  align-items: flex-start;
+
+  .preview-icon {
+    margin-top: 7px;
+  }
+}
+
+.preview-description {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Summary
Fixes two calendar week-view occurrence-visibility regressions and improves the description field UX.

### Bug 1 — editing an event made it disappear from its own week
`GetOccurrencesInWeek`'s multi-day weekly branch gated the whole Mon–Sun caller week against a single Sunday-aligned week, so an occurrence whose anchor landed on the **trailing Sunday** computed `weeksFromAnchor = -1` and was dropped. Editing relocates the series `StartDate` onto the clicked occurrence's date, so editing any Sunday occurrence triggered it. Now the stride is gated **per-candidate** on each candidate's own Sunday-aligned week (also fixes mixed CSVs like `"3,0"`). Follow-on to #882.

### Bug 2 — completing one day of a multi-day series removed the others
The recurrence-emit dedup gate keyed **per planningId**, so any compliance row for the planning suppressed *every* occurrence (e.g. completing Tuesday of a Mon–Fri series hid Mon/Wed/Thu/Fri). Now keyed **per (planning, date)** using the already-built `complianceDateSet`; the unused `compliancePlanningIdsInWeek` set is removed.

### Description field UX
- Beskrivelse textarea auto-grows while typing and stays user-resizable (scoped override beats the global `40px` text-field-wrapper theme rule that was clipping it).
- Event detail popover renders the description with preserved line breaks (`white-space: pre-wrap`, safe interpolation instead of `innerHTML`).
- Added stable ids (`calendarEventRepeat`, `repeatScope{Confirm,Cancel}Btn`) for e2e testing.

## Tests
- `CalendarOccurrencesWeekTests` — trailing-Sunday / bi-weekly / mixed-CSV occurrence generation (reflection, no DB). 5 tests.
- `CalendarCompleteOccurrenceTests` — completing one day of a Mon–Fri series keeps the other four visible and the completed day rendered exactly once. Mirrors the existing `CalendarActionableOnlyTests` harness.

All new + existing calendar backend tests pass locally; verified live in the running app for both bugs and the textarea/formatting.

A companion PR in `eform-angular-frontend` adds a Playwright e2e regression spec for the edit-stays-visible case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)