### PR TITLE
Serialize calendar deploy per (planning, site) to stop duplicate PlanningCaseSites (#934)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
@@ -36,7 +36,10 @@ using Microting.eForm.Infrastructure.Constants;
 using Microting.eForm.Infrastructure.Data.Entities;
 using Microting.eFormApi.BasePn.Abstractions;
 using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.ItemsPlanningBase.Infrastructure.Data;
 using NSubstitute;
 
 /// <summary>
@@ -901,6 +904,243 @@ public class EventDeployServiceTest : TestBaseSetup
             "No PlanningCaseSite may be written for a site outside the planning's "
             + "PlanningSites (#932).");
     }
+
+    // ------------------------------------------------------------------
+    // 13. EnsureDeployedAsync_ConcurrentPassesSameRotation_CreatesExactlyOnePlanningCaseSite
+    //
+    // Regression for #934. The forensic snapshot showed four identical
+    // PlanningCaseSites rows for the same (planning, site), three of them
+    // created in the same second — the 5s StreamEventChanges poll, ListEvents
+    // one-shots and the several window/board calls a single client fires per
+    // sync, all racing through the deploy path before any of them writes the
+    // Compliance row the idempotence guard keys on. This test fires N truly
+    // concurrent EnsureDeployedAsync passes (each on its OWN DbContexts, like
+    // separate gRPC requests on one pod) for the same rotation and asserts that
+    // exactly ONE PlanningCaseSite is created. Without the per-(planning, site)
+    // serialization in EventDeployService the passes each create a duplicate.
+    //
+    // Unlike the deferred happy-path test #8, this one drives the FULL deploy
+    // (real eForm template + CaseCreateLocalOnly), so it also covers the
+    // create → SDK case → Compliance write order end to end.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task EnsureDeployedAsync_ConcurrentPassesSameRotation_CreatesExactlyOnePlanningCaseSite()
+    {
+        const int passes = 4; // mirrors the 4-row forensic snapshot in #934
+        var core = await GetCore();
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        // SDK site whose MicrotingUid CaseCreateLocalOnly resolves against.
+        const int siteMicrotingUid = 4242;
+        var site = new Site
+        {
+            Name = "concurrent-deploy-site",
+            MicrotingUid = siteMicrotingUid,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(site);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        // Real eForm template so DeployForRotationAsync's ReadeForm +
+        // CaseCreateLocalOnly succeed (and the Compliance guard becomes
+        // effective for the second pass onward).
+        var template = await core.TemplateFromXml(CommentTemplateXml);
+        var templateId = await core.TemplateCreate(template);
+
+        // Full BC graph the deploy path reads: Area → Property → AreaRule →
+        // AreaRulePlanning(ItemPlanningId), plus the ItemsPlanning Planning +
+        // PlanningSite (the #935 site-narrowing + #932 guard require it).
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"ConcurrentProp-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id, EformId = templateId,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var rotationDate = DateTime.UtcNow.Date.AddDays(2);
+
+        var planning = new Microting.ItemsPlanningBase.Infrastructure.Data.Entities.Planning
+        {
+            WorkflowState = Constants.WorkflowStates.Created,
+            StartDate = rotationDate.AddDays(-7),
+            Enabled = true,
+            RepeatEvery = 1,
+            RepeatType = Microting.ItemsPlanningBase.Infrastructure.Enums.RepeatType.Day,
+            NextExecutionTime = rotationDate,
+            DayOfMonth = rotationDate.Day,
+            RepeatUntil = rotationDate.AddMonths(6),
+            RelatedEFormId = templateId,
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        ItemsPlanningPnDbContext.PlanningSites.Add(new Microting.ItemsPlanningBase.Infrastructure.Data.Entities.PlanningSite
+        {
+            PlanningId = planning.Id,
+            SiteId = site.Id,
+            WorkflowState = Constants.WorkflowStates.Created,
+        });
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
+            ItemPlanningId = planning.Id, StartDate = rotationDate.AddDays(-7), Status = true,
+            RepeatType = 1, RepeatEvery = 1, DayOfWeek = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // Shared calendar + core mocks (read-only across passes); each pass gets
+        // its OWN DbContexts, mirroring separate gRPC requests' scoped contexts.
+        var rotation = MakeRotation(id: 934, date: rotationDate, planningId: planning.Id, eformId: templateId);
+        var (calendar, coreHelper) = MakeMocks([rotation], core);
+        var sp = new ServiceCollection().AddSingleton(calendar).BuildServiceProvider();
+
+        var todayKey = DateTime.UtcNow.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var toKey = rotationDate.AddDays(1).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        // Warm the cached ServerVersion on the main thread so the concurrent
+        // context builds below don't race to detect it / open extra connections.
+        _ = CachedServerVersion();
+
+        // Act — N concurrent deploy passes for the same (planning, site,
+        // rotation). A Barrier holds every task at the gate until all are built,
+        // then releases them together so they genuinely overlap in the
+        // check-then-deploy window — without this the thread pool could run them
+        // sequentially on a constrained runner and the race would not reproduce.
+        using var startGate = new Barrier(passes);
+        var tasks = Enumerable.Range(0, passes).Select(_ => Task.Run(async () =>
+        {
+            var bc = NewBackendContext();
+            var ip = NewItemsPlanningContext();
+            try
+            {
+                var service = new EventDeployService(
+                    bc, ip, coreHelper, sp, NullLogger<EventDeployService>.Instance);
+                // Release all passes simultaneously (timeout guards against a hang
+                // if a sibling task faulted before reaching the gate).
+                startGate.SignalAndWait(TimeSpan.FromSeconds(60));
+                await service.EnsureDeployedAsync(
+                    PropertyId, BoardIds, todayKey, toKey, site.Id, CancellationToken.None);
+            }
+            finally
+            {
+                await bc.DisposeAsync();
+                await ip.DisposeAsync();
+            }
+        })).ToArray();
+        await Task.WhenAll(tasks);
+
+        // Assert — exactly one active PlanningCaseSite for (planning, site),
+        // read through a fresh context so we see all committed rows.
+        await using var verifyIp = NewItemsPlanningContext();
+        var planningCaseSiteCount = await verifyIp.PlanningCaseSites
+            .CountAsync(pcs => pcs.PlanningId == planning.Id
+                               && pcs.MicrotingSdkSiteId == site.Id
+                               && pcs.WorkflowState != Constants.WorkflowStates.Removed);
+        Assert.That(planningCaseSiteCount, Is.EqualTo(1),
+            $"Expected exactly one PlanningCaseSite for (planning {planning.Id}, site {site.Id}) "
+            + $"after {passes} concurrent deploy passes, but found {planningCaseSiteCount} (#934).");
+    }
+
+    /// <summary>
+    /// Builds a fresh <see cref="BackendConfigurationPnDbContext"/> against the
+    /// same test database as the inherited one, so concurrent passes use their
+    /// own context like separate gRPC requests (EF DbContext is not thread-safe).
+    /// </summary>
+    // Cached so the concurrent context builds in test #13 don't each open a
+    // version-detection connection against the shared testcontainer. Same DB
+    // server for both contexts, so one detection serves both. Warmed once
+    // (on the main thread) before any parallel use to avoid a detect race.
+    private ServerVersion? _serverVersion;
+
+    private ServerVersion CachedServerVersion()
+        => _serverVersion ??= ServerVersion.AutoDetect(
+            BackendConfigurationPnDbContext!.Database.GetConnectionString());
+
+    private BackendConfigurationPnDbContext NewBackendContext()
+    {
+        var cs = BackendConfigurationPnDbContext!.Database.GetConnectionString();
+        var ob = new DbContextOptionsBuilder<BackendConfigurationPnDbContext>();
+        ob.UseMySql(cs, CachedServerVersion(), b => b.EnableRetryOnFailure());
+        return new BackendConfigurationPnDbContext(ob.Options);
+    }
+
+    private ItemsPlanningPnDbContext NewItemsPlanningContext()
+    {
+        var cs = ItemsPlanningPnDbContext!.Database.GetConnectionString();
+        var ob = new DbContextOptionsBuilder<ItemsPlanningPnDbContext>();
+        ob.UseMySql(cs, CachedServerVersion(), b => b.EnableRetryOnFailure());
+        return new ItemsPlanningPnDbContext(ob.Options);
+    }
+
+    /// <summary>
+    /// A minimal real eForm (single Comment field) used to make the full deploy
+    /// path succeed. Copied from the SDK's CoreTesteFormCreateInDB test.
+    /// </summary>
+    private const string CommentTemplateXml = @"
+<?xml version='1.0' encoding='UTF-8'?>
+<Main>
+    <Id>9060</Id>
+    <Repeated>0</Repeated>
+    <Label>CommentMain</Label>
+    <StartDate>2017-07-07</StartDate>
+    <EndDate>2027-07-07</EndDate>
+    <Language>da</Language>
+    <MultiApproval>false</MultiApproval>
+    <FastNavigation>false</FastNavigation>
+    <Review>false</Review>
+    <Summary>false</Summary>
+    <DisplayOrder>0</DisplayOrder>
+    <ElementList>
+        <Element type='DataElement'>
+            <Id>9060</Id>
+            <Label>CommentDataElement</Label>
+            <Description><![CDATA[CommentDataElementDescription]]></Description>
+            <DisplayOrder>0</DisplayOrder>
+            <ReviewEnabled>false</ReviewEnabled>
+            <ManualSync>false</ManualSync>
+            <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+            <DoneButtonDisabled>false</DoneButtonDisabled>
+            <ApprovalEnabled>false</ApprovalEnabled>
+            <DataItemList>
+                <DataItem type='Comment'>
+                    <Id>73660</Id>
+                    <Label>CommentField</Label>
+                    <Description><![CDATA[CommentFieldDescription]]></Description>
+                    <DisplayOrder>0</DisplayOrder>
+                    <Multi>1</Multi>
+                    <GeolocationEnabled>false</GeolocationEnabled>
+                    <Split>false</Split>
+                    <Value />
+                    <ReadOnly>false</ReadOnly>
+                    <Mandatory>false</Mandatory>
+                    <Color>e8eaf6</Color>
+                </DataItem>
+            </DataItemList>
+        </Element>
+    </ElementList>
+</Main>";
 
     /// <summary>
     /// Captures every <see cref="ILogger.Log"/> invocation into an in-memory

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -61,6 +62,48 @@ public class EventDeployService(
     IServiceProvider serviceProvider,
     ILogger<EventDeployService> logger) : IEventDeployService
 {
+    // #934 — per-(planning, site) in-process deploy locks. Concurrent deploy
+    // passes (the 5s StreamEventChanges poll, ListEvents one-shots, and the
+    // several window/board requests a single client fires per sync) all call
+    // into the deploy path for the same rotation. The idempotence guard keys on
+    // the Compliance row, which DeployForRotationAsync writes LAST (after the
+    // slow CaseCreateLocalOnly), so two passes that both clear the guard before
+    // either writes Compliance each create a PlanningCase + PlanningCaseSite —
+    // only Compliance has a duplicate-key catch, so the PlanningCaseSites
+    // duplicate. That is the "N identical PlanningCaseSites within seconds"
+    // symptom in #934. Serializing the check-then-deploy per (planning, site)
+    // closes the window: the first pass writes Compliance before the next
+    // re-checks the guard, so the next short-circuits.
+    //
+    // Keyed on (planning, site) — NOT (planning, site, rotation) — so the
+    // dictionary stays bounded by planning×site and never grows with the
+    // calendar window over the life of the process. Different rotations of the
+    // same planning+site therefore serialize against each other, which is
+    // harmless: the rotation-aware Compliance guard still lets each distinct
+    // day deploy exactly once, and deploys only run for not-yet-deployed
+    // candidates.
+    //
+    // In-process only: a mobile client's stream is pinned to one pod and the
+    // racing window/ListEvents calls share that pod, so this covers the
+    // reported scenario. Cross-pod races remain bounded by the Compliance
+    // duplicate-key catch; making duplicates physically impossible across pods
+    // would need the (PlanningId, MicrotingSdkSiteId, OccurrenceDate) DB unique
+    // constraint #934 mentions (deferred — requires a base migration).
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> DeployLocks = new();
+
+    private static async Task<IDisposable> AcquireDeployLockAsync(
+        int planningId, int sdkSiteId, CancellationToken ct)
+    {
+        var gate = DeployLocks.GetOrAdd($"{planningId}:{sdkSiteId}", _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct).ConfigureAwait(false);
+        return new LockReleaser(gate);
+    }
+
+    private sealed class LockReleaser(SemaphoreSlim gate) : IDisposable
+    {
+        public void Dispose() => gate.Release();
+    }
+
     public async Task EnsureDeployedAsync(
         string propertyId,
         IReadOnlyCollection<string> boardIds,
@@ -207,6 +250,13 @@ public class EventDeployService(
             var planningId = task.PlanningId!.Value;
             var eformId = task.EformId!.Value;
 
+            // #934 — serialize the check-then-deploy for this (planning, site)
+            // so concurrent passes cannot both clear the Compliance guard before
+            // either writes it and each create a duplicate PlanningCaseSite.
+            // Disposed at the end of the iteration (incl. after `continue` and
+            // the catch below), releasing the gate.
+            using var deployLockHandle = await AcquireDeployLockAsync(planningId, sdkSiteId, cancellationToken)
+                .ConfigureAwait(false);
             try
             {
                 // 1. Idempotence guard — Compliance natural key + SDK site.
@@ -317,6 +367,13 @@ public class EventDeployService(
                         language,
                         cancellationToken)
                     .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation must abort the whole pass — not be swallowed as a
+                // per-rotation failure by the general catch below. (The lock is
+                // already released by the `using` as the exception unwinds.)
+                throw;
             }
             catch (Exception ex)
             {
@@ -540,6 +597,13 @@ public class EventDeployService(
         }
 
         var deadlineDate = deadline.Date;
+
+        // #934 — same per-(planning, site) serialization as the nightly path,
+        // so an on-demand calendar materialisation racing the eager-deploy poll
+        // for the same rotation cannot double-create a PlanningCaseSite. Held
+        // for the whole check-then-deploy and released on any return/throw.
+        using var deployLockHandle = await AcquireDeployLockAsync(
+            areaRulePlanning.ItemPlanningId, sdkSiteId, cancellationToken).ConfigureAwait(false);
 
         // Idempotence guard: another caller (nightly batch, parallel request)
         // may already have materialised this occurrence. Match the natural


### PR DESCRIPTION
## Issue
Fixes #934 — a daily-recurrence calendar task's deploy created **multiple identical `PlanningCaseSites`** rows for the same `(PlanningId, MicrotingSdkSiteId)`. Forensics: 4 rows, **3 in the same second**.

## Root cause
The deploy path (`EnsureDeployedAsync`, run on **every 5s `StreamEventChanges` poll** + `ListEvents` + the several window/board calls a client fires per sync) guards on the `Compliance` row — but `DeployForRotationAsync` writes `Compliance` **last**, after the slow `CaseCreateLocalOnly`. Concurrent passes all clear the guard before any writes `Compliance`, and each creates a `PlanningCase` + `PlanningCaseSite` (only `Compliance` has a duplicate-key catch).

## Fix (app-level — no DB constraint/migration, as scoped)
An in-process per-`(planning, site)` `SemaphoreSlim` serializes the check-then-deploy at **both** deploy entry points (the `EnsureDeployedAsync` loop and the on-demand `EnsureComplianceForOccurrenceAsync`). The first pass writes `Compliance` before the next re-checks the guard, so the next short-circuits.
- Keyed on `(planning, site)` (not rotation date) → lock dictionary bounded by planning×site, no growth with the calendar window. The rotation-aware `Compliance` guard still deploys each distinct day exactly once.
- Cross-pod races remain bounded by the existing `Compliance` duplicate-key catch; making them physically impossible would need the `(PlanningId, MicrotingSdkSiteId, OccurrenceDate)` unique index #934 mentions (deferred — base migration).
- Also re-throws `OperationCanceledException` from the per-rotation catch so a mid-deploy cancellation aborts the pass instead of being swallowed.

## Test
`EnsureDeployedAsync_ConcurrentPassesSameRotation_CreatesExactlyOnePlanningCaseSite` seeds a **real eForm template** + full Area/Property/AreaRule/AreaRulePlanning + Planning + PlanningSite + SDK Site, then fires **4 concurrent** deploy passes (each on its own DbContexts, gated by a `Barrier` so they truly overlap) and asserts exactly **one** `PlanningCaseSite`.
**Verified:** 4 rows without the lock (reproduces the forensic snapshot), 1 with it. Full `EventDeployServiceTest` fixture green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)