### PR TITLE
fix(calendar): yearly task snaps back to original day after move with scope (#952)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarYearlyMoveTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarYearlyMoveTests.cs
@@ -1,0 +1,277 @@
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+/// <summary>
+/// #952: an annually-repeating task, when MOVED (dragged) to a new date with
+/// scope "all" or "thisAndFollowing", must carry its day-of-month to the drop
+/// date. The yearly render reads <c>Planning.DayOfMonth</c> (and the edit
+/// round-trip reads <c>AreaRulePlanning.DayOfMonth</c>); if a move only shifts
+/// StartDate, the stale DayOfMonth re-pins the occurrence to the original day,
+/// so it "snaps back".
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarYearlyMoveTests : TestBaseSetup
+{
+    // Yearly RepeatType value. The plugin enum defines Year = 4; the
+    // items-planning enum only defines Day/Week/Month, so a yearly Planning
+    // stores the same value via a cast.
+    private const int YearRepeatType = 4;
+
+    private IUserService _userService;
+    private IBackendConfigurationTaskWizardService _taskWizardService;
+    private BackendConfigurationCalendarService _calendarService;
+
+    [SetUp]
+    public async Task SetupCalendarService()
+    {
+        BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarOccurrenceExceptions);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.CalendarConfigurations.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarConfigurations);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRulePlannings.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRulePlannings);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRules.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRules);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.Areas.RemoveRange(
+            BackendConfigurationPnDbContext.Areas);
+        BackendConfigurationPnDbContext.Properties.RemoveRange(
+            BackendConfigurationPnDbContext.Properties);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        ItemsPlanningPnDbContext!.Plannings.RemoveRange(
+            ItemsPlanningPnDbContext.Plannings);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        _userService = Substitute.For<IUserService>();
+        _userService.UserId.Returns(1);
+
+        var mockLanguage = new Language { Id = 1, Name = "English", LanguageCode = "en-US" };
+        _userService.GetCurrentUserLanguage().Returns(Task.FromResult(mockLanguage));
+
+        _taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        _taskWizardService.DeleteTask(Arg.Any<int>())
+            .Returns(Task.FromResult(new OperationResult(true)));
+
+        _calendarService = new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(),
+            _userService,
+            BackendConfigurationPnDbContext!,
+            null,
+            Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext!,
+            _taskWizardService,
+            NullLogger<BackendConfigurationCalendarService>.Instance
+        );
+    }
+
+    /// <summary>
+    /// Seeds a yearly AreaRulePlanning + Planning + CalendarConfiguration
+    /// anchored on <paramref name="startDate"/> with DayOfMonth = startDate.Day.
+    /// Returns the AreaRulePlanning Id.
+    /// </summary>
+    private async Task<int> SeedYearlyTask(DateTime startDate)
+    {
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1,
+            ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"TestProp-{Guid.NewGuid()}",
+            ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id,
+            PropertyId = property.Id,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planning = new Planning
+        {
+            Enabled = true,
+            RepeatEvery = 1,
+            RepeatType = (RepeatType)YearRepeatType,
+            DayOfMonth = startDate.Day,
+            StartDate = startDate,
+            RelatedEFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id,
+            PropertyId = property.Id,
+            AreaId = area.Id,
+            ItemPlanningId = planning.Id,
+            StartDate = startDate,
+            Status = true,
+            RepeatType = YearRepeatType,
+            RepeatEvery = 1,
+            DayOfMonth = startDate.Day,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id,
+            StartHour = 9.0,
+            Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        return arp.Id;
+    }
+
+    [Test]
+    public async Task MoveTask_ScopeAll_Yearly_CarriesDayOfMonthToDropDate()
+    {
+        // Anchored on the 4th of a far-future March; drag the whole series to the 9th.
+        var anchor = new DateTime(2030, 3, 4, 0, 0, 0, DateTimeKind.Utc);
+        var arpId = await SeedYearlyTask(anchor);
+        var newDate = new DateTime(2030, 3, 9, 0, 0, 0, DateTimeKind.Utc);
+
+        var result = await _calendarService.MoveTask(new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            NewDate = newDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 9.0,
+            Scope = "all"
+        });
+
+        Assert.That(result.Success, Is.True, result.Message);
+
+        // Re-fetch with AsNoTracking so the assertions read the PERSISTED row,
+        // not the in-memory entity MoveTask mutated.
+        var arp = await BackendConfigurationPnDbContext!.AreaRulePlannings.AsNoTracking().SingleAsync(x => x.Id == arpId);
+        var planning = await ItemsPlanningPnDbContext!.Plannings.AsNoTracking().SingleAsync(x => x.Id == arp.ItemPlanningId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(arp.StartDate!.Value.Date, Is.EqualTo(newDate.Date), "arp.StartDate shifted to the drop date");
+            Assert.That(planning.StartDate.Date, Is.EqualTo(newDate.Date), "planning.StartDate shifted to the drop date");
+            Assert.That(planning.DayOfMonth, Is.EqualTo(9), "planning.DayOfMonth (the yearly render anchor) follows the drop day");
+            Assert.That(arp.DayOfMonth, Is.EqualTo(9), "arp.DayOfMonth (the edit round-trip anchor) follows the drop day");
+        });
+    }
+
+    [Test]
+    public async Task MoveTask_ScopeThisAndFollowing_Yearly_CarriesDayOfMonthToDropDate()
+    {
+        // Series anchored several years in the PAST so the move actually shifts
+        // StartDate forward over real recurrence history (the snap-back the bug
+        // report hits is on a long-running series, not a freshly-created one).
+        var anchor = new DateTime(2024, 3, 4, 0, 0, 0, DateTimeKind.Utc);
+        var arpId = await SeedYearlyTask(anchor);
+        // originalDate is a future yearly occurrence of that series.
+        var originalDate = new DateTime(2027, 3, 4, 0, 0, 0, DateTimeKind.Utc);
+        var newDate = new DateTime(2027, 3, 9, 0, 0, 0, DateTimeKind.Utc);
+
+        var result = await _calendarService.MoveTask(new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            OriginalDate = originalDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewDate = newDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 9.0,
+            Scope = "thisAndFollowing"
+        });
+
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var arp = await BackendConfigurationPnDbContext!.AreaRulePlannings.AsNoTracking().SingleAsync(x => x.Id == arpId);
+        var planning = await ItemsPlanningPnDbContext!.Plannings.AsNoTracking().SingleAsync(x => x.Id == arp.ItemPlanningId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(arp.StartDate!.Value.Date, Is.EqualTo(newDate.Date));
+            Assert.That(planning.StartDate.Date, Is.EqualTo(newDate.Date));
+            Assert.That(planning.DayOfMonth, Is.EqualTo(9), "planning.DayOfMonth follows the drop day");
+            Assert.That(arp.DayOfMonth, Is.EqualTo(9), "arp.DayOfMonth follows the drop day");
+        });
+    }
+
+    [Test]
+    public async Task MoveTask_ScopeAll_Yearly_CrossMonth_CarriesMonthAndDay()
+    {
+        // The month follows StartDate; the day follows DayOfMonth. A cross-month
+        // move (Mar 4 -> Jul 9) must land the yearly anchor on Jul 9, not Jul 4.
+        var anchor = new DateTime(2030, 3, 4, 0, 0, 0, DateTimeKind.Utc);
+        var arpId = await SeedYearlyTask(anchor);
+        var newDate = new DateTime(2030, 7, 9, 0, 0, 0, DateTimeKind.Utc);
+
+        var result = await _calendarService.MoveTask(new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            NewDate = newDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 9.0,
+            Scope = "all"
+        });
+
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var arp = await BackendConfigurationPnDbContext!.AreaRulePlannings.AsNoTracking().SingleAsync(x => x.Id == arpId);
+        var planning = await ItemsPlanningPnDbContext!.Plannings.AsNoTracking().SingleAsync(x => x.Id == arp.ItemPlanningId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(planning.StartDate.Month, Is.EqualTo(7), "month follows the drop date");
+            Assert.That(planning.StartDate.Day, Is.EqualTo(9));
+            Assert.That(planning.DayOfMonth, Is.EqualTo(9));
+            Assert.That(arp.DayOfMonth, Is.EqualTo(9));
+        });
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -1858,6 +1858,15 @@ public class BackendConfigurationCalendarService(
                     arp.RepeatWeekdaysCsv = ((int)newDate.DayOfWeek).ToString(CultureInfo.InvariantCulture);
                     arp.DayOfWeek = (int)newDate.DayOfWeek;
                 }
