### PR TITLE
Fix: calendar modal toggle-row icons + spacing

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
@@ -355,7 +355,7 @@
 
     <!-- Active / inactive (paired view) -->
     <div class="gcal-row">
-      <mat-icon class="gcal-icon">visibility</mat-icon>
+      <mat-icon class="gcal-icon gcal-icon--hidden">visibility</mat-icon>
       <div class="gcal-row-content gcal-toggle-stack">
         <mat-slide-toggle
           id="calendarEventStatusActive"
@@ -374,7 +374,7 @@
 
     <!-- Overdue visibility (paired view; both off when inactive) -->
     <div class="gcal-row">
-      <mat-icon class="gcal-icon">schedule</mat-icon>
+      <mat-icon class="gcal-icon gcal-icon--hidden">schedule</mat-icon>
       <div class="gcal-row-content gcal-toggle-stack">
         <mat-slide-toggle
           id="calendarEventComplianceOn"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
@@ -129,11 +129,15 @@
 
 // Stack paired slide-toggles (e.g. Aktiv/Inaktiv, Vis/Skjul overskredet)
 // one per line. Without this they default to mat-slide-toggle's inline-flex
-// and pack side-by-side until the row wraps.
+// and pack side-by-side until the row wraps. margin-bottom adds breathing
+// room before the next field — slide-toggles are intrinsically shorter
+// than form-fields, so the .gcal-row's 4px margin-bottom alone makes the
+// transition into a form-field below look cramped.
 .gcal-toggle-stack {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  margin-bottom: 14px;
 }
 
 // Date + Time row


### PR DESCRIPTION
## Summary
- Mark the eye (`visibility`) and clock (`schedule`) icons on the two paired toggle rows in the calendar event modal with `gcal-icon--hidden`. The toggle copy is self-explanatory and the icons added noise. The class keeps the icon column width so toggles stay aligned with sibling form-field rows.
- Add `margin-bottom: 14px` on `.gcal-toggle-stack` so the transition from a stacked-toggle row to the next form-field row has visible breathing room — slide-toggles are intrinsically shorter than form-field rows, so the `.gcal-row`'s 4px default felt cramped.

## Companion PR
microting/eform-angular-frontend#7927 — workspace SCSS migration to MD3 floating-label form-fields. The workspace SCSS in that PR currently mirrors these rules as a temporary HMR workaround; once HMR is reliable, the workspace mirror can be dropped and these canonical rules take over.

## Test plan
- [x] Open `/plugins/backend-configuration-pn/calendar`, click an event, click Edit.
- [x] Toggle rows render with no eye/clock icon; toggle copy aligned with sibling form-field rows.
- [x] Clear gap (~14px) between each stacked-toggle row and the next form-field row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)