### PR TITLE
fix(calendar): dragging a task with a Compliance row creates a duplicate tile (#954)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarComplianceMoveTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarComplianceMoveTests.cs
@@ -1,0 +1,399 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+*/
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+using System.Globalization;
+using eFormCore;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+
+/// <summary>
+/// #954 — render-level regression coverage.
+///
+/// A recurring calendar task with a DEPLOYED-but-not-yet-done Compliance row
+/// (the row a device worker creates when opening the task:
+/// <c>MicrotingSdkCaseId &gt; 0</c> with a backing SDK Case whose
+/// <c>Status != 100</c>) used to render TWO tiles after a series-level move
+/// ("all" / "thisAndFollowing"): one at the old <c>Compliance.Deadline</c> and
+/// one at the new recurrence anchor.
+///
+/// The fix in <c>BackendConfigurationCalendarService.MoveTask</c> shifts the
+/// dragged occurrence's open Compliance row's <c>Deadline</c> to the new date so
+/// the recurrence-dedup gate (<c>complianceDateSet</c>, keyed
+/// <c>PlanningId:Deadline</c>) suppresses the duplicate recurrence tile — leaving
+/// a single tile at the new date.
+///
+/// These tests exercise the fix at the RENDER level via
+/// <see cref="BackendConfigurationCalendarService.GetTasksForWeek"/>, which is
+/// why a REAL SDK core (and seeded SDK Cases) is required: the move guard, the
+/// completion read, and the compliance-emit loop all consult the backing SDK
+/// Case. A <c>MicrotingSdkCaseId == 0</c> row is NOT emitted as a tile and NOT
+/// in the dedup set (Defect E / #935), so it would prove nothing here — every
+/// Compliance row below is deployed (<c>MicrotingSdkCaseId &gt; 0</c>).
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarComplianceMoveTests : TestBaseSetup
+{
+    private static string IsoUtc(DateTime d) =>
+        DateTime.SpecifyKind(d, DateTimeKind.Utc)
+            .ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+    private static string Key(DateTime d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static DateTime GetNextMonday()
+    {
+        var today = DateTime.UtcNow.Date;
+        var daysUntilMonday = ((int)DayOfWeek.Monday - (int)today.DayOfWeek + 7) % 7;
+        if (daysUntilMonday == 0) daysUntilMonday = 7; // always strictly future
+        return today.AddDays(daysUntilMonday);
+    }
+
+    [SetUp]
+    public async Task CleanCalendarTables()
+    {
+        // FK-safe cleanup so each test starts fresh (base [SetUp] already ran).
+        BackendConfigurationPnDbContext!.CalendarOccurrenceExceptionSites.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarOccurrenceExceptionSites);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.CalendarOccurrenceExceptions.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarOccurrenceExceptions);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.Compliances.RemoveRange(
+            BackendConfigurationPnDbContext.Compliances);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.CalendarConfigurations.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarConfigurations);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRulePlannings.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRulePlannings);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRules.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRules);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.Areas.RemoveRange(
+            BackendConfigurationPnDbContext.Areas);
+        BackendConfigurationPnDbContext.Properties.RemoveRange(
+            BackendConfigurationPnDbContext.Properties);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        ItemsPlanningPnDbContext!.Plannings.RemoveRange(
+            ItemsPlanningPnDbContext.Plannings);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        MicrotingDbContext!.Cases.RemoveRange(MicrotingDbContext.Cases);
+        await MicrotingDbContext.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Seeds an SDK Site + Case with the given completion status (100 =
+    /// completed, &lt;100 = open / deployed-not-done) and returns the Case Id.
+    /// Required non-null Case fields: SiteId (FK to a real Site), Status,
+    /// WorkflowState. Id is identity — captured from the generated row.
+    /// </summary>
+    private async Task<int> SeedSdkCase(int status, int microtingUid)
+    {
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        var sdkSite = new Site
+        {
+            Name = $"compliance-move-test-site-{microtingUid}",
+            MicrotingUid = microtingUid,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(sdkSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var sdkCase = new Case
+        {
+            SiteId = sdkSite.Id,
+            Status = status,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Cases.AddAsync(sdkCase);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        return sdkCase.Id;
+    }
+
+    /// <summary>
+    /// Seeds Area→Property→AreaRule(+translation)→Planning→AreaRulePlanning
+    /// (weekly Monday)→CalendarConfiguration. Returns
+    /// (arpId, propertyId, planningId, areaId).
+    /// </summary>
+    private async Task<(int ArpId, int PropertyId, int PlanningId, int AreaId)> SeedWeeklyMondaySeries(
+        DateTime startDate)
+    {
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"ComplianceMoveTest-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id, EformId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRuleTranslation = new AreaRuleTranslation
+        {
+            AreaRuleId = areaRule.Id, LanguageId = 1, Name = "Compliance Move Title",
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRuleTranslations.AddAsync(areaRuleTranslation);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Week,
+            StartDate = DateTime.SpecifyKind(startDate, DateTimeKind.Utc),
+            DayOfWeek = DayOfWeek.Monday, RelatedEFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        // Weekly Monday series: RepeatType=2 (weeks), RepeatWeekdaysCsv="1", DayOfWeek=1.
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
+            ItemPlanningId = planning.Id,
+            StartDate = DateTime.SpecifyKind(startDate, DateTimeKind.Utc), Status = true,
+            RepeatType = 2, RepeatEvery = 1, RepeatWeekdaysCsv = "1", DayOfWeek = 1,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        return (arp.Id, property.Id, planning.Id, area.Id);
+    }
+
+    /// <summary>
+    /// Seeds a DEPLOYED Compliance row (MicrotingSdkCaseId &gt; 0) at the given
+    /// deadline. Returns the Compliance Id.
+    /// </summary>
+    private async Task<int> SeedDeployedCompliance(int planningId, int propertyId, int areaId,
+        DateTime deadline, int sdkCaseId)
+    {
+        var compliance = new Compliance
+        {
+            PlanningId = planningId,
+            PropertyId = propertyId,
+            AreaId = areaId,
+            Deadline = DateTime.SpecifyKind(deadline, DateTimeKind.Utc),
+            StartDate = DateTime.SpecifyKind(deadline.AddDays(-7), DateTimeKind.Utc),
+            MicrotingSdkCaseId = sdkCaseId,
+            MicrotingSdkeFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Compliances.AddAsync(compliance);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        return compliance.Id;
+    }
+
+    private BackendConfigurationCalendarService BuildService(Core core)
+    {
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        userService.GetCurrentUserLanguage().Returns(Task.FromResult(
+            new Language { Id = 1, Name = "English", LanguageCode = "en-US" }));
+
+        // The move guard, completion read and compliance-emit loop all read the
+        // backing SDK Case, so the real core must be wired through coreHelper.
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+
+        var taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        taskWizardService.DeleteTask(Arg.Any<int>())
+            .Returns(Task.FromResult(new OperationResult(true)));
+
+        return new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(), userService,
+            BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext!, taskWizardService,
+            NullLogger<BackendConfigurationCalendarService>.Instance);
+    }
+
+    private async Task<List<CalendarTaskResponseModel>> TilesForWeek(
+        BackendConfigurationCalendarService service, int propertyId, DateTime weekMonday, int planningId)
+    {
+        var result = await service.GetTasksForWeek(new CalendarTaskRequestModel
+        {
+            PropertyId = propertyId,
+            WeekStart = IsoUtc(weekMonday),
+            WeekEnd = IsoUtc(weekMonday.AddDays(6).AddHours(23).AddMinutes(59)),
+            ActionableOnly = false,
+            BoardIds = [], TagNames = [], SiteIds = []
+        });
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model, Is.Not.Null);
+        return result.Model.Where(t => t.PlanningId == planningId).ToList();
+    }
+
+    // ------------------------------------------------------------------
+    // (a) #954 — render-level: deployed-open compliance renders a SINGLE
+    //     tile at the NEW date after a scope=all move, none at the old date.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task GetTasksForWeek_AfterScopeAllMove_DeployedOpenComplianceRendersSingleTileAtNewDate()
+    {
+        var core = await GetCore();
+
+        var monday = GetNextMonday();
+        var (arpId, propertyId, planningId, areaId) = await SeedWeeklyMondaySeries(monday);
+
+        // Deployed-open compliance at the original Monday (Status 66 != 100).
+        var openCaseId = await SeedSdkCase(status: 66, microtingUid: 9541);
+        await SeedDeployedCompliance(planningId, propertyId, areaId, monday, openCaseId);
+
+        var service = BuildService(core);
+
+        // Baseline: original Monday's week renders exactly ONE tile for this planning.
+        var beforeTiles = await TilesForWeek(service, propertyId, monday, planningId);
+        var beforeOnMonday = beforeTiles.Where(t => t.TaskDate == Key(monday)).ToList();
+        Assert.That(beforeOnMonday, Has.Count.EqualTo(1),
+            "before the move the original Monday must render exactly one tile (compliance dedups the recurrence)");
+
+        // Move the whole series Monday -> Monday+7.
+        var newDate = monday.AddDays(7);
+        var moveResult = await service.MoveTask(new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            OriginalDate = monday.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewDate = newDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 9.0,
+            Scope = "all"
+        });
+        Assert.That(moveResult.Success, Is.True, moveResult.Message);
+
+        // New-date week: exactly ONE tile for this planning, at Monday+7.
+        var afterNewTiles = await TilesForWeek(service, propertyId, newDate, planningId);
+        Assert.Multiple(() =>
+        {
+            Assert.That(afterNewTiles, Has.Count.EqualTo(1),
+                "after the move the new-date week must render exactly one tile for this planning");
+            Assert.That(afterNewTiles[0].TaskDate, Is.EqualTo(Key(newDate)),
+                "the single tile must sit at the new date");
+        });
+
+        // Original Monday's week: ZERO tiles for this planning on the original Monday.
+        var afterOldTiles = await TilesForWeek(service, propertyId, monday, planningId);
+        var afterOnOldMonday = afterOldTiles.Where(t => t.TaskDate == Key(monday)).ToList();
+        Assert.That(afterOnOldMonday, Is.Empty,
+            "no leftover duplicate tile remains on the original Monday after the series move");
+
+        // DB-level: the compliance row's Deadline followed the move to Monday+7.
+        var compliance = await BackendConfigurationPnDbContext!.Compliances
+            .AsNoTracking().SingleAsync(x => x.PlanningId == planningId);
+        Assert.That(compliance.Deadline.Date, Is.EqualTo(newDate.Date),
+            "the deployed-open compliance row's Deadline shifts to the new date");
+    }
+
+    // ------------------------------------------------------------------
+    // (b) #954 — only the dragged occurrence's open row moves; a completed
+    //     history row on an earlier date stays pinned (DB-level).
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task MoveTask_ScopeAll_LeavesCompletedHistoryRowOnOtherDatePinned()
+    {
+        var core = await GetCore();
+
+        var monday = GetNextMonday();
+        var (arpId, propertyId, planningId, areaId) = await SeedWeeklyMondaySeries(monday);
+
+        // Deployed-OPEN compliance at the future Monday (case A, Status 66).
+        var openCaseId = await SeedSdkCase(status: 66, microtingUid: 9542);
+        var openComplianceId = await SeedDeployedCompliance(planningId, propertyId, areaId, monday, openCaseId);
+
+        // COMPLETED history compliance at an earlier past date (case B, Status 100).
+        var historyDate = monday.AddDays(-7);
+        var completedCaseId = await SeedSdkCase(status: 100, microtingUid: 9543);
+        var historyComplianceId = await SeedDeployedCompliance(planningId, propertyId, areaId, historyDate, completedCaseId);
+
+        var service = BuildService(core);
+
+        var newDate = monday.AddDays(7);
+        var moveResult = await service.MoveTask(new CalendarTaskMoveRequestModel
+        {
+            Id = arpId,
+            OriginalDate = monday.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewDate = newDate.ToString("yyyy-MM-dd") + "T00:00:00Z",
+            NewStartHour = 9.0,
+            Scope = "all"
+        });
+        Assert.That(moveResult.Success, Is.True, moveResult.Message);
+
+        var openRow = await BackendConfigurationPnDbContext!.Compliances
+            .AsNoTracking().SingleAsync(x => x.Id == openComplianceId);
+        var historyRow = await BackendConfigurationPnDbContext.Compliances
+            .AsNoTracking().SingleAsync(x => x.Id == historyComplianceId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(openRow.Deadline.Date, Is.EqualTo(newDate.Date),
+                "the dragged occurrence's open row moves to the new date");
+            Assert.That(historyRow.Deadline.Date, Is.EqualTo(historyDate.Date),
+                "the completed history row stays pinned to its past date");
+        });
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -2024,6 +2024,66 @@ public class BackendConfigurationCalendarService(
                 }
             }
 
+            // #954: a series-level move ("thisAndFollowing"/"all") shifts the
+            // recurrence anchor but leaves the dragged occurrence's Compliance
+            // row at its old Deadline, so the compliance loop keeps painting a
+            // tile on the old day while the recurrence paints one on the new day
+            // — a duplicate. Carry that occurrence's Compliance row to the new
+            // date so a single tile remains (the dedup gate then suppresses the
+            // recurrence tile on that day). Scope "this" is excluded: it is
+            // rendered through the per-occurrence exception the compliance loop
+            // already consults. The move guard above rejected completed
+            // occurrences, so the row at originalDate is open; Compliance rows on
+            // other dates (incl. completed history) stay pinned. A 3-day window
+            // + in-memory .Date match avoids DateTime.Kind drift (mirrors
+            // IsTaskOccurrenceCompleted).
+            if (scope != "this" && !string.IsNullOrEmpty(moveModel.OriginalDate))
+            {
+                var origComplianceDate = DateTime.Parse(moveModel.OriginalDate,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal).Date;
+                var windowStart = origComplianceDate.AddDays(-1);
+                var windowEnd = origComplianceDate.AddDays(2);
+                var complianceCandidates = await backendConfigurationPnDbContext.Compliances
+                    .Where(x => x.PlanningId == arp.ItemPlanningId)
+                    .Where(x => x.Deadline >= windowStart && x.Deadline < windowEnd)
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .ToListAsync();
+                var complianceAtOriginalDate = complianceCandidates
+                    .Where(c => c.Deadline.Date == origComplianceDate)
+                    .ToList();
+
+                // Never relocate a COMPLETED occurrence's row: completed history
+                // stays pinned to its date even if (data anomaly) it shares the
+                // day with the open occurrence the move guard cleared. The guard
+                // only inspects one row per day (FirstOrDefault), so re-check
+                // completion here against the backing SDK case (Status == 100).
+                var caseIds = complianceAtOriginalDate
+                    .Select(c => c.MicrotingSdkCaseId)
+                    .Where(id => id > 0)
+                    .Distinct()
+                    .ToList();
+                var completedCaseIds = new HashSet<int>();
+                if (caseIds.Count > 0)
+                {
+                    var sdkCore = await coreHelper.GetCore().ConfigureAwait(false);
+                    await using var sdkDbContext = sdkCore.DbContextHelper.GetDbContext();
+                    completedCaseIds = (await sdkDbContext.Cases
+                        .Where(c => caseIds.Contains(c.Id) && c.Status == 100)
+                        .Select(c => c.Id)
+                        .ToListAsync()).ToHashSet();
+                }
+
+                foreach (var compliance in complianceAtOriginalDate
+                             .Where(c => !(c.MicrotingSdkCaseId > 0
+                                           && completedCaseIds.Contains(c.MicrotingSdkCaseId))))
+                {
+                    compliance.Deadline = newDate.Date;
+                    compliance.UpdatedByUserId = userService.UserId;
+                    await compliance.Update(backendConfigurationPnDbContext);
+                }
+            }
+
             return new OperationResult(true,
                 localizationService.GetString("CalendarTaskMovedSuccessfully"));
         }


### PR DESCRIPTION
## Issue
Fixes #954 — a task with an active **Compliance** row (created when a device worker opens/submits the task), dragged to a new date with scope **"All in series"** / **"This and following"**, showed **two tiles** (old date + new date) instead of one.

## Root cause
A series-level move shifts `AreaRulePlanning.StartDate` / `Planning.StartDate` (and deletes occurrence exceptions) but left `Compliance.Deadline` on the old date. `GetTasksForWeek` then emits a compliance-loop tile at the old `Deadline` **and** a recurrence tile at the new anchor. The dedup gate (`complianceDateSet`, keyed `PlanningId:Deadline`) only suppresses the recurrence tile when a compliance exists on the **same** day, so old ≠ new → both render. (Only deployed rows `MicrotingSdkCaseId>0` are emitted/deduped; `caseId=0` rows neither render nor dedup, so they never duplicated.)

## Fix
In `MoveTask`, after a series-level move (`scope != "this"`), shift the **dragged occurrence's** open `Compliance` row `Deadline` → new date, so the dedup gate collapses to a single tile.
- Scope `this` is excluded — it renders via the per-occurrence exception the compliance loop already consults.
- **Completed rows stay pinned**: the existing move guard already rejects completed occurrences, and the shift additionally re-checks the backing SDK case `Status==100` (so completed history is never relocated, even in the data-anomaly case where it shares the day). Other-date history is untouched (no collapsing).

## Tests
New `CalendarComplianceMoveTests` (integration, real SDK core + seeded SDK cases):
- **render-level**: after a scope=all move of a deployed-open compliance, `GetTasksForWeek` returns exactly **one** tile at the new date and **zero** on the original.
- completed history row on another date stays pinned.

Both verified **RED** without the fix (duplicate tile / unshifted deadline), **GREEN** with it; the full `CalendarOccurrenceExceptionTests` fixture still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)