+                // Yearly rules anchor on a fixed (month, day-of-month). The
+                // month follows StartDate, but the day-of-month is read from
+                // DayOfMonth by the yearly render; carry it to the drop day or
+                // the occurrence re-pins to the original day and snaps back
+                // (#952).
+                if (arp.RepeatType == (int)Infrastructure.Enums.RepeatType.Year)
+                {
+                    arp.DayOfMonth = newDate.Day;
+                }
                 arp.UpdatedByUserId = userService.UserId;
                 await arp.Update(backendConfigurationPnDbContext);
 
@@ -1868,6 +1877,10 @@ public class BackendConfigurationCalendarService(
                     // new weekday so NextExecutionTime does not pull the series
                     // back to the old day (the two-master defect, #925/#926).
                     oldPlanning.DayOfWeek = newDate.DayOfWeek;
+                    if (arp.RepeatType == (int)Infrastructure.Enums.RepeatType.Year)
+                    {
+                        oldPlanning.DayOfMonth = newDate.Day;
+                    }
                     oldPlanning.UpdatedByUserId = userService.UserId;
                     await oldPlanning.Update(itemsPlanningPnDbContext);
                 }
@@ -1925,6 +1938,12 @@ public class BackendConfigurationCalendarService(
                     arp.RepeatWeekdaysCsv = ((int)newDate.DayOfWeek).ToString(CultureInfo.InvariantCulture);
                     arp.DayOfWeek = (int)newDate.DayOfWeek;
                 }
