### PR TITLE
Scope gRPC calendar/event reads to the caller's own site (#931)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/GrpcServices/CalendarGrpcServiceTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/GrpcServices/CalendarGrpcServiceTests.cs
@@ -134,6 +134,33 @@ public class CalendarGrpcServiceTests
     }
 
     [Test]
+    public async Task GetTasksForWeek_ScopesToCallerSite_IgnoringClientSiteIds()
+    {
+        // #931 — the gRPC (mobile) path must hard-scope task visibility to the
+        // caller's own resolved site, NOT trust the client-supplied SiteIds.
+        var resolver = Substitute.For<IGrpcSiteResolver>();
+        resolver.GetSdkSiteIdAsync().Returns(7);
+        var access = Substitute.For<IBackendConfigurationUserPropertyAccess>();
+        access.HasAccessAsync(7, 10).Returns(true);
+        var calSvc = Substitute.For<IBackendConfigurationCalendarService>();
+
+        CalendarTaskRequestModel captured = null;
+        calSvc.GetTasksForWeek(Arg.Do<CalendarTaskRequestModel>(m => captured = m))
+            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, []));
+
+        var sut = CreateSut(calendarService: calSvc, access: access, resolver: resolver);
+
+        // Client asks for a DIFFERENT site (99) than the caller's own (7).
+        var request = new GetTasksForWeekRequest { PropertyId = 10, SiteIds = { 99 } };
+        await sut.GetTasksForWeek(request, Substitute.For<ServerCallContext>());
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.That(captured.SiteIds, Is.EquivalentTo(new[] { 7 }),
+            "gRPC must forward only the caller's resolved site (7), ignoring the "
+            + "client-supplied SiteIds (99).");
+    }
+
+    [Test]
     public void GetBoards_AccessDenied_ThrowsPermissionDenied()
     {
         var resolver = Substitute.For<IGrpcSiteResolver>();

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/GrpcServices/EventsGrpcServiceSiteScopeTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/GrpcServices/EventsGrpcServiceSiteScopeTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Grpc.Events;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationPropertiesService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.GrpcServices;
+using BackendConfiguration.Pn.Services.UserPropertyAccess;
+using Grpc.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BackendConfiguration.Pn.Test.GrpcServices;
+
+/// <summary>
+/// #931 — the mobile event stream (EventsGrpcService) must only surface events
+/// assigned to the calling worker's own SDK site, never the whole property.
+/// These are pure NSubstitute unit tests: GetTasksForWeek is mocked to return an
+/// empty result, so the envelope/field loaders short-circuit before touching any
+/// DbContext or SDK core (the null contexts below are therefore never
+/// dereferenced). The assertion is on the request model the service forwards to
+/// the calendar service — proving the per-site scoping the read relies on.
+/// </summary>
+[TestFixture]
+public class EventsGrpcServiceSiteScopeTests
+{
+    private static EventsGrpcService CreateSut(
+        IBackendConfigurationCalendarService calendarService,
+        IGrpcSiteResolver resolver,
+        IBackendConfigurationUserPropertyAccess access)
+    {
+        return new EventsGrpcService(
+            calendarService,
+            Substitute.For<IBackendConfigurationPropertiesService>(),
+            access,
+            resolver,
+            Substitute.For<IEFormCoreService>(),
+            null, // BackendConfigurationPnDbContext — untouched on the empty-result path
+            null, // ItemsPlanningPnDbContext — untouched on the empty-result path
+            Substitute.For<IEventDeployService>(),
+            NullLogger<EventsGrpcService>.Instance);
+    }
+
+    [Test]
+    public async Task ListEvents_ScopesReadToCallerSite()
+    {
+        var resolver = Substitute.For<IGrpcSiteResolver>();
+        resolver.GetSdkSiteIdAsync().Returns(7);
+        var access = Substitute.For<IBackendConfigurationUserPropertyAccess>();
+        access.HasAccessAsync(7, 10).Returns(true);
+
+        var calSvc = Substitute.For<IBackendConfigurationCalendarService>();
+        CalendarTaskRequestModel captured = null;
+        calSvc.GetTasksForWeek(Arg.Do<CalendarTaskRequestModel>(m => captured = m))
+            .Returns(new OperationDataResult<List<CalendarTaskResponseModel>>(true, []));
+
+        var sut = CreateSut(calSvc, resolver, access);
+
+        var request = new ListEventsRequest
+        {
+            PropertyId = "10",
+            FromDateKey = "2026-06-04",
+            ToDateKey = "2026-06-10"
+        };
+        await sut.ListEvents(request, Substitute.For<ServerCallContext>());
+
+        Assert.That(captured, Is.Not.Null);
+        Assert.That(captured.SiteIds, Is.EquivalentTo(new[] { 7 }),
+            "#931: the mobile read must be scoped to the caller's own site (7), "
+            + "not left empty (which returns every site's tasks on the property).");
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/CalendarGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/CalendarGrpcService.cs
@@ -36,7 +36,13 @@ public class CalendarGrpcService(
             WeekEnd = request.WeekEnd,
             BoardIds = request.BoardIds.ToList(),
             TagNames = request.TagNames.ToList(),
-            SiteIds = request.SiteIds.ToList()
+            // #931 — gRPC (mobile) callers only ever see tasks assigned to their
+            // own site. Hard-scope to the resolved caller site rather than
+            // trusting the client-supplied SiteIds; the property-access gate
+            // above already authorises property-level access, but per-task
+            // visibility must be the worker's own site. (The REST controller
+            // path is unchanged, so web keeps its all-sites view.)
+            SiteIds = [sdkSiteId]
         };
 
         var result = await calendarService.GetTasksForWeek(model);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -222,7 +222,11 @@ public class EventsGrpcService(
             WeekEnd = request.ToDateKey ?? string.Empty,
             BoardIds = TryParseBoardIds(request.BoardIds),
             TagNames = [],
-            SiteIds = [],
+            // #931 — scope mobile reads to the caller's own site. The deploy
+            // pass above intentionally enumerates property-wide and narrows
+            // itself; this read, which is what the worker actually sees, must
+            // only return events assigned to their site.
+            SiteIds = [sdkSiteId],
             ActionableOnly = true
         };
 
@@ -861,7 +865,7 @@ public class EventsGrpcService(
         {
             var (initialStart, initialEnd) = ComputeWatchWindow();
             var initial = await LoadEventsAsync(
-                propertyId, boardFilter, initialStart, initialEnd, ct).ConfigureAwait(false);
+                propertyId, boardFilter, initialStart, initialEnd, sdkSiteId, ct).ConfigureAwait(false);
             foreach (var op in initial)
             {
                 ct.ThrowIfCancellationRequested();
@@ -930,7 +934,7 @@ public class EventsGrpcService(
                 }
 
                 var current = await LoadEventsAsync(
-                    propertyId, boardFilter, windowStart, windowEnd, ct).ConfigureAwait(false);
+                    propertyId, boardFilter, windowStart, windowEnd, sdkSiteId, ct).ConfigureAwait(false);
 
                 var currentKeys = new HashSet<(string EventId, string PlanDayKey)>();
 
@@ -1048,6 +1052,7 @@ public class EventsGrpcService(
         List<int> boardFilter,
         DateTime windowStart,
         DateTime windowEnd,
+        int sdkSiteId,
         CancellationToken ct = default)
     {
         var model = new CalendarTaskRequestModel
@@ -1057,7 +1062,9 @@ public class EventsGrpcService(
             WeekEnd = windowEnd.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
             BoardIds = boardFilter,
             TagNames = [],
-            SiteIds = [],
+            // #931 — the mobile stream only surfaces events assigned to the
+            // caller's own site (the worker), never the whole property.
+            SiteIds = [sdkSiteId],
             ActionableOnly = true
         };
 
@@ -1786,7 +1793,9 @@ public class EventsGrpcService(
             WeekEnd = dayKey,
             BoardIds = [],
             TagNames = [],
-            SiteIds = [],
+            // #931 — scope the echo read to the caller's site, consistent with
+            // the list/stream reads; a worker only ever sees their own events.
+            SiteIds = [sdkSiteId],
             ActionableOnly = true
         }).ConfigureAwait(false);
 
@@ -1996,7 +2005,9 @@ public class EventsGrpcService(
             WeekEnd = dayKey,
             BoardIds = [],
             TagNames = [],
-            SiteIds = [],
+            // #931 — scope the echo read to the caller's site, consistent with
+            // the list/stream reads; a worker only ever sees their own events.
+            SiteIds = [sdkSiteId],
             ActionableOnly = true
         }).ConfigureAwait(false);
 
@@ -2289,7 +2300,9 @@ public class EventsGrpcService(
             WeekEnd = dayKey,
             BoardIds = [],
             TagNames = [],
-            SiteIds = [],
+            // #931 — scope the echo read to the caller's site, consistent with
+            // the list/stream reads; a worker only ever sees their own events.
+            SiteIds = [sdkSiteId],
             ActionableOnly = true
         }).ConfigureAwait(false);
 
@@ -3209,7 +3222,9 @@ public class EventsGrpcService(
             WeekEnd = dayKey,
             BoardIds = [],
             TagNames = [],
-            SiteIds = [],
+            // #931 — scope the echo read to the caller's site, consistent with
+            // the list/stream reads; a worker only ever sees their own events.
+            SiteIds = [sdkSiteId],
             ActionableOnly = true
         }).ConfigureAwait(false);
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/GrpcSiteResolver.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/GrpcSiteResolver.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microting.eForm.Infrastructure.Constants;
 using Microting.eFormApi.BasePn.Abstractions;
 
@@ -11,7 +12,10 @@ public interface IGrpcSiteResolver
     Task<int> GetSdkSiteIdAsync();
 }
 
