### PR TITLE
fix(calendar): cannot drag a moved occurrence back to its natural day (#953)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOccurrenceExceptionTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOccurrenceExceptionTests.cs
@@ -613,4 +613,103 @@ public class CalendarOccurrenceExceptionTests : TestBaseSetup
         // DeleteTask on the wizard service should have been called
         await _taskWizardService.Received(1).DeleteTask(arpId);
     }
+
+    [Test]
+    public async Task MoveTask_ScopeThis_BackToNaturalDay_ClearsOverrideInsteadOfOrphaning()
+    {
+        // Reproduces #953: a scope=this MOVE writes {OriginalDate=Mon, NewDate=Wed}
+        // and the occurrence renders on Wed. Dragging that Wed tile back to its
+        // natural Monday sends the DISPLAYED date (Wed) as OriginalDate. The move
+        // must reuse the SAME exception (matched by NewDate) and clear its
+        // override (NewDate -> null) so the occurrence renders naturally again —
+        // NOT create a second orphan {OriginalDate=Wed} row that leaves the tile
+        // stuck on Wed.
+        var baseMonday = GetNextMonday();
+        var startDate = DateTime.SpecifyKind(baseMonday, DateTimeKind.Utc);
+        var arpId = await SeedWeeklyTask(startDate);
+
+        var wed = baseMonday.AddDays(2);
+
+        var move1 = await _calendarService.MoveTask(new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            OriginalDate = baseMonday.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewDate = wed.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 10.0,
+            Scope = "this"
+        });
+        Assert.That(move1.Success, Is.True, move1.Message);
+
+        // Drag the now-Wed tile back to natural Monday (FE sends displayed date = Wed).
+        var move2 = await _calendarService.MoveTask(new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            OriginalDate = wed.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewDate = baseMonday.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 9.0,
+            Scope = "this"
+        });
+        Assert.That(move2.Success, Is.True, move2.Message);
+
+        var exceptions = await BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+
+        Assert.That(exceptions, Has.Count.EqualTo(1),
+            "move-back must reuse the original exception row, not create a second orphan");
+        Assert.That(exceptions[0].OriginalDate.Date, Is.EqualTo(baseMonday.Date),
+            "the surviving row keeps the natural OriginalDate");
+        Assert.That(exceptions[0].NewDate, Is.Null,
+            "back-to-natural clears the override so the occurrence renders on its natural day");
+        Assert.That(exceptions[0].StartHour, Is.EqualTo(9.0),
+            "the dropped start hour is retained (consistent with the same-day move path)");
+    }
+
+    [Test]
+    public async Task MoveTask_ScopeThis_ReMoveAlreadyMovedOccurrence_RelocatesSingleException()
+    {
+        // #953 sibling: move Mon -> Wed, then drag the Wed tile on to Thu (both
+        // scope=this). The second move sends the displayed date (Wed); it must
+        // RELOCATE the existing exception (NewDate -> Thu), not create a second
+        // {OriginalDate=Wed} row.
+        var baseMonday = GetNextMonday();
+        var startDate = DateTime.SpecifyKind(baseMonday, DateTimeKind.Utc);
+        var arpId = await SeedWeeklyTask(startDate);
+
+        var wed = baseMonday.AddDays(2);
+        var thu = baseMonday.AddDays(3);
+
+        await _calendarService.MoveTask(new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            OriginalDate = baseMonday.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewDate = wed.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 10.0,
+            Scope = "this"
+        });
+
+        var move2 = await _calendarService.MoveTask(new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            OriginalDate = wed.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewDate = thu.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 11.0,
+            Scope = "this"
+        });
+        Assert.That(move2.Success, Is.True, move2.Message);
+
+        var exceptions = await BackendConfigurationPnDbContext!.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+
+        Assert.That(exceptions, Has.Count.EqualTo(1),
+            "re-moving an already-moved occurrence must reuse the original exception row");
+        Assert.That(exceptions[0].OriginalDate.Date, Is.EqualTo(baseMonday.Date),
+            "the surviving row keeps the natural OriginalDate");
+        Assert.That(exceptions[0].NewDate!.Value.Date, Is.EqualTo(thu.Date),
+            "the surviving row's NewDate is relocated to the latest drop date");
+        Assert.That(exceptions[0].StartHour, Is.EqualTo(11.0));
+    }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -1741,15 +1741,40 @@ public class BackendConfigurationCalendarService(
                 var originalDate = DateTime.Parse(moveModel.OriginalDate, CultureInfo.InvariantCulture,
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal).Date;
 
+                // The frontend sends the DISPLAYED date as OriginalDate. Prefer
+                // an exception keyed on that natural date; otherwise (if a prior
+                // scope=this move relocated a DIFFERENT occurrence onto the
+                // displayed date) reuse THAT move's exception, matched by its
+                // NewDate. Without the NewDate fallback, dragging an
+                // already-moved occurrence again — or back to its natural day —
+                // orphans the original row and the tile never moves (#953,
+                // mirrors the delete-after-move fix #915).
                 var exception = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
                     .Where(x => x.AreaRulePlanningId == moveModel.Id)
                     .Where(x => x.OriginalDate == originalDate)
                     .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                     .FirstOrDefaultAsync();
 
+                if (exception == null)
+                {
+                    // No natural-keyed exception: look for an occurrence a prior
+                    // move relocated onto this displayed date. The
+                    // OriginalDate != displayedDate guard keeps this strictly to
+                    // moved-away occurrences (a same-day override stores
+                    // NewDate = null, so it is never matched here anyway).
+                    exception = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
+                        .Where(x => x.AreaRulePlanningId == moveModel.Id)
+                        .Where(x => x.NewDate.HasValue && x.NewDate.Value.Date == originalDate
+                                    && x.OriginalDate.Date != originalDate)
+                        .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                        .FirstOrDefaultAsync();
+                }
+
                 if (exception != null)
                 {
-                    exception.NewDate = newDate.Date != originalDate ? newDate : null;
+                    // Clear the override when the occurrence lands back on its
+                    // own natural day; otherwise relocate it.
+                    exception.NewDate = newDate.Date != exception.OriginalDate.Date ? newDate : null;
                     exception.StartHour = moveModel.NewStartHour;
                     exception.UpdatedByUserId = userService.UserId;
                     await exception.Update(backendConfigurationPnDbContext);


### PR DESCRIPTION
## Issue
Fixes #953 — for a recurring task, dragging an occurrence off its natural day (scope **"Only this"**) works, but dragging it **back** — or dragging the already-moved occurrence again — silently failed; the tile stayed put.

## Root cause
A scope=this move stores a `CalendarOccurrenceException` keyed on the **natural** date with `NewDate` = the drop date; the occurrence then renders on the drop date. When that occurrence is dragged again, the frontend sends the **displayed** date as `OriginalDate`. `MoveTask` only looked up exceptions by `OriginalDate == displayedDate`, so the prior move's row (keyed on the natural date, `NewDate == displayedDate`) was never found → a second orphan exception was created and the original override stayed in effect.

## Fix
In the `scope == "this"` branch of `MoveTask`: keep the natural-date lookup first, then **fall back to matching by `NewDate == displayedDate`** (guarded with `OriginalDate != displayedDate` so it only matches genuinely moved-away occurrences). Relocate that row, or clear its override (`NewDate = null`) when it lands back on its own natural day. Mirrors the delete-after-move fix (#915).

## Tests
New in `CalendarOccurrenceExceptionTests`:
- `…BackToNaturalDay_ClearsOverrideInsteadOfOrphaning` — Mon→Wed then Wed→Mon ⇒ single row, `NewDate=null`.
- `…ReMoveAlreadyMovedOccurrence_RelocatesSingleException` — Mon→Wed then Wed→Thu ⇒ single row relocated to Thu.

RED before the fix (2 rows), GREEN after; full fixture (11 tests incl. the #915 delete-after-move regression) passes.

## Known limitation (pre-existing, out of scope)
When a moved occurrence's destination day is **also** a natural recurrence day, two tiles stack on that date and the frontend sends the same displayed date for both — so which tile a drag refers to is inherently ambiguous via the current FE protocol. This fix prefers the natural-keyed exception when one exists; the stacked-overlap case is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)