### PR TITLE
Fix calendar recurrence-rule persistence (#925, #938, #929, #926, #927)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarRecurrenceRulePersistenceFixTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarRecurrenceRulePersistenceFixTests.cs
@@ -1,0 +1,490 @@
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Infrastructure.Models.TaskWizard;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.eForm.Infrastructure.Models;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using NSubstitute;
+using PluginRepeatType = BackendConfiguration.Pn.Infrastructure.Enums.RepeatType;
+using PlanningRepeatType = Microting.ItemsPlanningBase.Infrastructure.Enums.RepeatType;
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+/// <summary>
+/// Locks in the calendar recurrence-rule persistence fixes:
+///   #925/#938 — Planning.DayOfMonth derivation from start date per RepeatType
+///   #926 — MoveTask (thisAndFollowing + all) re-derives the Nth-weekday rule
+///   #927 — UpdateTask thisAndFollowing re-anchors on a changed date but keeps
+///          the series start on an unchanged (pure field) edit
+///   #929 — UpdateTask scope=all persists the weekly DayOfWeek
+/// Mirrors the fixture/seed pattern of <see cref="CalendarUpdateTaskScopeTests"/>;
+/// the task wizard is mocked, so these tests assert on the rows the
+/// CalendarService itself writes plus the wizard mock's received calls.
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarRecurrenceRulePersistenceFixTests : TestBaseSetup
+{
+    private IUserService _userService;
+    private IBackendConfigurationTaskWizardService _taskWizardService;
+    private BackendConfigurationCalendarService _calendarService;
+
+    [SetUp]
+    public async Task SetupCalendarService()
+    {
+        // FK-safe cleanup so each test starts fresh.
+        BackendConfigurationPnDbContext!.CalendarOccurrenceExceptionSites.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarOccurrenceExceptionSites);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.CalendarOccurrenceExceptions.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarOccurrenceExceptions);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.CalendarConfigurations.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarConfigurations);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRulePlannings.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRulePlannings);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRuleTranslations.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRuleTranslations);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRules.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRules);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.Areas.RemoveRange(
+            BackendConfigurationPnDbContext.Areas);
+        BackendConfigurationPnDbContext.Properties.RemoveRange(
+            BackendConfigurationPnDbContext.Properties);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        ItemsPlanningPnDbContext!.Plannings.RemoveRange(
+            ItemsPlanningPnDbContext.Plannings);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        _userService = Substitute.For<IUserService>();
+        _userService.UserId.Returns(1);
+        _userService.GetCurrentUserLanguage()
+            .Returns(Task.FromResult(new Language { Id = 1, Name = "English", LanguageCode = "en-US" }));
+
+        _taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        // scope=all / thisAndFollowing delegate field updates to the wizard.
+        _taskWizardService.UpdateTask(Arg.Any<TaskWizardCreateModel>())
+            .Returns(Task.FromResult(new OperationResult(true)));
+
+        _calendarService = new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(),
+            _userService,
+            BackendConfigurationPnDbContext!,
+            null,
+            Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext!,
+            _taskWizardService,
+            NullLogger<BackendConfigurationCalendarService>.Instance
+        );
+    }
+
+    /// <summary>
+    /// Seeds Area→Property→AreaRule(+translation)→Planning→AreaRulePlanning→
+    /// CalendarConfiguration for a recurring series with explicit recurrence
+    /// metadata. Returns the ARP Id. The wizard is mocked, so this seed is the
+    /// only source of recurrence rows the assertions read back.
+    /// </summary>
+    private async Task<int> SeedTask(
+        DateTime startDate,
+        int arpRepeatType,
+        int? repeatOrdinalWeek,
+        int dayOfWeek,
+        int dayOfMonth = 0,
+        PlanningRepeatType planningRepeatType = PlanningRepeatType.Month,
+        DayOfWeek? planningDayOfWeek = null)
+    {
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"TestProp-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id, EformId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRuleTranslation = new AreaRuleTranslation
+        {
+            AreaRuleId = areaRule.Id, LanguageId = 1, Name = "Original Title",
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRuleTranslations.AddAsync(areaRuleTranslation);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = planningRepeatType, StartDate = startDate,
+            DayOfWeek = planningDayOfWeek, RelatedEFormId = 0, Description = "Original description",
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
+            ItemPlanningId = planning.Id, StartDate = startDate, Status = true,
+            RepeatType = arpRepeatType, RepeatEvery = 1,
+            DayOfWeek = dayOfWeek, DayOfMonth = dayOfMonth, RepeatOrdinalWeek = repeatOrdinalWeek,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        return arp.Id;
+    }
+
+    private static CalendarTaskUpdateRequestModel BuildEdit(
+        int arpId, DateTime startDate, string scope, DateTime originalDate,
+        int repeatType, int? repeatOrdinalWeek,
+        double startHour = 11.0, double duration = 2.0)
+    {
+        return new CalendarTaskUpdateRequestModel
+        {
+            Id = arpId,
+            Scope = scope,
+            OriginalDate = originalDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            StartDate = DateTime.SpecifyKind(startDate, DateTimeKind.Utc),
+            StartHour = startHour,
+            Duration = duration,
+            Status = 1,
+            RepeatType = repeatType,
+            RepeatEvery = 1,
+            RepeatOrdinalWeek = repeatOrdinalWeek,
+            ComplianceEnabled = false,
+            PropertyId = 0,
+            EformId = 0,
+            Sites = [101],
+            TagIds = [],
+            BoardId = 42,
+            Color = "#abcdef",
+            DescriptionHtml = "Edited description",
+            Translates = [new CommonTranslationsModel { LanguageId = 1, Name = "Edited Title" }]
+        };
+    }
+
+    // ------------------------------------------------------------------
+    // A. DeriveDayOfMonth unit tests (#925/#938) — pure, no DB needed.
+    // ------------------------------------------------------------------
+
+    [TestCase(PluginRepeatType.Week, 2026, 6, 4, ExpectedResult = 1)]
+    [TestCase(PluginRepeatType.Day, 2026, 6, 15, ExpectedResult = 1)]
+    [TestCase(PluginRepeatType.Month, 2026, 6, 15, ExpectedResult = 15)]
+    [TestCase(PluginRepeatType.Month, 2026, 1, 31, ExpectedResult = 28)] // capped at 28
+    [TestCase(PluginRepeatType.Month, 2026, 6, 1, ExpectedResult = 1)]
+    [TestCase(PluginRepeatType.Year, 2026, 6, 4, ExpectedResult = 4)]
+    [TestCase(PluginRepeatType.Year, 2026, 12, 31, ExpectedResult = 31)] // NOT capped
+    public int DeriveDayOfMonth_DerivesPerRepeatType(
+        PluginRepeatType repeatType, int year, int month, int day)
+    {
+        return BackendConfigurationTaskWizardService.DeriveDayOfMonth(
+            repeatType, new DateTime(year, month, day));
+    }
+
+    // ------------------------------------------------------------------
+    // B. MoveTask thisAndFollowing re-derives the Nth-weekday rule (#926).
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task MoveTask_ThisAndFollowing_ReDerivesNthWeekday()
+    {
+        // Monthly 1st-Thursday rule starting Thu 2026-06-04.
+        var seriesStart = DateTime.SpecifyKind(new DateTime(2026, 6, 4), DateTimeKind.Utc);
+        var arpId = await SeedTask(
+            seriesStart, arpRepeatType: 3, repeatOrdinalWeek: 1, dayOfWeek: 4,
+            planningRepeatType: PlanningRepeatType.Month, planningDayOfWeek: DayOfWeek.Thursday);
+
+        // Drag the 1st Thursday of July (2026-07-02) to Wed 2026-07-01.
+        var originalDate = new DateTime(2026, 7, 2);
+        var newDate = new DateTime(2026, 7, 1); // Wednesday
+        var moveModel = new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            OriginalDate = originalDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewDate = newDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 10.0,
+            Scope = "thisAndFollowing"
+        };
+
+        var result = await _calendarService.MoveTask(moveModel);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var arp = await BackendConfigurationPnDbContext!.AreaRulePlannings.SingleAsync(x => x.Id == arpId);
+        var planning = await ItemsPlanningPnDbContext!.Plannings.SingleAsync(x => x.Id == arp.ItemPlanningId);
+        Assert.Multiple(() =>
+        {
+            Assert.That(arp.DayOfWeek, Is.EqualTo(3), "Wednesday");
+            Assert.That(arp.RepeatOrdinalWeek, Is.EqualTo(1), "(1-1)/7+1 = 1st Wednesday");
+            Assert.That(arp.StartDate!.Value.Date, Is.EqualTo(newDate.Date));
+            Assert.That(planning.DayOfWeek, Is.EqualTo(DayOfWeek.Wednesday));
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // C. MoveTask scope=all re-derives the Nth-weekday rule (#926).
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task MoveTask_ScopeAll_ReDerivesNthWeekday()
+    {
+        var seriesStart = DateTime.SpecifyKind(new DateTime(2026, 6, 4), DateTimeKind.Utc);
+        var arpId = await SeedTask(
+            seriesStart, arpRepeatType: 3, repeatOrdinalWeek: 1, dayOfWeek: 4,
+            planningRepeatType: PlanningRepeatType.Month, planningDayOfWeek: DayOfWeek.Thursday);
+
+        var newDate = new DateTime(2026, 7, 1); // Wednesday
+        var moveModel = new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            OriginalDate = new DateTime(2026, 7, 2).ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewDate = newDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 10.0,
+            Scope = "all"
+        };
+
+        var result = await _calendarService.MoveTask(moveModel);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var arp = await BackendConfigurationPnDbContext!.AreaRulePlannings.SingleAsync(x => x.Id == arpId);
+        var planning = await ItemsPlanningPnDbContext!.Plannings.SingleAsync(x => x.Id == arp.ItemPlanningId);
+        Assert.Multiple(() =>
+        {
+            Assert.That(arp.DayOfWeek, Is.EqualTo(3), "Wednesday");
+            Assert.That(arp.RepeatOrdinalWeek, Is.EqualTo(1));
+            Assert.That(arp.StartDate!.Value.Date, Is.EqualTo(newDate.Date));
+            Assert.That(planning.DayOfWeek, Is.EqualTo(DayOfWeek.Wednesday));
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // D. UpdateTask thisAndFollowing with a CHANGED date re-anchors (#927).
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task UpdateTask_ThisAndFollowing_ChangedDate_ReAnchorsSeries()
+    {
+        var seriesStart = DateTime.SpecifyKind(new DateTime(2026, 6, 4), DateTimeKind.Utc);
+        var arpId = await SeedTask(
+            seriesStart, arpRepeatType: 3, repeatOrdinalWeek: 1, dayOfWeek: 4,
+            planningRepeatType: PlanningRepeatType.Month, planningDayOfWeek: DayOfWeek.Thursday);
+
+        // OriginalDate = 1st Thursday of July; the edit moves it to Wed 2026-07-01.
+        var model = BuildEdit(
+            arpId,
+            startDate: new DateTime(2026, 7, 1),
+            scope: "thisAndFollowing",
+            originalDate: new DateTime(2026, 7, 2),
+            repeatType: 3,
+            repeatOrdinalWeek: 1);
+
+        var result = await _calendarService.UpdateTask(model);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var arp = await BackendConfigurationPnDbContext!.AreaRulePlannings.SingleAsync(x => x.Id == arpId);
+        var planning = await ItemsPlanningPnDbContext!.Plannings.SingleAsync(x => x.Id == arp.ItemPlanningId);
+        Assert.Multiple(() =>
+        {
+            Assert.That(arp.StartDate!.Value.Date, Is.EqualTo(new DateTime(2026, 7, 1)), "re-anchored");
+            Assert.That(arp.DayOfWeek, Is.EqualTo(3), "Wednesday");
+            Assert.That(arp.RepeatOrdinalWeek, Is.EqualTo(1));
+            Assert.That(planning.StartDate.Date, Is.EqualTo(new DateTime(2026, 7, 1)));
+        });
+        // The wizard must rebuild the series from the re-anchored start date.
+        await _taskWizardService.Received().UpdateTask(
+            Arg.Is<TaskWizardCreateModel>(m => m.StartDate.HasValue && m.StartDate.Value.Date == new DateTime(2026, 7, 1)));
+
+        // No backfill anchor may survive at/after the new anchor — it would
+        // shadow the re-anchored series' own occurrences with stale values.
+        var exceptions = await BackendConfigurationPnDbContext.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        Assert.That(exceptions.Any(e => e.OriginalDate.Date >= new DateTime(2026, 7, 1)), Is.False,
+            "no anchor may shadow the re-anchored series");
+    }
+
+    // ------------------------------------------------------------------
+    // G. UpdateTask thisAndFollowing BACKWARD move to the SAME weekday must
+    //    not leave a backfill anchor shadowing the re-anchored series (#927
+    //    cutoff). This is the case the weekday-changing test D cannot trigger.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task UpdateTask_ThisAndFollowing_BackwardSameWeekday_NoShadowAnchor()
+    {
+        // Weekly Thursday series from Thu 2026-06-04.
+        var seriesStart = DateTime.SpecifyKind(new DateTime(2026, 6, 4), DateTimeKind.Utc);
+        var arpId = await SeedTask(
+            seriesStart, arpRepeatType: 2, repeatOrdinalWeek: null, dayOfWeek: 4,
+            planningRepeatType: PlanningRepeatType.Week, planningDayOfWeek: DayOfWeek.Thursday);
+
+        // Edit the Thu 2026-07-16 occurrence back to the earlier Thu 2026-07-09.
+        var model = BuildEdit(
+            arpId,
+            startDate: new DateTime(2026, 7, 9),
+            scope: "thisAndFollowing",
+            originalDate: new DateTime(2026, 7, 16),
+            repeatType: 2,
+            repeatOrdinalWeek: null);
+
+        var result = await _calendarService.UpdateTask(model);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var exceptions = await BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        Assert.Multiple(() =>
+        {
+            // The re-anchored Thursday (and everything after it) is regenerated
+            // by the series, so no anchor may remain at/after it.
+            Assert.That(exceptions.Any(e => e.OriginalDate.Date >= new DateTime(2026, 7, 9)), Is.False,
+                "the Jul-09 anchor (and later) must be cleared, not left to shadow the series");
+            // Genuinely-past occurrences (before the new anchor) stay pinned.
+            Assert.That(exceptions.Any(e => e.OriginalDate.Date == new DateTime(2026, 7, 2)), Is.True,
+                "the Jul-02 past occurrence stays anchored with its old values");
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // H. MoveTask thisAndFollowing BACKWARD move to the SAME weekday — same
+    //    cutoff guarantee on the drag path (#927 companion).
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task MoveTask_ThisAndFollowing_BackwardSameWeekday_NoShadowAnchor()
+    {
+        var seriesStart = DateTime.SpecifyKind(new DateTime(2026, 6, 4), DateTimeKind.Utc);
+        var arpId = await SeedTask(
+            seriesStart, arpRepeatType: 2, repeatOrdinalWeek: null, dayOfWeek: 4,
+            planningRepeatType: PlanningRepeatType.Week, planningDayOfWeek: DayOfWeek.Thursday);
+
+        var moveModel = new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            OriginalDate = new DateTime(2026, 7, 16).ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewDate = new DateTime(2026, 7, 9).ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 10.0,
+            Scope = "thisAndFollowing"
+        };
+
+        var result = await _calendarService.MoveTask(moveModel);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var exceptions = await BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        Assert.Multiple(() =>
+        {
+            Assert.That(exceptions.Any(e => e.OriginalDate.Date >= new DateTime(2026, 7, 9)), Is.False,
+                "the Jul-09 anchor (and later) must be cleared, not left to shadow the series");
+            Assert.That(exceptions.Any(e => e.OriginalDate.Date == new DateTime(2026, 7, 2)), Is.True,
+                "the Jul-02 past occurrence stays anchored");
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // E. UpdateTask thisAndFollowing with an UNCHANGED date keeps the series
+    //    start (#927 regression guard — pure field edit).
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task UpdateTask_ThisAndFollowing_UnchangedDate_KeepsSeriesStart()
+    {
+        var seriesStart = DateTime.SpecifyKind(new DateTime(2026, 6, 4), DateTimeKind.Utc);
+        var arpId = await SeedTask(
+            seriesStart, arpRepeatType: 3, repeatOrdinalWeek: 1, dayOfWeek: 4,
+            planningRepeatType: PlanningRepeatType.Month, planningDayOfWeek: DayOfWeek.Thursday);
+
+        // StartDate == OriginalDate → pure field edit, no date move.
+        var model = BuildEdit(
+            arpId,
+            startDate: new DateTime(2026, 7, 2),
+            scope: "thisAndFollowing",
+            originalDate: new DateTime(2026, 7, 2),
+            repeatType: 3,
+            repeatOrdinalWeek: 1);
+
+        var result = await _calendarService.UpdateTask(model);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var arp = await BackendConfigurationPnDbContext!.AreaRulePlannings.SingleAsync(x => x.Id == arpId);
+        Assert.That(arp.StartDate!.Value.Date, Is.EqualTo(new DateTime(2026, 6, 4)),
+            "series start must NOT be relocated on an unchanged-date edit");
+        await _taskWizardService.Received().UpdateTask(
+            Arg.Is<TaskWizardCreateModel>(m => m.StartDate.HasValue && m.StartDate.Value.Date == new DateTime(2026, 6, 4)));
+    }
+
+    // ------------------------------------------------------------------
+    // F. UpdateTask scope=all persists the weekly DayOfWeek (#929).
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task UpdateTask_ScopeAll_PersistsWeeklyDayOfWeek()
+    {
+        // Weekly rule with a stale Sunday (0) DayOfWeek default that would
+        // otherwise mislabel the event.
+        var seriesStart = DateTime.SpecifyKind(new DateTime(2026, 6, 4), DateTimeKind.Utc); // Thursday
+        var arpId = await SeedTask(
+            seriesStart, arpRepeatType: 2, repeatOrdinalWeek: null, dayOfWeek: 0,
+            planningRepeatType: PlanningRepeatType.Week, planningDayOfWeek: DayOfWeek.Thursday);
+
+        var model = BuildEdit(
+            arpId,
+            startDate: new DateTime(2026, 6, 4),
+            scope: "all",
+            originalDate: new DateTime(2026, 6, 4),
+            repeatType: 2,
+            repeatOrdinalWeek: null);
+
+        var result = await _calendarService.UpdateTask(model);
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var arp = await BackendConfigurationPnDbContext!.AreaRulePlannings.SingleAsync(x => x.Id == arpId);
+        Assert.That(arp.DayOfWeek, Is.EqualTo(4), "Thursday");
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -937,10 +937,11 @@ public class BackendConfigurationCalendarService(
                 latestArp.RepeatOrdinalWeek = createModel.RepeatOrdinalWeek;
                 // Capture the planned weekday from the start date so the
                 // monthlyByDay iterator (Nth weekday of month) has the target
-                // weekday available. Scoped to monthlyByDay rules to avoid
-                // disturbing the column for other rule kinds, where it is
-                // unused but may be read by adjacent Area Rule Planning UI.
-                if (createModel.RepeatOrdinalWeek.HasValue)
+                // weekday available, and so a plain weekly rule reports the
+                // correct weekday in the edit dialog instead of defaulting to
+                // Sunday (DayOfWeek=0) when the FE sends a null weekday CSV (#929).
+                if (createModel.RepeatOrdinalWeek.HasValue
+                    || createModel.RepeatType == (int)Infrastructure.Enums.RepeatType.Week)
                 {
                     latestArp.DayOfWeek = (int)createModel.StartDate.DayOfWeek;
                 }
@@ -1118,10 +1119,11 @@ public class BackendConfigurationCalendarService(
                 arp.RepeatOrdinalWeek = updateModel.RepeatOrdinalWeek;
                 // Mirror the create handler: keep DayOfWeek in sync with the
                 // start date so the monthlyByDay iterator reads the right
-                // target weekday after edits that move the anchor date.
-                // Scoped to monthlyByDay rules per the same rationale as
-                // create.
-                if (updateModel.RepeatOrdinalWeek.HasValue)
+                // target weekday after edits that move the anchor date, and so
+                // a plain weekly rule reports the correct weekday in the edit
+                // dialog instead of defaulting to Sunday (#929).
+                if (updateModel.RepeatOrdinalWeek.HasValue
+                    || updateModel.RepeatType == (int)Infrastructure.Enums.RepeatType.Week)
                 {
                     arp.DayOfWeek = (int)updateModel.StartDate.DayOfWeek;
                 }
@@ -1337,10 +1339,35 @@ public class BackendConfigurationCalendarService(
             }
         }
 
-        // Apply NEW field values to the series. Pass the EXISTING StartDate to
-        // the wizard so its StartDate write is a no-op — this is the #885 fix:
-        // a thisAndFollowing edit must not drag the series anchor onto the
-        // clicked occurrence's date.
+        // Distinguish a pure field edit from a date move. When the new start
+        // date equals the edited occurrence's date, the user only changed
+        // fields (title/time/colour) — keep the series anchor where it is so we
+        // don't drag the whole series onto the clicked occurrence (#885). When
+        // the date actually changed, a "this and following" edit re-anchors the
+        // series forward to the new date (exactly like a thisAndFollowing drag):
+        // the rule from that date on follows the new weekday/ordinal, while past
+        // occurrences stay pinned by the backfill anchors created above. Without
+        // this re-anchor the iterator keeps generating from the old anchor and
+        // the moved occurrence snaps to a stale weekday (#927).
+        var newAnchor = DateTime.SpecifyKind(updateModel.StartDate, DateTimeKind.Utc).Date;
+        var dateChanged = newAnchor != originalDate;
+        if (dateChanged)
+        {
+            arp.StartDate = newAnchor;
+            arp.UpdatedByUserId = userService.UserId;
+            await arp.Update(backendConfigurationPnDbContext);
+            if (planning != null)
+            {
+                planning.StartDate = newAnchor;
+                planning.UpdatedByUserId = userService.UserId;
+                await planning.Update(itemsPlanningPnDbContext);
+            }
+        }
+
+        // Apply NEW field values to the series. The wizard re-derives the
+        // items-planning weekday/day-of-month from this StartDate, so it must
+        // receive the (possibly re-anchored) series start to keep both
+        // scheduler masters in agreement.
         var wizardModel = new TaskWizardCreateModel
         {
             Id = updateModel.Id,
@@ -1366,7 +1393,8 @@ public class BackendConfigurationCalendarService(
         arp.RepeatWeekdaysCsv = updateModel.RepeatWeekdaysCsv;
         arp.DayOfMonth = updateModel.DayOfMonth ?? 0;
         arp.RepeatOrdinalWeek = updateModel.RepeatOrdinalWeek;
-        if (updateModel.RepeatOrdinalWeek.HasValue)
+        if (updateModel.RepeatOrdinalWeek.HasValue
+            || updateModel.RepeatType == (int)Infrastructure.Enums.RepeatType.Week)
         {
             arp.DayOfWeek = (int)updateModel.StartDate.DayOfWeek;
         }
@@ -1406,11 +1434,17 @@ public class BackendConfigurationCalendarService(
             await calConfig.Create(backendConfigurationPnDbContext);
         }
 
-        // From originalDate forward the updated series is the source of truth;
-        // drop any pre-edit overrides so they don't shadow the new values.
+        // From the re-anchored series' start forward, the updated series is the
+        // source of truth; drop any pre-edit overrides (including past anchors
+        // just backfilled for dates the new series now regenerates) so they
+        // don't shadow the new values. For a backward date move the new anchor
+        // is earlier than originalDate, so the cutoff is the new anchor — else a
+        // backfilled anchor at/after the new anchor double-renders the same day
+        // with stale values (#927).
+        var staleCutoff = dateChanged && newAnchor < originalDate ? newAnchor : originalDate;
         var staleExceptions = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
             .Where(x => x.AreaRulePlanningId == updateModel.Id)
-            .Where(x => x.OriginalDate >= originalDate)
+            .Where(x => x.OriginalDate >= staleCutoff)
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
             .ToListAsync();
         foreach (var stale in staleExceptions)
@@ -1749,12 +1783,33 @@ public class BackendConfigurationCalendarService(
                 }
 
                 arp.StartDate = newDate;
+                // Re-derive the recurrence weekday from the drop date so the
+                // moved series follows the new weekday instead of snapping back
+                // to the original one (#926). For an Nth-weekday-of-month rule
+                // also re-derive the ordinal week; for a single-day weekly rule
+                // rewrite the explicit weekday CSV. Multi-day weekly CSVs are
+                // left untouched (a single drag has no single target weekday).
+                if (arp.RepeatOrdinalWeek.HasValue)
+                {
+                    arp.DayOfWeek = (int)newDate.DayOfWeek;
+                    arp.RepeatOrdinalWeek = (newDate.Day - 1) / 7 + 1;
+                }
+                else if (!string.IsNullOrEmpty(arp.RepeatWeekdaysCsv)
+                         && !arp.RepeatWeekdaysCsv.Contains(','))
+                {
+                    arp.RepeatWeekdaysCsv = ((int)newDate.DayOfWeek).ToString(CultureInfo.InvariantCulture);
+                    arp.DayOfWeek = (int)newDate.DayOfWeek;
+                }
                 arp.UpdatedByUserId = userService.UserId;
                 await arp.Update(backendConfigurationPnDbContext);
 
                 if (oldPlanning != null)
                 {
                     oldPlanning.StartDate = newDate;
+                    // Keep the items-planning scheduler master in sync with the
+                    // new weekday so NextExecutionTime does not pull the series
+                    // back to the old day (the two-master defect, #925/#926).
+                    oldPlanning.DayOfWeek = newDate.DayOfWeek;
                     oldPlanning.UpdatedByUserId = userService.UserId;
                     await oldPlanning.Update(itemsPlanningPnDbContext);
                 }
@@ -1778,9 +1833,14 @@ public class BackendConfigurationCalendarService(
                     await calConfig.Create(backendConfigurationPnDbContext);
                 }
 
+                // For a backward move the new anchor precedes originalDate, so
+                // drop backfilled anchors at/after the new anchor too — otherwise
+                // they double-render the re-anchored series' own days with stale
+                // values (companion to the #927 cutoff fix).
+                var staleCutoff = newDate < originalDate ? newDate : originalDate;
                 var staleExceptions = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
                     .Where(x => x.AreaRulePlanningId == moveModel.Id)
-                    .Where(x => x.OriginalDate >= originalDate)
+                    .Where(x => x.OriginalDate >= staleCutoff)
                     .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                     .ToListAsync();
 
@@ -1792,6 +1852,21 @@ public class BackendConfigurationCalendarService(
             else
             {
                 arp.StartDate = newDate;
+                // Re-derive the recurrence weekday/ordinal from the drop date so
+                // a whole-series move follows the new weekday instead of snapping
+                // back to the original one (#926), mirroring the thisAndFollowing
+                // branch above.
+                if (arp.RepeatOrdinalWeek.HasValue)
+                {
+                    arp.DayOfWeek = (int)newDate.DayOfWeek;
+                    arp.RepeatOrdinalWeek = (newDate.Day - 1) / 7 + 1;
+                }
+                else if (!string.IsNullOrEmpty(arp.RepeatWeekdaysCsv)
+                         && !arp.RepeatWeekdaysCsv.Contains(','))
+                {
+                    arp.RepeatWeekdaysCsv = ((int)newDate.DayOfWeek).ToString(CultureInfo.InvariantCulture);
+                    arp.DayOfWeek = (int)newDate.DayOfWeek;
+                }
                 arp.UpdatedByUserId = userService.UserId;
                 await arp.Update(backendConfigurationPnDbContext);
 
@@ -1803,6 +1878,7 @@ public class BackendConfigurationCalendarService(
                 if (planning != null)
                 {
                     planning.StartDate = newDate;
+                    planning.DayOfWeek = newDate.DayOfWeek;
                     planning.UpdatedByUserId = userService.UserId;
                     await planning.Update(itemsPlanningPnDbContext);
                 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskWizardService/BackendConfigurationTaskWizardService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskWizardService/BackendConfigurationTaskWizardService.cs
@@ -341,6 +341,27 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
         }
     }
 
+    /// <summary>
+    /// Derives the items-planning <c>Planning.DayOfMonth</c> from a start date per
+    /// RepeatType. Month captures the day-of-month capped at 28 (so the rule fires
+    /// every month even in February); Year keeps the real day (the renderer clamps
+    /// to month length); every other type uses 1. Shared by the create and the two
+    /// update/reactivation paths so an edit never regresses the day-of-month (#938).
+    /// </summary>
+    internal static int DeriveDayOfMonth(RepeatType repeatType, DateTime startDate)
+    {
+        switch (repeatType)
+        {
+            case RepeatType.Month:
+                var dayOfMonth = startDate.Day;
+                return dayOfMonth > 28 ? 28 : dayOfMonth;
+            case RepeatType.Year:
+                return startDate.Day;
+            default:
+                return 1;
+        }
+    }
+
     /// <inheritdoc />
     public async Task<OperationResult> CreateTask(TaskWizardCreateModel createModel)
     {
@@ -395,34 +416,12 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                     0, 0, 0);
             }
 
-            var dayOfWeek = DayOfWeek.Monday;
-            if (createModel.RepeatType == RepeatType.Week)
-            {
-                // get day of week from start date
-                dayOfWeek = createModel.StartDate.Value.DayOfWeek;
-            }
-
-            var dayOfMonth = 1;
-            if (createModel.RepeatType == RepeatType.Month)
-            {
-                // get day of month from start date
-                dayOfMonth = createModel.StartDate.Value.Day;
-                if (dayOfMonth > 28)
-                {
-                    dayOfMonth = 28;
-                }
-            }
-            else if (createModel.RepeatType == RepeatType.Year)
-            {
-                // Yearly recurs on the same day-of-month + month as the start date,
-                // so it needs DayOfMonth captured — otherwise the renderer's Year
-                // branch falls back to DayOfMonth=1, the occurrence lands on the
-                // 1st (wrong week) and never appears (#922). Keep the real day
-                // (no 28-cap): the month is fixed, and the renderer clamps the
-                // candidate to the month's length, so a 29th/30th/31st yearly
-                // renders on its actual day rather than being pulled to the 28th.
-                dayOfMonth = createModel.StartDate.Value.Day;
-            }
+            // Anchor the items-planning scheduler to the start date's weekday for
+            // every RepeatType, not just Week. The scheduler uses Planning.DayOfWeek
+            // to compute NextExecutionTime; a hard-coded Monday default pulled
+            // yearly/monthly tasks back to the Monday of the start week (#925).
+            var dayOfWeek = createModel.StartDate.Value.DayOfWeek;
+            var dayOfMonth = DeriveDayOfMonth(createModel.RepeatType, createModel.StartDate.Value);
 
             // create planning
             var planning = new Planning
@@ -861,10 +860,13 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                 // create item planning
                 case false when areaRulePlanning.Status:
                 {
-                    planning.DayOfMonth = 1;
                     planning.StartDate = updateModel.StartDate!.Value;
+                    // Derive DayOfMonth/DayOfWeek from the start date per RepeatType
+                    // (mirror the create path); hard-coding 1/Monday here regressed
+                    // monthly & yearly render on edit/reactivation (#938, #925).
+                    planning.DayOfMonth = DeriveDayOfMonth(updateModel.RepeatType, planning.StartDate);
                     planning.Enabled = true;
-                    planning.DayOfWeek = DayOfWeek.Monday;
+                    planning.DayOfWeek = planning.StartDate.DayOfWeek;
                     planning.RepeatEvery = updateModel.RepeatEvery;
                     planning.ReportGroupPlanningTagId = (int)updateModel.ItemPlanningTagId!;
                     planning.SdkFolderName = folderName;
@@ -1023,8 +1025,12 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                     planning.PushMessageOnDeployment = areaRulePlanning.SendNotifications;
                     planning.StartDate = new DateTime((int)(areaRulePlanning.StartDate?.Year),
                         (int)(areaRulePlanning.StartDate?.Month), (int)(areaRulePlanning.StartDate?.Day), 0, 0, 0);
-                    planning.DayOfMonth = 1;
-                    planning.DayOfWeek = DayOfWeek.Friday;
+                    // Derive DayOfMonth/DayOfWeek from the start date per RepeatType
+                    // (mirror the create path); hard-coding 1/Friday here regressed
+                    // monthly & yearly render and misplaced weekly rules on update
+                    // (#938, #925).
+                    planning.DayOfMonth = DeriveDayOfMonth(updateModel.RepeatType, planning.StartDate);
+                    planning.DayOfWeek = planning.StartDate.DayOfWeek;
                     planning.RepeatType =
                         (Microting.ItemsPlanningBase.Infrastructure.Enums.RepeatType)updateModel.RepeatType;
                     planning.RelatedEFormId = updateModel.EformId;


### PR DESCRIPTION
## Summary
Fixes the "two-master" DayOfWeek/DayOfMonth recurrence-persistence cluster: the items-planning scheduler (`Planning.DayOfWeek`/`DayOfMonth`) and the calendar renderer (`AreaRulePlanning.DayOfWeek`/`RepeatOrdinalWeek`) disagreed after create/edit/move because weekday/day-of-month were hard-coded instead of derived from the start date.

Closes #925, closes #938, closes #929, closes #926, closes #927.

## Changes
- **#925** — `TaskWizardService.CreateTask` + both `UpdateTask` branches derive `Planning.DayOfWeek` from the start date for **every** RepeatType (was hard-coded Monday in create, Monday/Friday in the two update branches). Yearly/monthly tasks no longer anchor to the Monday of the start week.
- **#938** — both `UpdateTask` branches derive `Planning.DayOfMonth` per RepeatType via a shared `DeriveDayOfMonth` helper (Month→day capped 28, Year→real day, else 1) instead of hard-coding `1`. Edit/reactivation no longer regresses monthly & yearly render.
- **#929** — `CalendarService` persists `arp.DayOfWeek` for plain weekly rules (not just ordinal rules) at all three create/update sites, so the edit dialog shows the real weekday instead of defaulting to Sunday.
- **#926** — `MoveTask` (both `thisAndFollowing` and scope=`all`) re-derives `arp.DayOfWeek` + `arp.RepeatOrdinalWeek` from the drop date for Nth-weekday rules, rewrites a single-day weekly CSV, and syncs `Planning.DayOfWeek`. The moved series follows the new weekday instead of snapping back.
- **#927** — `UpdateTaskThisAndFollowing` distinguishes a pure field edit (date unchanged → keep series anchor, the #885 behaviour) from a date change (re-anchor forward like a thisAndFollowing move, passing the new start date to the wizard). Both this and `MoveTask` now clear backfill anchors at/after the new anchor on a **backward** move so they can't shadow the re-anchored series.

## Tests
New `CalendarRecurrenceRulePersistenceFixTests` (14 cases): `DeriveDayOfMonth` boundary matrix, MoveTask thisAndFollowing/all Nth-weekday re-derivation, UpdateTask changed-date re-anchor, unchanged-date keep-series-start regression guard, backward-same-weekday no-shadow-anchor guards (MoveTask + UpdateTask), weekly DayOfWeek persistence.

All **72** calendar integration tests pass locally (Testcontainers MariaDB); the existing `UpdateTask_ScopeThisAndFollowing_AnchorsPastOccurrences_KeepsSeriesStart` (#885) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)