-public class GrpcSiteResolver(IUserService userService, IEFormCoreService coreHelper)
+public class GrpcSiteResolver(
+    IUserService userService,
+    IEFormCoreService coreHelper,
+    ILogger<GrpcSiteResolver> logger)
     : IGrpcSiteResolver
 {
     public async Task<int> GetSdkSiteIdAsync()
@@ -32,14 +36,34 @@ public class GrpcSiteResolver(IUserService userService, IEFormCoreService coreHe
 
         if (worker == null)
         {
+            // Since #931 made gRPC reads site-scoped, a 0 here means the caller
+            // sees an EMPTY calendar. Surface the misconfiguration so it can be
+            // diagnosed rather than mistaken for "no tasks".
+            logger.LogWarning(
+                "GrpcSiteResolver: no non-removed SDK worker for the current user's email; "
+                + "gRPC event reads will be site-scoped to 0 and return empty (#931).");
             return 0;
         }
 
+        // Deterministic site selection: a worker enrolled on more than one site
+        // must always resolve to the SAME site, otherwise the #931 site-scoped
+        // reads would non-deterministically surface a different — or empty —
+        // calendar depending on which SiteWorker row the engine returned first.
         var siteWorker = await sdkDbContext.SiteWorkers
             .Where(sw => sw.WorkerId == worker.Id && sw.WorkflowState != Constants.WorkflowStates.Removed)
+            .OrderBy(sw => sw.Id)
             .FirstOrDefaultAsync()
             .ConfigureAwait(false);
 
-        return siteWorker?.SiteId ?? 0;
+        if (siteWorker == null)
+        {
+            logger.LogWarning(
+                "GrpcSiteResolver: SDK worker {WorkerId} has no non-removed SiteWorker mapping; "
+                + "gRPC event reads will be site-scoped to 0 and return empty (#931).",
+                worker.Id);
+            return 0;
+        }
+
+        return siteWorker.SiteId ?? 0;
     }
 }


