### PR TITLE
fix(events): key StreamEventChanges diff on (eventId, planDayKey)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/events.proto
@@ -156,7 +156,13 @@ message EventChange {
   oneof kind {
     Event upserted = 1;
     string removed_id = 2;
+    RemovedOccurrence removed_occurrence = 3;
   }
+}
+
+message RemovedOccurrence {
+  string event_id = 1;
+  string plan_day_key = 2;
 }
 
 message Property {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -853,9 +853,8 @@ public class EventsGrpcService(
         // window forward without dropping the subscription.
         // ComputeWatchWindow uses today-N..today+M relative to UTC.
 
-        // seen: event_id (numeric) → state-hash. Tracks every Event we have
-        // already emitted, so subsequent polls only re-emit on real changes.
-        var seen = new Dictionary<int, string>();
+        // (eventId, planDayKey) → state-hash; composite so scope=this move emits removal+upsert.
+        var seen = new Dictionary<(string EventId, string PlanDayKey), string>();
 
         // 1. Initial snapshot.
         try
@@ -868,11 +867,7 @@ public class EventsGrpcService(
                 ct.ThrowIfCancellationRequested();
                 await responseStream.WriteAsync(new EventChange { Upserted = op }, ct)
                     .ConfigureAwait(false);
-                if (int.TryParse(op.Id, NumberStyles.Integer, CultureInfo.InvariantCulture,
-                        out var eventId))
-                {
-                    seen[eventId] = ComputeStateHash(op);
-                }
+                seen[(op.Id, op.PlanDayKey)] = ComputeStateHash(op);
             }
         }
         catch (OperationCanceledException)
@@ -937,37 +932,55 @@ public class EventsGrpcService(
                 var current = await LoadEventsAsync(
                     propertyId, boardFilter, windowStart, windowEnd, ct).ConfigureAwait(false);
 
-                var currentIds = new HashSet<int>();
+                var currentKeys = new HashSet<(string EventId, string PlanDayKey)>();
 
                 foreach (var op in current)
                 {
-                    if (!int.TryParse(op.Id, NumberStyles.Integer, CultureInfo.InvariantCulture,
-                            out var eventId))
-                    {
-                        continue;
-                    }
-                    currentIds.Add(eventId);
+                    var seenKey = (op.Id, op.PlanDayKey);
+                    currentKeys.Add(seenKey);
 
                     var hash = ComputeStateHash(op);
-                    if (!seen.TryGetValue(eventId, out var prevHash) || prevHash != hash)
+                    if (!seen.TryGetValue(seenKey, out var prevHash) || prevHash != hash)
                     {
                         ct.ThrowIfCancellationRequested();
                         await responseStream.WriteAsync(new EventChange { Upserted = op }, ct)
                             .ConfigureAwait(false);
-                        seen[eventId] = hash;
+                        seen[seenKey] = hash;
                     }
                 }
 
-                // Detect removals: anything in `seen` but not in `currentIds`.
-                var removed = seen.Keys.Where(id => !currentIds.Contains(id)).ToList();
-                foreach (var id in removed)
+                // Whole-event delete → RemovedId; partial → RemovedOccurrence per missing rotation.
+                var lostKeys = seen.Keys.Where(k => !currentKeys.Contains(k)).ToList();
+                var survivingEventIds = currentKeys.Select(k => k.EventId).ToHashSet();
+                var fullyLostEventIds = lostKeys
+                    .Select(k => k.EventId)
+                    .Where(id => !survivingEventIds.Contains(id))
+                    .ToHashSet();
+
+                foreach (var eventId in fullyLostEventIds)
                 {
                     ct.ThrowIfCancellationRequested();
+                    await responseStream.WriteAsync(
+                        new EventChange { RemovedId = eventId }, ct).ConfigureAwait(false);
+                }
+
+                foreach (var key in lostKeys)
+                {
+                    if (fullyLostEventIds.Contains(key.EventId)) continue;
+                    ct.ThrowIfCancellationRequested();
                     await responseStream.WriteAsync(new EventChange
+                    {
+                        RemovedOccurrence = new RemovedOccurrence
                         {
-                            RemovedId = id.ToString(CultureInfo.InvariantCulture)
-                        }, ct).ConfigureAwait(false);
-                    seen.Remove(id);
+                            EventId = key.EventId,
+                            PlanDayKey = key.PlanDayKey,
+                        }
+                    }, ct).ConfigureAwait(false);
+                }
+
+                foreach (var key in lostKeys)
+                {
+                    seen.Remove(key);
                 }
 
                 // Successful poll — clear the consecutive-error tracker so the


### PR DESCRIPTION
## Summary

Closes the server half of [flutter-eform#825](https://github.com/microting/flutter-eform/issues/825).

The streaming diff in `StreamEventChanges` keyed its `seen` map on the numeric `eventId` alone. When the web calendar moved a single occurrence of a recurring event (`scope=this`), the server-side `BackendConfigurationCalendarService` correctly emitted the event at the new `plan_day_key`, but the diff loop only emitted an `Upserted` for the new date — no removal for the old one, because the id stayed in `currentIds`. The mobile client kept the old-date row indefinitely.

## Changes

- **`Protos/events.proto`** — additive: new `RemovedOccurrence { event_id, plan_day_key }` message + new oneof case `removed_occurrence = 3` in `EventChange`. `removed_id = 2` is preserved for whole-event-delete (back-compat with older flutter clients).
- **`Services/GrpcServices/EventsGrpcService.cs`** — rekey `seen` and `currentKeys` on `(string EventId, string PlanDayKey)` value tuple. Removal pass now distinguishes:
  - **Whole-event delete** (no rotation of an eventId survives in `currentKeys`) → emit one `RemovedId` per gone event id. Old clients consume this and wipe by id.
  - **Partial removal** (event still has surviving rotations) → emit `RemovedOccurrence` per missing `(eventId, planDayKey)`. Covers the scope=this move case.

## Verification

- Code review + simplification passed three rounds of dual-subagent gate (code-reviewer + code-simplifier in parallel).
- Behavioral equivalence to the previous wire shape preserved for whole-event-delete; new wire shape only fires when at least one rotation survives.
- E2E verification on emulator is the responsibility of the companion flutter-eform PR (server + client must both ship before the bug fix is observable end-to-end).

## Test plan

- [ ] CI green
- [ ] (flutter-eform PR) emulator drag scope=this move → stale tile disappears within one poll cycle
- [ ] (flutter-eform PR) emulator whole-event delete → all rotations disappear (regression test for the existing `removeEvent(id)` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)