+                // Carry the yearly day-of-month to the drop day (#952); see the
+                // thisAndFollowing branch above for the rationale.
+                if (arp.RepeatType == (int)Infrastructure.Enums.RepeatType.Year)
+                {
+                    arp.DayOfMonth = newDate.Day;
+                }
                 arp.UpdatedByUserId = userService.UserId;
                 await arp.Update(backendConfigurationPnDbContext);
 
@@ -1937,6 +1956,10 @@ public class BackendConfigurationCalendarService(
                 {
                     planning.StartDate = newDate;
                     planning.DayOfWeek = newDate.DayOfWeek;
+                    if (arp.RepeatType == (int)Infrastructure.Enums.RepeatType.Year)
+                    {
+                        planning.DayOfMonth = newDate.Day;
+                    }
                     planning.UpdatedByUserId = userService.UserId;
                     await planning.Update(itemsPlanningPnDbContext);
                 }


### PR DESCRIPTION
## Issue
Fixes #952 — an annually-repeating calendar task, when dragged to a new date with scope **"This and following"** or **"All in series"**, snapped back to its original day.

## Root cause
`MoveTask` advanced `StartDate` but never updated `DayOfMonth`. The yearly render (`GetOccurrencesInWeek`, `case (RepeatType)4 // Year`) computes the occurrence **day** from `planning.DayOfMonth ?? startDate.Day` and the **month** from `startDate.Month`. So the month followed the move but the stale `DayOfMonth` re-pinned the day → snap-back. The edit round-trip reads `arp.DayOfMonth` (via the view-model), so it must stay in sync too.

## Fix
In both the `thisAndFollowing` and `all` branches of `MoveTask`, carry the drop day into `DayOfMonth` on **both** the `AreaRulePlanning` (edit round-trip source) and the items-planning `Planning` row (render source), guarded to `RepeatType.Year (4)` so monthly/weekly/Nth-weekday rules are untouched.

## Tests
New `CalendarYearlyMoveTests` (integration, Testcontainers MariaDB):
- `scope=all` — day carried to drop date
- `scope=thisAndFollowing` — over a **past-anchored** series (exercises the real StartDate shift)
- cross-month move — month + day both follow

Verified RED before the fix (DayOfMonth stayed `4`), GREEN after; existing `CalendarOccurrenceExceptionTests` still pass.

## Out of scope (noted for follow-up)
`EnumerateOccurrences` has no `Year` branch, so the `thisAndFollowing` past-occurrence backfill is a no-op for yearly series. Never-deployed past yearly occurrences are not anchored (deployed ones still render via the compliance loop). Pre-existing; not addressed here to keep this fix focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)