### PR TITLE
Fix dimmed (completed/inactive) calendar tiles bleeding through stacked active events

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/n/calendar-ui-gaps.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/n/calendar-ui-gaps.spec.ts
@@ -298,18 +298,25 @@ test.describe.serial('Calendar UI gaps (#897)', () => {
       // 2) It carries the dimmed class (.gcal-task--inactive ← status===false).
       await expect(block).toHaveClass(/gcal-task--inactive/);
 
-      // 3) Computed-style probe: the dimming is actually applied — opacity is
-      //    reduced below 1 (the SCSS sets opacity: 0.45 on .gcal-task--inactive).
-      //    A filtered-out task would be absent; a non-dimmed task would be at
-      //    opacity 1. This is the regression guard that "dimmed, not hidden"
-      //    holds at the rendered-pixel level, not just the class level.
-      const opacity = await block.evaluate(
-        el => parseFloat(getComputedStyle(el as HTMLElement).opacity)
-      );
+      // 3) Computed-style probe: the dimming is actually applied. The dimmed
+      //    state is rendered via a CSS `filter` (grayscale + brightness) rather
+      //    than element `opacity` — element opacity made the tile translucent
+      //    and let an overlapping active tile bleed through, so the dimmed tile
+      //    must stay fully OPAQUE (opacity 1) and dim via filter instead. This
+      //    is the regression guard that "dimmed, not hidden" holds at the
+      //    rendered-pixel level, and that the tile is not see-through.
+      const { opacity, filter } = await block.evaluate(el => {
+        const cs = getComputedStyle(el as HTMLElement);
+        return { opacity: parseFloat(cs.opacity), filter: cs.filter };
+      });
       expect(
         opacity,
-        `inactive task should be visibly dimmed (opacity < 1), got ${opacity}`
-      ).toBeLessThan(1);
+        `inactive task must stay fully opaque so overlapping tiles don't bleed through, got ${opacity}`
+      ).toBe(1);
+      expect(
+        filter,
+        `inactive task should be visibly dimmed via a CSS filter, got "${filter}"`
+      ).not.toBe('none');
     });
 
     // ----- Overdue filter: intentionally not implementable via the UI ------

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
@@ -26,14 +26,34 @@
     opacity: 0;
   }
 
+  // Dimmed states (completed / inactive) must stay FULLY OPAQUE. Conflicting
+  // events stack with overlapping z-indexes ordered by start time, so a dimmed
+  // tile can sit on top of an active one; element-level `opacity` here made the
+  // tile translucent and let the active tile bleed through, rendering the dimmed
+  // tile's text unreadable. Express "dimmed" via `filter` (desaturate + darken)
+  // instead — it keeps the tile opaque, and the slight darkening actually lifts
+  // the white text's contrast.
   &.completed {
-    opacity: 0.6;
+    // Keep a hint of the board colour so the category is still recognisable,
+    // but muted and settled. Strike-through + the green check mark (set in the
+    // template) carry the "done" meaning.
+    filter: saturate(0.55) brightness(0.82);
     text-decoration: line-through;
   }
 
   &.gcal-task--inactive {
-    opacity: 0.45;
-    filter: grayscale(0.7);
+    // Fully de-categorised: drained of colour and dimmed so it clearly recedes
+    // behind active tiles, while staying opaque and legible.
+    filter: grayscale(0.95) brightness(0.82);
+  }
+
+  // Hover must never drop a dimmed tile back to translucency (that would
+  // reintroduce the bleed-through over a stacked active tile). Lift via filter
+  // instead of opacity.
+  &.completed:hover,
+  &.gcal-task--inactive:hover {
+    opacity: 1;
+    filter: saturate(0.7) brightness(0.92);
   }
 
   &.resizing {
@@ -116,7 +136,8 @@
 
     // Completed task (SDK case Status == 100): turn the check_circle glyph
     // green so users can spot completion at a glance. The block also
-    // dims to opacity 0.6 + line-through via .task-block.completed above,
+    // dims via CSS filter (saturate + brightness) + line-through via
+    // .task-block.completed above,
     // but at 16px on the red background those are easy to miss.
     // #61BA5B matches the project's $eform-green palette token (used
     // elsewhere in the frontend); grep $eform-green to find the source.


### PR DESCRIPTION
## Problem
Completed and inactive calendar event tiles were dimmed with whole-element `opacity` (`0.6` / `0.45`). Because conflicting events stack with overlapping z-indexes ordered by start time, a dimmed tile can sit **on top of** an active tile — the element opacity made it translucent, the active tile bled through, and the dimmed tile's text became unreadable.

## Fix
Keep dimmed tiles **fully opaque** and express the dimming via CSS `filter` (which post-processes the already-painted pixels and does not introduce alpha), so nothing behind them shows through:
- **completed** → `filter: saturate(0.55) brightness(0.82)` + line-through — muted/settled but keeps a hint of the board colour so the category is still recognisable.
- **inactive** → `filter: grayscale(0.95) brightness(0.82)` — drained of colour so it clearly recedes, still opaque and legible.
- dimmed `:hover` lifts via `filter` (`opacity` stays `1`) so hovering never re-introduces translucency.

The slight darkening (`brightness < 1`) also *raises* the white text's contrast vs the old opacity treatment.

## Before / after
Verified with a faithful mockup of the tile markup + SCSS, a dimmed tile stacked over an active one: before, the active tile bled through the translucent dimmed tile; after, the dimmed tile is solid and its text is fully legible, with no bleed-through.

## Tests
Updated the U10 e2e guard (`calendar-ui-gaps.spec.ts`): it now asserts the inactive tile has `opacity === 1` **and** `filter !== 'none'` ("dimmed but opaque") instead of the old `opacity < 1`. No other calendar e2e asserts tile opacity/filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)