### PR TITLE
Fix #915: delete (scope=this) of a moved occurrence keeps it visible

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOccurrenceExceptionTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOccurrenceExceptionTests.cs
@@ -464,6 +464,55 @@ public class CalendarOccurrenceExceptionTests : TestBaseSetup
     }
 
     [Test]
+    public async Task DeleteTask_ScopeThis_AfterMove_FlipsExistingExceptionInsteadOfCreatingSecond()
+    {
+        // Reproduces #915: a scope=this MOVE writes {OriginalDate=X, NewDate=Y,
+        // IsDeleted=false} and the occurrence then renders at Y. A scope=this
+        // DELETE of that occurrence sends the DISPLAYED date (Y) as OriginalDate.
+        // The delete must flip the SAME exception's IsDeleted to true (matching
+        // by NewDate), NOT create a second {OriginalDate=Y, IsDeleted=true} row
+        // that leaves the moved occurrence visible.
+        var baseMonday = GetNextMonday();
+        var startDate = DateTime.SpecifyKind(baseMonday, DateTimeKind.Utc);
+        var arpId = await SeedWeeklyTask(startDate);
+
+        var movedToDate = baseMonday.AddDays(2); // Wed
+
+        // MOVE the Monday occurrence to Wednesday (scope=this).
+        var moveResult = await _calendarService.MoveTask(new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            OriginalDate = baseMonday.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewDate = movedToDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 10.0,
+            Scope = "this"
+        });
+        Assert.That(moveResult.Success, Is.True, moveResult.Message);
+
+        // DELETE the now-moved occurrence (scope=this) using its DISPLAYED date (Wed).
+        var deleteResult = await _calendarService.DeleteTask(new CalendarTaskDeleteRequestModel
+        {
+            Id = arpId,
+            OriginalDate = movedToDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            Scope = "this"
+        });
+        Assert.That(deleteResult.Success, Is.True, deleteResult.Message);
+
+        var exceptions = await BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+
+        // Exactly ONE exception row — the original move row, now flagged deleted.
+        Assert.That(exceptions, Has.Count.EqualTo(1),
+            "delete-after-move must reuse the move exception row, not create a second one");
+        Assert.That(exceptions[0].OriginalDate.Date, Is.EqualTo(baseMonday.Date),
+            "the surviving row is the original move exception (OriginalDate=X)");
+        Assert.That(exceptions[0].IsDeleted, Is.True,
+            "the moved occurrence's exception must be flagged deleted so it stops rendering");
+    }
+
+    [Test]
     public async Task DeleteTask_ScopeThisAndFollowing_SetsEndDateToDayBefore()
     {
         // Arrange

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -1445,11 +1445,19 @@ public class BackendConfigurationCalendarService(
                 var originalDate = DateTime.Parse(deleteModel.OriginalDate, CultureInfo.InvariantCulture,
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal).Date;
 
-                var existing = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
+                var exceptions = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
                     .Where(x => x.AreaRulePlanningId == deleteModel.Id)
-                    .Where(x => x.OriginalDate == originalDate)
                     .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-                    .FirstOrDefaultAsync();
+                    .ToListAsync();
+
+                // Match the occurrence's own exception by OriginalDate first. If the
+                // occurrence was previously moved (scope=this), it now renders at its
+                // NewDate and the delete payload sends that displayed date — so fall
+                // back to matching by NewDate, flipping the SAME row's IsDeleted instead
+                // of creating a duplicate exception that leaves the moved occurrence
+                // visible (#915).
+                var existing = exceptions.FirstOrDefault(x => x.OriginalDate.Date == originalDate)
+                    ?? exceptions.FirstOrDefault(x => x.NewDate.HasValue && x.NewDate.Value.Date == originalDate);
 
                 if (existing != null)
                 {

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-delete-scope.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-delete-scope.spec.ts
@@ -446,15 +446,14 @@ test.describe.serial('Calendar delete scope (#895)', () => {
     // assert ONLY the observable invariant: after the move-then-delete the
     // occurrence is gone, and earlier weeks (untouched by the move) are intact.
     //
-    // fixme: CI shows the occurrence remains VISIBLE after move(scope=this)
-    // then delete(scope=this) — the moved occurrence renders via its
-    // exception's NewDate, and the delete targets the displayed (moved) date,
-    // so the existing move-exception's IsDeleted flag isn't flipped (a second
-    // exception is created instead). This move-then-delete-this interaction
-    // (single-exception-row reuse) is the part covered server-side and may
-    // warrant a separate bug investigation; left as a documented placeholder
-    // so the rest of the delete-scope suite stays green.
-    test.fixme('D07: scope=this delete after a move keeps the occurrence gone', async ({ page }) => {
+    // #915 FIXED: the moved occurrence renders via its exception's NewDate, and
+    // a scope=this delete targets the displayed (moved) date. DeleteTask now
+    // falls back to matching an existing exception by NewDate == originalDate, so
+    // it flips that row's IsDeleted instead of creating a second exception — the
+    // moved occurrence disappears. The single-exception-row reuse invariant is
+    // asserted server-side (CalendarOccurrenceExceptionTests
+    // .DeleteTask_ScopeThis_AfterMove_FlipsExistingExceptionInsteadOfCreatingSecond).
+    test('D07: scope=this delete after a move keeps the occurrence gone', async ({ page }) => {
       const calendarPage = new CalendarUiEnhancementsPage(page);
       const title = `D07-${generateRandmString(5)}`;
       const startDay = 5; // Saturday


### PR DESCRIPTION
## Issue #915
Deleting (scope=this) an occurrence that was **first moved** (scope=this) left it visible.

A scope=this MOVE writes a `CalendarOccurrenceException{OriginalDate=X, NewDate=Y, IsDeleted=false}` and the occurrence then renders at `Y`. A subsequent scope=this DELETE sends the **displayed** date `Y` as `OriginalDate`. The old `DeleteTask` only matched exceptions by `OriginalDate==Y`, found none, and created a **second** `{OriginalDate=Y, IsDeleted=true}` row — so the original X-row's `IsDeleted` stayed `false` and the moved occurrence kept rendering at `Y`.

## Fix (backend-only)
`DeleteTask` (scope=="this") now loads the ARP's non-removed exceptions and matches by `OriginalDate.Date` first, falling back to `NewDate.Date == originalDate`, flipping the **existing** row's `IsDeleted` instead of creating a duplicate.

- `.Date` comparison on both sides (MoveTask stores `NewDate` with a possible time component).
- `OriginalDate`-first priority keeps the non-moved-delete path unchanged.
- Field-only "this"-edit exceptions (#885) have `NewDate == null` and are excluded by the `HasValue` guard, so they are never wrongly matched.

## Tests
- **Server-side:** `CalendarOccurrenceExceptionTests.DeleteTask_ScopeThis_AfterMove_FlipsExistingExceptionInsteadOfCreatingSecond` — runs the real MoveTask→DeleteTask sequence and asserts exactly one surviving row with `OriginalDate==X` and `IsDeleted==true`. (9/9 in the fixture pass locally.)
- **E2e:** un-fixme `D07` in `calendar-delete-scope.spec.ts` (acceptance test for the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)