### PR TITLE
Make calendar UpdateTask scope-aware (#885)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarUpdateTaskScopeTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarUpdateTaskScopeTests.cs
@@ -1,0 +1,384 @@
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Infrastructure.Models.TaskWizard;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.eForm.Infrastructure.Models;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+/// <summary>
+/// Scope-aware UpdateTask behavior for issue #885. Mirrors the fixture/seed
+/// pattern of <see cref="CalendarOccurrenceExceptionTests"/>. The task wizard
+/// is mocked, so the helpers' own DB writes are what these tests assert.
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarUpdateTaskScopeTests : TestBaseSetup
+{
+    private IUserService _userService;
+    private IBackendConfigurationTaskWizardService _taskWizardService;
+    private BackendConfigurationCalendarService _calendarService;
+
+    [SetUp]
+    public async Task SetupCalendarService()
+    {
+        // FK-safe cleanup so each test starts fresh.
+        BackendConfigurationPnDbContext!.CalendarOccurrenceExceptionSites.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarOccurrenceExceptionSites);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.CalendarOccurrenceExceptions.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarOccurrenceExceptions);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.CalendarConfigurations.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarConfigurations);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRulePlannings.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRulePlannings);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRuleTranslations.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRuleTranslations);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRules.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRules);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.Areas.RemoveRange(
+            BackendConfigurationPnDbContext.Areas);
+        BackendConfigurationPnDbContext.Properties.RemoveRange(
+            BackendConfigurationPnDbContext.Properties);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        ItemsPlanningPnDbContext!.Plannings.RemoveRange(
+            ItemsPlanningPnDbContext.Plannings);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        _userService = Substitute.For<IUserService>();
+        _userService.UserId.Returns(1);
+        _userService.GetCurrentUserLanguage()
+            .Returns(Task.FromResult(new Language { Id = 1, Name = "English", LanguageCode = "en-US" }));
+
+        _taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        // scope=all / thisAndFollowing delegate field updates to the wizard.
+        _taskWizardService.UpdateTask(Arg.Any<TaskWizardCreateModel>())
+            .Returns(Task.FromResult(new OperationResult(true)));
+
+        _calendarService = new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(),
+            _userService,
+            BackendConfigurationPnDbContext!,
+            null,
+            Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext!,
+            _taskWizardService,
+            NullLogger<BackendConfigurationCalendarService>.Instance
+        );
+    }
+
+    private static DateTime GetNextMonday()
+    {
+        var today = DateTime.UtcNow.Date;
+        var daysUntilMonday = ((int)DayOfWeek.Monday - (int)today.DayOfWeek + 7) % 7;
+        if (daysUntilMonday == 0) daysUntilMonday = 7; // always future
+        return today.AddDays(daysUntilMonday);
+    }
+
+    /// <summary>
+    /// Seeds Area→Property→AreaRule(+translation)→Planning→AreaRulePlanning→
+    /// CalendarConfiguration for a weekly series. Returns the ARP Id.
+    /// </summary>
+    private async Task<int> SeedWeeklyTask(DateTime startDate, string title = "Original Title")
+    {
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"TestProp-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id, EformId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRuleTranslation = new AreaRuleTranslation
+        {
+            AreaRuleId = areaRule.Id, LanguageId = 1, Name = title,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRuleTranslations.AddAsync(areaRuleTranslation);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Week, StartDate = startDate,
+            RelatedEFormId = 0, Description = "Original description",
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
+            ItemPlanningId = planning.Id, StartDate = startDate, Status = true,
+            RepeatType = 2, RepeatEvery = 1,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        return arp.Id;
+    }
+
+    private static CalendarTaskUpdateRequestModel BuildEdit(int arpId, DateTime startDate, string scope,
+        DateTime originalDate, string title = "Edited Title", double startHour = 11.0, double duration = 2.0,
+        int propertyId = 0)
+    {
+        return new CalendarTaskUpdateRequestModel
+        {
+            Id = arpId,
+            Scope = scope,
+            OriginalDate = originalDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            StartDate = DateTime.SpecifyKind(startDate, DateTimeKind.Utc),
+            StartHour = startHour,
+            Duration = duration,
+            Status = 1,
+            RepeatType = 2,
+            RepeatEvery = 1,
+            ComplianceEnabled = false,
+            PropertyId = propertyId,
+            EformId = 0,
+            Sites = [101],
+            TagIds = [],
+            BoardId = 42,
+            Color = "#abcdef",
+            DescriptionHtml = "Edited description",
+            Translates = [new CommonTranslationsModel { LanguageId = 1, Name = title }]
+        };
+    }
+
+    [Test]
+    public async Task UpdateTask_ScopeThis_DoesNotCallWizard_NorMoveSeriesStart()
+    {
+        var baseMonday = GetNextMonday();
+        var startDate = DateTime.SpecifyKind(baseMonday, DateTimeKind.Utc);
+        var arpId = await SeedWeeklyTask(startDate);
+
+        var model = BuildEdit(arpId, baseMonday, "this", baseMonday);
+        var result = await _calendarService.UpdateTask(model);
+
+        Assert.That(result.Success, Is.True, result.Message);
+        // The bug: relocating the series. A "this" edit must not touch the series anchor.
+        await _taskWizardService.DidNotReceive().UpdateTask(Arg.Any<TaskWizardCreateModel>());
+        var arp = await BackendConfigurationPnDbContext!.AreaRulePlannings.FirstAsync(x => x.Id == arpId);
+        Assert.That(arp.StartDate!.Value.Date, Is.EqualTo(baseMonday.Date));
+    }
+
+    [Test]
+    public async Task UpdateTask_ScopeThis_CreatesExceptionWithFieldOverrides()
+    {
+        var baseMonday = GetNextMonday();
+        var startDate = DateTime.SpecifyKind(baseMonday, DateTimeKind.Utc);
+        var arpId = await SeedWeeklyTask(startDate);
+
+        var model = BuildEdit(arpId, baseMonday, "this", baseMonday,
+            title: "Edited Title", startHour: 11.0, duration: 2.0);
+        var result = await _calendarService.UpdateTask(model);
+
+        Assert.That(result.Success, Is.True, result.Message);
+        var exception = await BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions
+            .Include(x => x.ExceptionSites)
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .SingleAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.OriginalDate.Date, Is.EqualTo(baseMonday.Date));
+            Assert.That(exception.Title, Is.EqualTo("Edited Title"));
+            Assert.That(exception.DescriptionHtml, Is.EqualTo("Edited description"));
+            Assert.That(exception.BoardId, Is.EqualTo(42));
+            Assert.That(exception.Color, Is.EqualTo("#abcdef"));
+            Assert.That(exception.StartHour, Is.EqualTo(11.0));
+            Assert.That(exception.Duration, Is.EqualTo(2.0));
+            Assert.That(exception.IsDeleted, Is.False);
+            // NewDate stays null when the occurrence date is unchanged.
+            Assert.That(exception.NewDate, Is.Null);
+            // Per-occurrence assignees recorded without touching the series.
+            Assert.That(exception.ExceptionSites
+                .Where(s => s.WorkflowState != Constants.WorkflowStates.Removed)
+                .Select(s => s.SiteId), Is.EquivalentTo(new[] { 101 }));
+        });
+    }
+
+    [Test]
+    public async Task UpdateTask_ScopeThis_ReusesExistingExceptionForDate()
+    {
+        var baseMonday = GetNextMonday();
+        var startDate = DateTime.SpecifyKind(baseMonday, DateTimeKind.Utc);
+        var arpId = await SeedWeeklyTask(startDate);
+
+        // Pre-existing move-style exception for the same occurrence.
+        var existing = new CalendarOccurrenceException
+        {
+            AreaRulePlanningId = arpId, OriginalDate = baseMonday, IsDeleted = false,
+            StartHour = 8.0, WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions.AddAsync(existing);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var model = BuildEdit(arpId, baseMonday, "this", baseMonday, startHour: 13.0);
+        var result = await _calendarService.UpdateTask(model);
+
+        Assert.That(result.Success, Is.True, result.Message);
+        var exceptions = await BackendConfigurationPnDbContext.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        Assert.That(exceptions, Has.Count.EqualTo(1), "should update the existing row, not create a duplicate");
+        Assert.That(exceptions[0].StartHour, Is.EqualTo(13.0));
+        Assert.That(exceptions[0].Title, Is.EqualTo("Edited Title"));
+    }
+
+    [Test]
+    public async Task UpdateTask_ScopeThis_OnPreviouslyDeletedOccurrence_UnDeletesIt()
+    {
+        var baseMonday = GetNextMonday();
+        var startDate = DateTime.SpecifyKind(baseMonday, DateTimeKind.Utc);
+        var arpId = await SeedWeeklyTask(startDate);
+
+        // A prior "delete this occurrence" left an IsDeleted exception.
+        var deleted = new CalendarOccurrenceException
+        {
+            AreaRulePlanningId = arpId, OriginalDate = baseMonday, IsDeleted = true,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions.AddAsync(deleted);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var model = BuildEdit(arpId, baseMonday, "this", baseMonday);
+        var result = await _calendarService.UpdateTask(model);
+
+        Assert.That(result.Success, Is.True, result.Message);
+        var exception = await BackendConfigurationPnDbContext.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .SingleAsync();
+        // Editing the occurrence must bring it back so the edit is visible.
+        Assert.That(exception.IsDeleted, Is.False);
+        Assert.That(exception.Title, Is.EqualTo("Edited Title"));
+    }
+
+    [Test]
+    public async Task UpdateTask_ScopeAll_DoesNotCreateException_AndUpdatesCalConfig()
+    {
+        var baseMonday = GetNextMonday();
+        var startDate = DateTime.SpecifyKind(baseMonday, DateTimeKind.Utc);
+        var arpId = await SeedWeeklyTask(startDate);
+
+        var model = BuildEdit(arpId, baseMonday, "all", baseMonday, startHour: 14.0, duration: 1.5);
+        var result = await _calendarService.UpdateTask(model);
+
+        Assert.That(result.Success, Is.True, result.Message);
+        // "all" goes through the wizard for field updates...
+        await _taskWizardService.Received().UpdateTask(Arg.Any<TaskWizardCreateModel>());
+        // ...and writes no per-occurrence exception.
+        var exceptions = await BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        Assert.That(exceptions, Is.Empty);
+        var calConfig = await BackendConfigurationPnDbContext.CalendarConfigurations
+            .FirstAsync(x => x.AreaRulePlanningId == arpId);
+        Assert.That(calConfig.StartHour, Is.EqualTo(14.0));
+        Assert.That(calConfig.Duration, Is.EqualTo(1.5));
+        Assert.That(calConfig.BoardId, Is.EqualTo(42));
+    }
+
+    [Test]
+    public async Task UpdateTask_ScopeThisAndFollowing_AnchorsPastOccurrences_KeepsSeriesStart()
+    {
+        var nextMonday = GetNextMonday();
+        // Series started four weeks before the edited (future) occurrence.
+        var seriesStart = DateTime.SpecifyKind(nextMonday.AddDays(-28), DateTimeKind.Utc);
+        var arpId = await SeedWeeklyTask(seriesStart);
+
+        // Edit "this and following" at the upcoming (future) Monday.
+        var model = BuildEdit(arpId, nextMonday, "thisAndFollowing", nextMonday, startHour: 11.0, duration: 2.0);
+        var result = await _calendarService.UpdateTask(model);
+
+        Assert.That(result.Success, Is.True, result.Message);
+
+        // Four past occurrences (seriesStart, +7, +14, +21) anchored with OLD values.
+        var anchors = await BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .OrderBy(x => x.OriginalDate)
+            .ToListAsync();
+        Assert.That(anchors, Has.Count.EqualTo(4), "one anchor per past occurrence before originalDate");
+        Assert.Multiple(() =>
+        {
+            foreach (var a in anchors)
+            {
+                Assert.That(a.OriginalDate.Date, Is.LessThan(nextMonday.Date));
+                Assert.That(a.StartHour, Is.EqualTo(9.0), "past anchors keep the OLD start hour");
+                Assert.That(a.Duration, Is.EqualTo(1.0), "past anchors keep the OLD duration");
+                Assert.That(a.IsDeleted, Is.False);
+            }
+        });
+
+        // Series anchor must NOT have been relocated onto the edited occurrence.
+        var arp = await BackendConfigurationPnDbContext.AreaRulePlannings.FirstAsync(x => x.Id == arpId);
+        Assert.That(arp.StartDate!.Value.Date, Is.EqualTo(seriesStart.Date));
+
+        // Series (and therefore future occurrences) reflect the NEW values.
+        var calConfig = await BackendConfigurationPnDbContext.CalendarConfigurations
+            .FirstAsync(x => x.AreaRulePlanningId == arpId);
+        Assert.That(calConfig.StartHour, Is.EqualTo(11.0));
+        Assert.That(calConfig.Duration, Is.EqualTo(2.0));
+
+        // The wizard is used for the series field update, anchored at the
+        // ORIGINAL start date (not the edited occurrence's date) — the #885 fix.
+        await _taskWizardService.Received().UpdateTask(
+            Arg.Is<TaskWizardCreateModel>(m => m.StartDate == arp.StartDate));
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarUpdateTaskScopeTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarUpdateTaskScopeTests.cs
@@ -104,7 +104,8 @@ public class CalendarUpdateTaskScopeTests : TestBaseSetup
     /// Seeds Area→Property→AreaRule(+translation)→Planning→AreaRulePlanning→
     /// CalendarConfiguration for a weekly series. Returns the ARP Id.
     /// </summary>
-    private async Task<int> SeedWeeklyTask(DateTime startDate, string title = "Original Title")
+    private async Task<int> SeedWeeklyTask(DateTime startDate, string title = "Original Title",
+        int arpRepeatType = 2)
     {
         var area = new Area
         {
@@ -151,7 +152,7 @@ public class CalendarUpdateTaskScopeTests : TestBaseSetup
         {
             AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
             ItemPlanningId = planning.Id, StartDate = startDate, Status = true,
-            RepeatType = 2, RepeatEvery = 1,
+            RepeatType = arpRepeatType, RepeatEvery = 1,
             WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
         };
         await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
@@ -277,6 +278,33 @@ public class CalendarUpdateTaskScopeTests : TestBaseSetup
         Assert.That(exceptions, Has.Count.EqualTo(1), "should update the existing row, not create a duplicate");
         Assert.That(exceptions[0].StartHour, Is.EqualTo(13.0));
         Assert.That(exceptions[0].Title, Is.EqualTo("Edited Title"));
+    }
+
+    [Test]
+    public async Task UpdateTask_ScopeThis_OnNonRecurringTask_UpdatesSeries_NoException()
+    {
+        var baseMonday = GetNextMonday();
+        var startDate = DateTime.SpecifyKind(baseMonday, DateTimeKind.Utc);
+        // One-off event (RepeatType=0). The frontend sends scope="this" for
+        // non-recurring edits — the backend must treat it as a full update.
+        var arpId = await SeedWeeklyTask(startDate, arpRepeatType: 0);
+
+        var model = BuildEdit(arpId, baseMonday, "this", baseMonday, startHour: 15.0);
+        model.RepeatType = 0;
+        var result = await _calendarService.UpdateTask(model);
+
+        Assert.That(result.Success, Is.True, result.Message);
+        // Must NOT create an occurrence exception for a one-off...
+        var exceptions = await BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        Assert.That(exceptions, Is.Empty);
+        // ...and must update the event itself (wizard + CalendarConfiguration).
+        await _taskWizardService.Received().UpdateTask(Arg.Any<TaskWizardCreateModel>());
+        var calConfig = await BackendConfigurationPnDbContext.CalendarConfigurations
+            .FirstAsync(x => x.AreaRulePlanningId == arpId);
+        Assert.That(calConfig.StartHour, Is.EqualTo(15.0));
     }
 
     [Test]

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -225,7 +225,7 @@
     <PackageReference Include="Microting.EformAngularFrontendBase" Version="10.0.34" />
     <PackageReference Include="Microting.eFormApi.BasePn" Version="10.0.26" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
-    <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.38" />
+    <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.39" />
     <PackageReference Include="Microting.eFormCaseTemplateBase" Version="10.0.30" />
     <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.31" />
     <PackageReference Include="Microting.TimePlanningBase" Version="10.0.48" />

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskUpdateRequestModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskUpdateRequestModel.cs
@@ -3,4 +3,13 @@ namespace BackendConfiguration.Pn.Infrastructure.Models.Calendar;
 public class CalendarTaskUpdateRequestModel : CalendarTaskCreateRequestModel
 {
     public int Id { get; set; }
+
+    // Edit scope (issue #885): "this" | "thisAndFollowing" | "all".
+    // Null/empty is treated as "all" for backward compatibility.
+    public string Scope { get; set; }
+
+    // The pre-edit occurrence date ("yyyy-MM-dd") the user opened. Required
+    // for "this"/"thisAndFollowing" so the edit targets the right occurrence
+    // instead of relocating the whole series. StartDate carries the new date.
+    public string OriginalDate { get; set; }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -1022,6 +1022,25 @@ public class BackendConfigurationCalendarService(
             // ResizeTask/DeleteTask. Only "all" (the default) falls through to
             // the full-series wizard update below.
             var scope = updateModel.Scope ?? "all";
+
+            // Scope only diverges for a recurring series. A one-off event has a
+            // single occurrence, so "this"/"thisAndFollowing" are equivalent to
+            // "all". The frontend defaults a non-recurring edit's scope to
+            // "this" (and always sends originalDate); without this guard such an
+            // edit would be stored as an occurrence exception instead of
+            // updating the event itself.
+            if (scope != "all")
+            {
+                var isRecurringSeries = await backendConfigurationPnDbContext.AreaRulePlannings
+                    .Where(x => x.Id == updateModel.Id)
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .AnyAsync(x => x.RepeatType.HasValue && x.RepeatType.Value > 0);
+                if (!isRecurringSeries)
+                {
+                    scope = "all";
+                }
+            }
+
             if (scope == "this" && !string.IsNullOrEmpty(updateModel.OriginalDate))
             {
                 return await UpdateTaskThisOccurrence(updateModel);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -478,6 +478,9 @@ public class BackendConfigurationCalendarService(
                         Attachments = MapAttachments(arp)
                     };
 
+                    // Per-occurrence field overrides from a "this"-scope edit (#885).
+                    ApplyOccurrenceFieldOverrides(model, exception);
+
                     // Bug A fix: if a non-actionable compliance was stripped for this
                     // (planningId, occurrenceDate), propagate its ComplianceId + SdkCaseId
                     // so any device-side write routes through the PK lookup. Leave
@@ -558,6 +561,8 @@ public class BackendConfigurationCalendarService(
                             Attachments = MapAttachments(arp)
                         };
 
+                        ApplyOccurrenceFieldOverrides(orphanModel, orphan);
+
                         if (ShouldIncludeTask(orphanModel, requestModel))
                         {
                             result.Add(orphanModel);
@@ -633,6 +638,8 @@ public class BackendConfigurationCalendarService(
                     DescriptionHtml = movedPlanning.Description,
                     Attachments = MapAttachments(arp)
                 };
+
+                ApplyOccurrenceFieldOverrides(movedModel, movedIn);
 
                 if (ShouldIncludeTask(movedModel, requestModel))
                 {
@@ -833,6 +840,8 @@ public class BackendConfigurationCalendarService(
                     ExceptionId = complianceException?.Id,
                 };
 
+                ApplyOccurrenceFieldOverrides(model, complianceException);
+
                 if (ShouldIncludeTask(model, requestModel))
                 {
                     result.Add(model);
@@ -1006,6 +1015,22 @@ public class BackendConfigurationCalendarService(
                     localizationService.GetString("AtLeastOneWorkerMustBeAssigned"));
             }
 
+            // Scope-aware edit (issue #885). "this"/"thisAndFollowing" must NOT
+            // relocate the series anchor (which the task wizard's StartDate
+            // write does); they record per-occurrence overrides on a
+            // CalendarOccurrenceException instead, mirroring MoveTask/
+            // ResizeTask/DeleteTask. Only "all" (the default) falls through to
+            // the full-series wizard update below.
+            var scope = updateModel.Scope ?? "all";
+            if (scope == "this" && !string.IsNullOrEmpty(updateModel.OriginalDate))
+            {
+                return await UpdateTaskThisOccurrence(updateModel);
+            }
+            if (scope == "thisAndFollowing" && !string.IsNullOrEmpty(updateModel.OriginalDate))
+            {
+                return await UpdateTaskThisAndFollowing(updateModel);
+            }
+
             // Delegate to TaskWizard service for full task field updates
             var wizardModel = new TaskWizardCreateModel
             {
@@ -1110,6 +1135,257 @@ public class BackendConfigurationCalendarService(
             return new OperationResult(false,
                 $"{localizationService.GetString("ErrorWhileUpdatingCalendarTask")}: {e.Message}");
         }
+    }
+
+    // Edit scope="this" (#885): record a single-occurrence override on a
+    // CalendarOccurrenceException without touching the series. Reuses an
+    // existing exception for the date (e.g. from a prior move/resize) so a
+    // date+field edit collapses into one row. Per-occurrence assignees use
+    // ExceptionSites; eForm/tags/status/compliance/repeat stay series-level.
+    private async Task<OperationResult> UpdateTaskThisOccurrence(CalendarTaskUpdateRequestModel updateModel)
+    {
+        var originalDate = DateTime.Parse(updateModel.OriginalDate, CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal).Date;
+        var newDate = updateModel.StartDate.Date;
+        var title = updateModel.Translates?.FirstOrDefault()?.Name;
+
+        var exception = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == updateModel.Id)
+            .Where(x => x.OriginalDate == originalDate)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .FirstOrDefaultAsync();
+
+        if (exception == null)
+        {
+            exception = new CalendarOccurrenceException
+            {
+                AreaRulePlanningId = updateModel.Id,
+                OriginalDate = originalDate,
+                IsDeleted = false,
+                NewDate = newDate != originalDate ? newDate : null,
+                StartHour = updateModel.StartHour,
+                Duration = updateModel.Duration,
+                Title = title,
+                DescriptionHtml = updateModel.DescriptionHtml,
+                BoardId = updateModel.BoardId,
+                Color = updateModel.Color,
+                CreatedByUserId = userService.UserId,
+                UpdatedByUserId = userService.UserId
+            };
+            await exception.Create(backendConfigurationPnDbContext);
+        }
+        else
+        {
+            // Re-editing an occurrence that was previously deleted via
+            // scope="this" must bring it back, otherwise the edit is stored
+            // but GetTasksForWeek keeps skipping it (IsDeleted gate).
+            exception.IsDeleted = false;
+            exception.NewDate = newDate != originalDate ? newDate : null;
+            exception.StartHour = updateModel.StartHour;
+            exception.Duration = updateModel.Duration;
+            exception.Title = title;
+            exception.DescriptionHtml = updateModel.DescriptionHtml;
+            exception.BoardId = updateModel.BoardId;
+            exception.Color = updateModel.Color;
+            exception.UpdatedByUserId = userService.UserId;
+            await exception.Update(backendConfigurationPnDbContext);
+        }
+
+        // Replace the per-occurrence assignee set with the edited Sites so
+        // this occurrence reflects the change without mutating the series.
+        var currentSites = await backendConfigurationPnDbContext.CalendarOccurrenceExceptionSites
+            .Where(x => x.CalendarOccurrenceExceptionId == exception.Id)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        foreach (var s in currentSites)
+        {
+            await s.Delete(backendConfigurationPnDbContext);
+        }
+        foreach (var siteId in updateModel.Sites)
+        {
+            var exceptionSite = new CalendarOccurrenceExceptionSite
+            {
+                CalendarOccurrenceExceptionId = exception.Id,
+                SiteId = siteId,
+                CreatedByUserId = userService.UserId,
+                UpdatedByUserId = userService.UserId
+            };
+            await exceptionSite.Create(backendConfigurationPnDbContext);
+        }
+
+        return new OperationResult(true,
+            localizationService.GetString("CalendarTaskUpdatedSuccessfully"));
+    }
+
+    // Edit scope="thisAndFollowing" (#885): anchor every PAST occurrence with
+    // the OLD field values, then apply the NEW values to the series WITHOUT
+    // relocating its StartDate (the wizard is given the unchanged anchor), and
+    // clear exceptions from originalDate forward so future occurrences render
+    // from the updated series. Mirrors the MoveTask thisAndFollowing handler.
+    private async Task<OperationResult> UpdateTaskThisAndFollowing(CalendarTaskUpdateRequestModel updateModel)
+    {
+        var originalDate = DateTime.Parse(updateModel.OriginalDate, CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal).Date;
+
+        var arp = await backendConfigurationPnDbContext.AreaRulePlannings
+            .Include(x => x.AreaRule)
+                .ThenInclude(x => x.AreaRuleTranslations)
+            .FirstOrDefaultAsync(x => x.Id == updateModel.Id
+                && x.WorkflowState != Constants.WorkflowStates.Removed);
+        if (arp == null || arp.StartDate == null)
+        {
+            // No live series (or a malformed row without an anchor) — refuse
+            // rather than fall back to the clicked date, which would relocate
+            // the series and reintroduce the #885 bug.
+            return new OperationResult(false,
+                localizationService.GetString("ErrorWhileUpdatingCalendarTask"));
+        }
+
+        var planning = await itemsPlanningPnDbContext.Plannings
+            .FirstOrDefaultAsync(x => x.Id == arp.ItemPlanningId
+                && x.WorkflowState != Constants.WorkflowStates.Removed);
+        var calConfig = await backendConfigurationPnDbContext.CalendarConfigurations
+            .Where(x => x.AreaRulePlanningId == updateModel.Id)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .FirstOrDefaultAsync();
+
+        // Capture OLD field values before mutating the series so past
+        // occurrences keep showing what they showed before the edit.
+        var oldTitle = arp.AreaRule?.AreaRuleTranslations?.FirstOrDefault()?.Name;
+        var oldDescription = planning?.Description;
+        var oldBoardId = calConfig?.BoardId;
+        var oldColor = calConfig?.Color;
+        var oldStartHour = calConfig?.StartHour ?? 9.0;
+        var oldDuration = calConfig?.Duration ?? 1.0;
+
+        if (planning != null)
+        {
+            var existingPastDates = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
+                .Where(x => x.AreaRulePlanningId == updateModel.Id)
+                .Where(x => x.OriginalDate < originalDate)
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Select(x => x.OriginalDate)
+                .ToListAsync();
+            var existingSet = new HashSet<DateTime>(existingPastDates);
+
+            foreach (var occDate in EnumerateOccurrences(planning, planning.StartDate.Date, originalDate,
+                         arp.RepeatWeekdaysCsv, arp.RepeatOrdinalWeek, arp.DayOfWeek))
+            {
+                if (existingSet.Contains(occDate)) continue;
+                var anchor = new CalendarOccurrenceException
+                {
+                    AreaRulePlanningId = updateModel.Id,
+                    OriginalDate = occDate,
+                    IsDeleted = false,
+                    NewDate = null,
+                    StartHour = oldStartHour,
+                    Duration = oldDuration,
+                    Title = oldTitle,
+                    DescriptionHtml = oldDescription,
+                    BoardId = oldBoardId,
+                    Color = oldColor,
+                    CreatedByUserId = userService.UserId,
+                    UpdatedByUserId = userService.UserId
+                };
+                await anchor.Create(backendConfigurationPnDbContext);
+            }
+        }
+
+        // Apply NEW field values to the series. Pass the EXISTING StartDate to
+        // the wizard so its StartDate write is a no-op — this is the #885 fix:
+        // a thisAndFollowing edit must not drag the series anchor onto the
+        // clicked occurrence's date.
+        var wizardModel = new TaskWizardCreateModel
+        {
+            Id = updateModel.Id,
+            PropertyId = updateModel.PropertyId,
+            FolderId = updateModel.FolderId,
+            ItemPlanningTagId = updateModel.ItemPlanningTagId,
+            TagIds = updateModel.TagIds,
+            Translates = updateModel.Translates,
+            EformId = updateModel.EformId,
+            StartDate = arp.StartDate.Value,
+            RepeatType = (Infrastructure.Enums.RepeatType)updateModel.RepeatType,
+            RepeatEvery = updateModel.RepeatEvery,
+            Status = (Infrastructure.Enums.TaskWizardStatuses)updateModel.Status,
+            Sites = updateModel.Sites,
+            ComplianceEnabled = updateModel.ComplianceEnabled
+        };
+        var wizardResult = await taskWizardService.UpdateTask(wizardModel);
+        if (!wizardResult.Success)
+        {
+            return wizardResult;
+        }
+
+        arp.RepeatWeekdaysCsv = updateModel.RepeatWeekdaysCsv;
+        arp.DayOfMonth = updateModel.DayOfMonth ?? 0;
+        arp.RepeatOrdinalWeek = updateModel.RepeatOrdinalWeek;
+        if (updateModel.RepeatOrdinalWeek.HasValue)
+        {
+            arp.DayOfWeek = (int)updateModel.StartDate.DayOfWeek;
+        }
+        arp.RepeatEndMode = updateModel.RepeatEndMode;
+        arp.RepeatOccurrences = updateModel.RepeatOccurrences;
+        arp.RepeatUntilDate = updateModel.RepeatUntilDate;
+        await arp.Update(backendConfigurationPnDbContext);
+
+        if (planning != null)
+        {
+            planning.Description = updateModel.DescriptionHtml ?? string.Empty;
+            planning.UpdatedByUserId = userService.UserId;
+            await planning.Update(itemsPlanningPnDbContext);
+        }
+
+        if (calConfig != null)
+        {
+            calConfig.StartHour = updateModel.StartHour;
+            calConfig.Duration = updateModel.Duration;
+            calConfig.BoardId = updateModel.BoardId;
+            calConfig.Color = updateModel.Color;
+            calConfig.UpdatedByUserId = userService.UserId;
+            await calConfig.Update(backendConfigurationPnDbContext);
+        }
+        else
+        {
+            calConfig = new CalendarConfiguration
+            {
+                AreaRulePlanningId = updateModel.Id,
+                StartHour = updateModel.StartHour,
+                Duration = updateModel.Duration,
+                BoardId = updateModel.BoardId,
+                Color = updateModel.Color,
+                CreatedByUserId = userService.UserId,
+                UpdatedByUserId = userService.UserId
+            };
+            await calConfig.Create(backendConfigurationPnDbContext);
+        }
+
+        // From originalDate forward the updated series is the source of truth;
+        // drop any pre-edit overrides so they don't shadow the new values.
+        var staleExceptions = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == updateModel.Id)
+            .Where(x => x.OriginalDate >= originalDate)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        foreach (var stale in staleExceptions)
+        {
+            await stale.Delete(backendConfigurationPnDbContext);
+        }
+
+        return new OperationResult(true,
+            localizationService.GetString("CalendarTaskUpdatedSuccessfully"));
+    }
+
+    // Overlay a per-occurrence exception's field overrides (#885) onto a
+    // rendered task. Null override fields inherit the series value, so this is
+    // safe to call for move/resize/delete exceptions that carry no field edits.
+    private static void ApplyOccurrenceFieldOverrides(CalendarTaskResponseModel model, CalendarOccurrenceException exception)
+    {
+        if (exception == null) return;
+        if (!string.IsNullOrEmpty(exception.Title)) model.Title = exception.Title;
+        if (exception.DescriptionHtml != null) model.DescriptionHtml = exception.DescriptionHtml;
+        if (exception.BoardId.HasValue) model.BoardId = exception.BoardId;
+        if (!string.IsNullOrEmpty(exception.Color)) model.Color = exception.Color;
     }
 
     public async Task<OperationResult> DeleteTask(CalendarTaskDeleteRequestModel deleteModel)

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task-request.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task-request.model.ts
@@ -23,6 +23,8 @@ export interface CalendarTaskCreateModel {
 export interface CalendarTaskUpdateModel extends CalendarTaskCreateModel {
   id: number;
   repeatSeriesId?: string;
+  // Pre-edit occurrence date ("YYYY-MM-DD") for scope-aware edits (#885).
+  originalDate?: string;
 }
 
 export type RepeatEditScope = 'this' | 'thisAndFollowing' | 'all';

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -787,6 +787,10 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       repeatRule: repeatRuleValue === 'customCurrent' ? 'custom' : repeatRuleValue,
       id: this.data.task?.id,
       repeatSeriesId: this.data.task?.repeatSeriesId,
+      // Pre-edit occurrence date so a "this"/"thisAndFollowing" edit targets
+      // the right occurrence instead of relocating the series (#885).
+      // startDate/taskDate above carry the NEW (edited) date.
+      originalDate: this.data.task?.taskDate,
     };
 
     const doSave = (scope?: string) => {


### PR DESCRIPTION
## Summary
Fixes #885 — editing a recurring calendar event no longer relocates the whole series `StartDate` (which silently dropped all past occurrences and made true per-occurrence edits impossible).

`UpdateTask` now branches on the edit **scope** the frontend already sends, mirroring `MoveTask`/`ResizeTask`/`DeleteTask`:

| Scope | Behavior |
|-------|----------|
| `this` | Records the edit on a `CalendarOccurrenceException` (title, description, board, color, start hour, duration, date, assignees). **Never calls the task wizard**, so the series anchor is untouched. Re-editing a previously deleted occurrence un-deletes it. |
| `thisAndFollowing` | Anchors every past occurrence with the **OLD** field values, applies the new values to the series **without moving its anchor** (wizard is given the original `StartDate`), and clears exceptions from the edited date forward. |
| `all` / null | Unchanged full-series update. |

`GetTasksForWeek` overlays per-occurrence `Title`/`DescriptionHtml`/`BoardId`/`Color` from the exception (null = inherit series) across the recurrence, orphan-anchor, moved-in and compliance render paths.

## Scope (intentional limitations)
`eForm`, tags, status, compliance and repeat remain **series-level only** — they touch compliance-case deployment / reporting and are out of scope for per-occurrence overrides in this increment.

## Dependencies
- Requires **Microting.EformBackendConfigurationBase 10.0.39** (adds nullable `Title`/`DescriptionHtml`/`BoardId`/`Color` to `CalendarOccurrenceException`; base PR microting/eform-backendconfiguration-base#858). NuGet ref bumped in this PR.

## Tests
6 new integration tests in `CalendarUpdateTaskScopeTests.cs` (real MariaDB via Testcontainers, all green locally):
- `this` does not call the wizard nor move the series start
- `this` creates an exception with all field overrides + per-occurrence assignees
- `this` reuses an existing exception for the date (no duplicate)
- `this` on a previously-deleted occurrence un-deletes it
- `all` writes no exception and updates CalendarConfiguration
- `thisAndFollowing` anchors past occurrences with old values, keeps the series start, updates the series to new values

## Review notes
Addressed an internal review: un-delete on re-edit; guard against a null series `StartDate` (refuse rather than fall back to the clicked date and reintroduce the bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)