### PR DESCRIPTION
## Issue
Fixes #931 — the gRPC (mobile) calendar/event reads returned **every** task on a property regardless of assignment, leaking other workers' events to any worker with property-level access.

## Requirement
Web/REST stays **unchanged** (admins see all sites); only the **gRPC** paths are hard-scoped to the calling worker's own SDK site.

## Fix
Forward `SiteIds = [callerSdkSiteId]` (already resolved for the access gate) on every gRPC read, reusing the existing per-task filter in `ShouldIncludeTask` (`task.AssigneeIds` = the planning's `PlanningSites.SiteId`). **`GetTasksForWeek` / `ShouldIncludeTask` / `CalendarController` are untouched**, so web keeps all-sites.
- `CalendarGrpcService.GetTasksForWeek` — stopped trusting client-supplied `SiteIds`; hard-scoped to the resolved caller site.
- `EventsGrpcService.ListEvents` + `LoadEventsAsync` (StreamEventChanges initial snapshot + poll) — `LoadEventsAsync` gained an `sdkSiteId` param threaded from both call sites.
- The 4 write-path echo reads (`CompleteEvent`, idempotent re-tap, `SetComment`, `SetFieldValue`) — scoped for consistency.
- The deploy path (`EventDeployService.EnsureDeployedAsync`) is **deliberately left property-wide** (it does its own #935 site-narrowing).

Also hardened `GrpcSiteResolver`: deterministic `SiteWorker` ordering (a multi-site worker must always resolve to the same site, else the strict filter could surface a different/empty calendar) + a warning log when a user resolves to site `0` (so a deleted worker/site mapping is diagnosable, not a silently blank calendar).

## Tests (pure NSubstitute, no DB)
- `CalendarGrpcServiceTests.GetTasksForWeek_ScopesToCallerSite_IgnoringClientSiteIds` — captures the forwarded model, asserts `SiteIds == [callerSite]` even when the client sends a different site.
- `EventsGrpcServiceSiteScopeTests.ListEvents_ScopesReadToCallerSite` — same, for the primary mobile read path. 12/12 gRPC unit tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)