### PR TITLE
fix: guard ConfigureDbContext() Migrate() with IHistoryRepository (Galera-safe)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -47,6 +47,8 @@ using Infrastructure.Data.Seed.Data;
 using Infrastructure.Models.Settings;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -754,15 +756,27 @@ public class EformBackendConfigurationPlugin : IEformPlugin
 
         var chemicalsContextFactory = new ChemicalsContextFactory();
         var chemicalsDbContext = chemicalsContextFactory.CreateDbContext([chemicalBaseConnectionString]);
-        chemicalsDbContext.Database.Migrate();
+        var chemicalsHistoryRepo = chemicalsDbContext.GetService<IHistoryRepository>();
+        if (!chemicalsHistoryRepo.Exists() || chemicalsDbContext.Database.GetPendingMigrations().Any())
+        {
+            chemicalsDbContext.Database.Migrate();
+        }
 
         var caseTemplatePnContextFactory = new CaseTemplatePnContextFactory();
         var caseTemplateContext = caseTemplatePnContextFactory.CreateDbContext([documentsConnectionString]);
-        caseTemplateContext.Database.Migrate();
+        var caseTemplateHistoryRepo = caseTemplateContext.GetService<IHistoryRepository>();
+        if (!caseTemplateHistoryRepo.Exists() || caseTemplateContext.Database.GetPendingMigrations().Any())
+        {
+            caseTemplateContext.Database.Migrate();
+        }
 
         var contextFactory = new BackendConfigurationPnContextFactory();
         var context = contextFactory.CreateDbContext([connectionString]);
-        context.Database.Migrate();
+        var historyRepo = context.GetService<IHistoryRepository>();
+        if (!historyRepo.Exists() || context.Database.GetPendingMigrations().Any())
+        {
+            context.Database.Migrate();
+        }
 
         // Seed database
         SeedDatabase(connectionString);
@@ -777,7 +791,11 @@ public class EformBackendConfigurationPlugin : IEformPlugin
         // Ensure all pending migrations are applied before the backfill queries the schema
         var contextFactory = new BackendConfigurationPnContextFactory();
         using var migrationContext = contextFactory.CreateDbContext([_connectionString]);
-        migrationContext.Database.Migrate();
+        var migrationHistoryRepo = migrationContext.GetService<IHistoryRepository>();
+        if (!migrationHistoryRepo.Exists() || migrationContext.Database.GetPendingMigrations().Any())
+        {
+            migrationContext.Database.Migrate();
+        }
 
         using var scope = serviceProvider.CreateScope();
         var backfillService = scope.ServiceProvider.GetRequiredService<WorkorderCaseGroupIdBackfillService>();


### PR DESCRIPTION
## Summary

- Wrap `Database.Migrate()` in `ConfigureDbContext()` with an `IHistoryRepository.Exists()` guard to eliminate unnecessary DDL on every API pod restart

## Why

On a MariaDB 11.4 Galera cluster with ~250 tenants, `Database.Migrate()` issues DDL (`CREATE TABLE IF NOT EXISTS __EFMigrationsHistory`, `GET_LOCK`) on every app restart even when the schema is already current. With multiple pods per tenant this causes cluster-wide desync/resync on every rolling update.

The guard pattern:
- `IHistoryRepository.Exists()` — safe `information_schema` read, returns false if history table is absent
- `GetPendingMigrations().Any()` — only called when the table exists
- `Database.Migrate()` — called **only** when needed: fresh install, or pending migrations

In production (schema current): no DDL, no `GET_LOCK`. On fresh plugin activation: falls through and creates the schema.

## Test Plan
- [ ] Plugin activates from UI correctly (schema created on first activation)
- [ ] Subsequent pod restarts do not trigger DDL when schema is current

🤖 Generated with [Claude Code](https://claude.com/claude-code)