### PR TITLE
fix(calendar): edit-modal 'Gentag' re-anchors on date change + completed occurrences immutable across scopes (#960)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarCompletedPeriodSuppressionTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarCompletedPeriodSuppressionTests.cs
@@ -1,0 +1,369 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+*/
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+using System.Globalization;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Infrastructure.Models.TaskWizard;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+
+/// <summary>
+/// #960 — period-level completed-occurrence suppression.
+///
+/// A completed occurrence freezes its WHOLE recurrence period. When a monthly
+/// Nth-weekday rule is re-anchored to a different weekday (e.g. an "all"/
+/// "thisAndFollowing" edit moves "1st Friday" → "1st Thursday"), the recurrence
+/// emit loop would otherwise sprout a phantom not-completed sibling next to the
+/// pinned completed occurrence in a month that is already done.
+///
+/// These tests pin the rule on the NEW weekday (Thursday) and seed a completed
+/// compliance on the OLD weekday (Friday) of the same month, then assert the
+/// completed month renders exactly one (completed) tile — while a future month
+/// with no completed occurrence still renders the rule normally.
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarCompletedPeriodSuppressionTests : TestBaseSetup
+{
+    private static string IsoUtc(DateTime d) =>
+        DateTime.SpecifyKind(d, DateTimeKind.Utc)
+            .ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+    private static string Key(DateTime d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    [Test]
+    public async Task GetTasksForWeek_MonthlyNthWeekday_CompletedMonth_NoPhantomSibling()
+    {
+        // Boot a real SDK Core so completion (Case.Status==100) can be read.
+        var core = await GetCore();
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        var sdkSite = new Site
+        {
+            Name = "period-suppression-test-site",
+            MicrotingUid = 5454,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(sdkSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        // Completed (Status=100) backing case for the 1st-Friday-of-July occurrence.
+        var sdkCase = new Microting.eForm.Infrastructure.Data.Entities.Case
+        {
+            SiteId = sdkSite.Id,
+            Status = 100,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Cases.AddAsync(sdkCase);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"PeriodSuppressionTest-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id, EformId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // Monthly Nth-weekday rule starting 2026-01-01, RE-ANCHORED to the
+        // 1st THURSDAY of each month (the new pattern after the edit).
+        var startDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Month, StartDate = startDate,
+            RelatedEFormId = 0, WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
+            ItemPlanningId = planning.Id, StartDate = startDate, Status = true,
+            RepeatType = 3, RepeatEvery = 1, RepeatOrdinalWeek = 1, DayOfWeek = 4, // 1st Thursday
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // Completed occurrence on the OLD pattern: 1st FRIDAY of July 2026 = Jul 3.
+        var completedFriday = new DateTime(2026, 7, 3, 0, 0, 0, DateTimeKind.Utc);
+        var compliance = new Compliance
+        {
+            PlanningId = planning.Id, PropertyId = property.Id, AreaId = area.Id,
+            Deadline = completedFriday, StartDate = completedFriday.AddDays(-30),
+            MicrotingSdkCaseId = sdkCase.Id, MicrotingSdkeFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Removed // completed path soft-deletes
+        };
+        await BackendConfigurationPnDbContext.Compliances.AddAsync(compliance);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var service = BuildService(core);
+
+        // --- Completed month (July 2026): week Mon Jun 29 – Sun Jul 5 holds
+        //     both the rule's 1st Thursday (Jul 2) and the completed Fri (Jul 3).
+        var julyWeekStart = new DateTime(2026, 6, 29, 0, 0, 0, DateTimeKind.Utc);
+        var julyResult = await service.GetTasksForWeek(new CalendarTaskRequestModel
+        {
+            PropertyId = property.Id,
+            WeekStart = IsoUtc(julyWeekStart),
+            WeekEnd = IsoUtc(julyWeekStart.AddDays(6).AddHours(23).AddMinutes(59)),
+            ActionableOnly = false,
+            BoardIds = [], TagNames = [], SiteIds = []
+        });
+
+        Assert.That(julyResult.Success, Is.True, julyResult.Message);
+        Assert.That(julyResult.Model, Is.Not.Null);
+
+        var thursdayTiles = julyResult.Model!.Where(t => t.TaskDate == Key(new DateTime(2026, 7, 2))).ToList();
+        var fridayTiles = julyResult.Model!.Where(t => t.TaskDate == Key(completedFriday)).ToList();
+
+        Assert.Multiple(() =>
+        {
+            // The phantom: re-anchored Thursday in the completed month must NOT render.
+            Assert.That(thursdayTiles, Is.Empty,
+                "No phantom not-completed Thursday sibling in a completed month");
+            // The real completed occurrence renders exactly once via the compliance loop.
+            Assert.That(fridayTiles, Has.Count.EqualTo(1),
+                "Completed Friday renders exactly once");
+            Assert.That(fridayTiles[0].Completed, Is.True, "Friday must show completed");
+            Assert.That(fridayTiles[0].IsFromCompliance, Is.True, "Friday must be the compliance row");
+        });
+
+        // --- Future month (August 2026): no completed occurrence → the rule's
+        //     1st Thursday (Aug 6) renders normally as a not-completed tile.
+        var augWeekStart = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc);
+        var augResult = await service.GetTasksForWeek(new CalendarTaskRequestModel
+        {
+            PropertyId = property.Id,
+            WeekStart = IsoUtc(augWeekStart),
+            WeekEnd = IsoUtc(augWeekStart.AddDays(6).AddHours(23).AddMinutes(59)),
+            ActionableOnly = false,
+            BoardIds = [], TagNames = [], SiteIds = []
+        });
+
+        Assert.That(augResult.Success, Is.True, augResult.Message);
+        var augThursday = augResult.Model!.Where(t => t.TaskDate == Key(new DateTime(2026, 8, 6))).ToList();
+        Assert.Multiple(() =>
+        {
+            Assert.That(augThursday, Has.Count.EqualTo(1),
+                "Future month with no completed occurrence renders the rule's 1st Thursday");
+            Assert.That(augThursday[0].Completed, Is.False, "Future Thursday is not completed");
+        });
+    }
+
+    [Test]
+    public async Task UpdateTask_ScopeAll_DateChange_RelocatesNonCompleted_FreezesCompleted()
+    {
+        var core = await GetCore();
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        var sdkSite = new Site
+        {
+            Name = "all-repattern-test-site", MicrotingUid = 6565,
+            LanguageId = language.Id, WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(sdkSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        // Two backing cases: one NOT completed (relocatable), one completed (frozen).
+        var caseNotDone = new Microting.eForm.Infrastructure.Data.Entities.Case
+        { SiteId = sdkSite.Id, Status = 66, WorkflowState = Constants.WorkflowStates.Created };
+        var caseDone = new Microting.eForm.Infrastructure.Data.Entities.Case
+        { SiteId = sdkSite.Id, Status = 100, WorkflowState = Constants.WorkflowStates.Created };
+        await MicrotingDbContext.Cases.AddRangeAsync(caseNotDone, caseDone);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"AllRepatternTest-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id, EformId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // Monthly Nth-weekday series currently on the 1st FRIDAY (DayOfWeek=5).
+        var startDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Month, StartDate = startDate,
+            RelatedEFormId = 0, WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
+            ItemPlanningId = planning.Id, StartDate = startDate, Status = true,
+            RepeatType = 3, RepeatEvery = 1, RepeatOrdinalWeek = 1, DayOfWeek = 5, // 1st Friday (old)
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // Deployed-but-NOT-completed past occurrence: 1st Friday of May 2026 = May 1.
+        var mayFriday = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        var notDone = new Compliance
+        {
+            PlanningId = planning.Id, PropertyId = property.Id, AreaId = area.Id,
+            Deadline = mayFriday, StartDate = mayFriday.AddDays(-30),
+            MicrotingSdkCaseId = caseNotDone.Id, MicrotingSdkeFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        // Completed (frozen) occurrence: 1st Friday of July 2026 = Jul 3.
+        var julyFriday = new DateTime(2026, 7, 3, 0, 0, 0, DateTimeKind.Utc);
+        var done = new Compliance
+        {
+            PlanningId = planning.Id, PropertyId = property.Id, AreaId = area.Id,
+            Deadline = julyFriday, StartDate = julyFriday.AddDays(-30),
+            MicrotingSdkCaseId = caseDone.Id, MicrotingSdkeFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await BackendConfigurationPnDbContext.Compliances.AddRangeAsync(notDone, done);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        var notDoneId = notDone.Id;
+        var doneId = done.Id;
+
+        var service = BuildService(core);
+
+        // scope=all, change the 1st Friday → 1st Thursday going forward. Click a
+        // future occurrence (Sep 4, old Friday) and move it to Sep 3 (new Thursday).
+        var result = await service.UpdateTask(new CalendarTaskUpdateRequestModel
+        {
+            Id = arp.Id,
+            Scope = "all",
+            OriginalDate = "2026-09-04T00:00:00Z",
+            StartDate = new DateTime(2026, 9, 3, 0, 0, 0, DateTimeKind.Utc), // 1st Thursday of Sep
+            StartHour = 9.0,
+            Duration = 1.0,
+            Status = 1,
+            RepeatType = 3,
+            RepeatEvery = 1,
+            RepeatOrdinalWeek = 1,
+            ComplianceEnabled = false,
+            PropertyId = property.Id,
+            EformId = 0,
+            Sites = [(int)sdkSite.Id],
+            TagIds = [],
+            Translates = []
+        });
+
+        Assert.That(result.Success, Is.True, result.Message);
+
+        var reloadedNotDone = await BackendConfigurationPnDbContext.Compliances.AsNoTracking()
+            .FirstAsync(c => c.Id == notDoneId);
+        var reloadedDone = await BackendConfigurationPnDbContext.Compliances.AsNoTracking()
+            .FirstAsync(c => c.Id == doneId);
+
+        Assert.Multiple(() =>
+        {
+            // Deployed-not-completed past Friday moves to the new pattern's 1st
+            // Thursday of the SAME month (May 7), preserving its period.
+            Assert.That(reloadedNotDone.Deadline.Date, Is.EqualTo(new DateTime(2026, 5, 7)),
+                "Non-completed past occurrence relocates to 1st Thursday of May");
+            // Completed occurrence is frozen — Deadline must never change (R2).
+            Assert.That(reloadedDone.Deadline.Date, Is.EqualTo(julyFriday.Date),
+                "Completed occurrence stays on its original date");
+        });
+    }
+
+    private BackendConfigurationCalendarService BuildService(eFormCore.Core core)
+    {
+        var language = MicrotingDbContext!.Languages.First();
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        userService.GetCurrentUserLanguage().Returns(Task.FromResult(language));
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+        var taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        taskWizardService.DeleteTask(Arg.Any<int>()).Returns(Task.FromResult(new OperationResult(true)));
+        taskWizardService.UpdateTask(Arg.Any<TaskWizardCreateModel>())
+            .Returns(Task.FromResult(new OperationResult(true)));
+
+        return new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(), userService,
+            BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext!, taskWizardService,
+            NullLogger<BackendConfigurationCalendarService>.Instance);
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -324,6 +324,71 @@ public class BackendConfigurationCalendarService(
                 .Where(x => planningIds.Contains(x.Id))
                 .ToDictionaryAsync(x => x.Id);
 
+            // --- Period-level completed suppression (#960) ---
+            // A completed occurrence (backing SDK Case Status==100) freezes its
+            // WHOLE recurrence period. When a rule is re-anchored (e.g. the
+            // weekday changes under a "thisAndFollowing"/"all" edit) the emit
+            // loop would otherwise sprout a phantom not-completed sibling in a
+            // period that is already completed. We suppress those here.
+            //
+            // Crucially this looks BEYOND the rendered week: a re-anchored
+            // sibling can land in a different week of the SAME month/year than
+            // the completed occurrence, so we scan completed compliances across
+            // the year(s) the rendered week touches and bucket them by period
+            // (CompletedPeriodKey decides month/ISO-week/year granularity and
+            // returns null for multi-day-weekly/daily — those are covered
+            // exactly by the per-(planning,date) complianceDateSet instead).
+            var completedPeriodSet = new HashSet<string>();
+            {
+                // Full calendar year(s) the rendered week touches, widened by a
+                // week on each side so a weekly period whose ISO week straddles a
+                // Dec/Jan boundary is still fully covered regardless of how the
+                // caller aligns its 7-day window (month/year periods are already
+                // within the year span).
+                var periodWindowStart = new DateTime(weekStart.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(-7);
+                var periodWindowEnd = new DateTime(weekEnd.Year, 12, 31, 23, 59, 59, DateTimeKind.Utc).AddDays(7);
+                // NOTE: deliberately NO WorkflowState filter — the canonical
+                // completion path sets the backing Case to Status=100 AND
+                // soft-deletes the Compliance row (see removedCompletedInWeek
+                // above). Excluding Removed rows would miss the most common
+                // completed shape and let a phantom sibling slip through.
+                var periodCompliances = await backendConfigurationPnDbContext.Compliances
+                    .Where(x => x.PropertyId == requestModel.PropertyId)
+                    .Where(x => x.MicrotingSdkCaseId > 0)
+                    .Where(x => planningIds.Contains(x.PlanningId))
+                    .Where(x => x.Deadline >= periodWindowStart && x.Deadline <= periodWindowEnd)
+                    .Select(x => new { x.PlanningId, x.Deadline, x.MicrotingSdkCaseId })
+                    .ToListAsync();
+                var periodCaseIds = periodCompliances.Select(x => x.MicrotingSdkCaseId).Distinct().ToList();
+                if (periodCaseIds.Count > 0)
+                {
+                    var sdkCoreForPeriods = await coreHelper.GetCore().ConfigureAwait(false);
+                    await using var sdkDbContextForPeriods = sdkCoreForPeriods.DbContextHelper.GetDbContext();
+                    var completedCaseIds = (await sdkDbContextForPeriods.Cases
+                        .Where(c => periodCaseIds.Contains(c.Id) && c.Status == 100)
+                        .Select(c => c.Id)
+                        .ToListAsync()).ToHashSet();
+
+                    // Per-planning RepeatType + weekday CSV drive the period
+                    // granularity; use the same planning the emit loop uses.
+                    var repeatInfoByPlanningId = areaRulePlannings
+                        .Where(a => planningsDict.ContainsKey(a.ItemPlanningId))
+                        .GroupBy(a => a.ItemPlanningId)
+                        .ToDictionary(
+                            g => g.Key,
+                            g => (RepeatType: planningsDict[g.Key].RepeatType,
+                                  Csv: g.First().RepeatWeekdaysCsv));
+
+                    foreach (var c in periodCompliances)
+                    {
+                        if (!completedCaseIds.Contains(c.MicrotingSdkCaseId)) continue;
+                        if (!repeatInfoByPlanningId.TryGetValue(c.PlanningId, out var info)) continue;
+                        var key = CompletedPeriodKey(info.RepeatType, info.Csv, c.Deadline);
+                        if (key != null) completedPeriodSet.Add($"{c.PlanningId}:{key}");
+                    }
+                }
+            }
+
             // Batch-load calendar configurations
             var arpIds = areaRulePlannings.Select(x => x.Id).ToList();
             var calConfigsDict = await backendConfigurationPnDbContext.CalendarConfigurations
@@ -448,6 +513,16 @@ public class BackendConfigurationCalendarService(
                     if (complianceDateSet.Contains($"{arp.ItemPlanningId}:{occurrenceDate.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}"))
                         continue;
 
+                    // Completed occurrences freeze their whole recurrence period:
+                    // skip a re-anchored rule occurrence whose period already
+                    // contains a completed occurrence (rendered by the compliance
+                    // loop on its real date). Kills the "all"/"thisAndFollowing"
+                    // phantom sibling and hardens completed-immutability (#960).
+                    var completedPeriodKey = CompletedPeriodKey(planning.RepeatType, arp.RepeatWeekdaysCsv, occurrenceDate);
+                    if (completedPeriodKey != null
+                        && completedPeriodSet.Contains($"{arp.ItemPlanningId}:{completedPeriodKey}"))
+                        continue;
+
                     CalendarOccurrenceException exception = null;
                     if (exceptionsByArp.TryGetValue(arp.Id, out var arpExceptions))
                     {
@@ -548,6 +623,14 @@ public class BackendConfigurationCalendarService(
                         // sibling tiles (#928). Let the compliance loop own it.
                         if (complianceDateSet.Contains(
                                 $"{planning.Id}:{orphan.OriginalDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}"))
+                            continue;
+
+                        // Completed-period backstop (#960 R2): never render an
+                        // orphan anchor inside a period that already holds a
+                        // completed occurrence — the compliance loop owns it.
+                        var orphanPeriodKey = CompletedPeriodKey(planning.RepeatType, arp.RepeatWeekdaysCsv, orphan.OriginalDate);
+                        if (orphanPeriodKey != null
+                            && completedPeriodSet.Contains($"{arp.ItemPlanningId}:{orphanPeriodKey}"))
                             continue;
 
                         var orphanStartHour = orphan.StartHour ?? (isAllDay ? 0 : calConfig?.StartHour ?? 9.0);
@@ -1093,12 +1176,17 @@ public class BackendConfigurationCalendarService(
             // genuine date change, or a one-off (whose anchor == its own date),
             // still flows through to relocate as before.
             var wizardStartDate = updateModel.StartDate;
+            // Whether this "all" edit actually moves the occurrence date (and so
+            // potentially re-patterns the rule). A pure time/field edit keeps the
+            // anchor and must not relocate any past Compliance rows (#960).
+            var dateChanged = true;
             if (!string.IsNullOrEmpty(updateModel.OriginalDate))
             {
                 var parsedOriginalDate = DateTime.Parse(updateModel.OriginalDate, CultureInfo.InvariantCulture,
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal).Date;
                 if (updateModel.StartDate.Date == parsedOriginalDate)
                 {
+                    dateChanged = false;
                     var currentStartDate = await backendConfigurationPnDbContext.AreaRulePlannings
                         .Where(x => x.Id == updateModel.Id)
                         .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
@@ -1173,6 +1261,17 @@ public class BackendConfigurationCalendarService(
                     planning.Description = updateModel.DescriptionHtml ?? string.Empty;
                     planning.UpdatedByUserId = userService.UserId;
                     await planning.Update(itemsPlanningPnDbContext);
+
+                    // #960 — "all" re-patterns non-completed occurrences. The rule
+                    // re-anchor above handles future + never-deployed dates; already
+                    // deployed-but-NOT-completed Compliance rows keep their old
+                    // Deadline, so move each to the new-pattern date within its own
+                    // recurrence period. COMPLETED rows (SDK Case Status==100) are
+                    // frozen and never touched (R2 immutability).
+                    if (dateChanged)
+                    {
+                        await RelocateNonCompletedComplianceRowsToNewPattern(arp, planning);
+                    }
                 }
             }
 
@@ -1687,6 +1786,92 @@ public class BackendConfigurationCalendarService(
             .Where(c => c.Id == compliance.MicrotingSdkCaseId)
             .FirstOrDefaultAsync();
         return sdkCase?.Status == 100;
+    }
+
+    // #960 — under an "all" date/pattern edit, deployed-but-NOT-completed
+    // occurrences must adopt the new pattern too. The rule re-anchor handles
+    // future + never-deployed dates, but already-deployed Compliance rows keep
+    // their old Deadline, so move each non-completed one to the new-pattern
+    // date within its OWN recurrence period. COMPLETED rows (backing SDK Case
+    // Status==100) are frozen and never touched — the hard immutability
+    // invariant (R2). Rows already on the new-pattern date are left as-is.
+    private async Task RelocateNonCompletedComplianceRowsToNewPattern(
+        AreaRulePlanning arp,
+        Microting.ItemsPlanningBase.Infrastructure.Data.Entities.Planning planning)
+    {
+        var rows = await backendConfigurationPnDbContext.Compliances
+            .Where(c => c.PlanningId == arp.ItemPlanningId)
+            .Where(c => c.MicrotingSdkCaseId > 0)
+            .Where(c => c.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        if (rows.Count == 0) return;
+
+        var caseIds = rows.Select(c => c.MicrotingSdkCaseId).Distinct().ToList();
+        var sdkCore = await coreHelper.GetCore().ConfigureAwait(false);
+        await using var sdkDbContext = sdkCore.DbContextHelper.GetDbContext();
+        var completedCaseIds = (await sdkDbContext.Cases
+            .Where(c => caseIds.Contains(c.Id) && c.Status == 100)
+            .Select(c => c.Id)
+            .ToListAsync()).ToHashSet();
+
+        foreach (var row in rows)
+        {
+            // Completed occurrences are immutable — never relocate (R2).
+            if (completedCaseIds.Contains(row.MicrotingSdkCaseId)) continue;
+            var newDate = NewPatternDateForPeriodOf(planning, arp, row.Deadline);
+            if (newDate == null) continue;                          // kind has no single per-period anchor
+            if (newDate.Value.Date == row.Deadline.Date) continue;  // already aligned — no-op
+            row.Deadline = newDate.Value.Date;
+            row.UpdatedByUserId = userService.UserId;
+            await row.Update(backendConfigurationPnDbContext);
+        }
+    }
+
+    // The new-pattern occurrence date in the SAME recurrence period as
+    // `oldDeadline`, using the rule's CURRENT (post-edit) pattern. Returns null
+    // for kinds with no single per-period anchor (daily / multi-day weekly) or
+    // when an Nth-weekday ordinal spills past the month. Reuses
+    // NthWeekdayOfMonth so it can never drift from the recurrence enumerators.
+    private static DateTime? NewPatternDateForPeriodOf(
+        Microting.ItemsPlanningBase.Infrastructure.Data.Entities.Planning planning,
+        AreaRulePlanning arp,
+        DateTime oldDeadline)
+    {
+        switch ((int)planning.RepeatType)
+        {
+            case 2: // Week — only single-weekday rules have one occurrence per week.
+            {
+                if (ParseWeekdaysCsv(arp.RepeatWeekdaysCsv).Length > 1) return null;
+                // DayOfWeek is stored .NET/JS-style (Sun=0..Sat=6).
+                int targetDow = arp.DayOfWeek;
+                // Monday-aligned week containing oldDeadline, projected onto targetDow.
+                var monday = oldDeadline.Date.AddDays(-(((int)oldDeadline.DayOfWeek + 6) % 7));
+                return monday.AddDays((targetDow + 6) % 7);
+            }
+            case 3: // Month
+            {
+                if (arp.RepeatOrdinalWeek.HasValue)
+                {
+                    return NthWeekdayOfMonth(oldDeadline.Year, oldDeadline.Month,
+                        arp.RepeatOrdinalWeek.Value, arp.DayOfWeek);
+                }
+                // Legacy day-of-month: clamp to the month length.
+                var dom = arp.DayOfMonth > 0 ? arp.DayOfMonth : (planning.DayOfMonth ?? oldDeadline.Day);
+                var daysInMonth = DateTime.DaysInMonth(oldDeadline.Year, oldDeadline.Month);
+                return new DateTime(oldDeadline.Year, oldDeadline.Month,
+                    Math.Min(dom, daysInMonth), 0, 0, 0, DateTimeKind.Utc);
+            }
+            case 4: // Year — fixed month + day-of-month from the new pattern, same year.
+            {
+                var month = planning.StartDate.Month;
+                var dom = arp.DayOfMonth > 0 ? arp.DayOfMonth : (planning.DayOfMonth ?? oldDeadline.Day);
+                var daysInMonth = DateTime.DaysInMonth(oldDeadline.Year, month);
+                return new DateTime(oldDeadline.Year, month,
+                    Math.Min(dom, daysInMonth), 0, 0, 0, DateTimeKind.Utc);
+            }
+            default:
+                return null; // Day / None — no single per-period anchor to relocate.
+        }
     }
 
     public async Task<OperationResult> MoveTask(CalendarTaskMoveRequestModel moveModel)
@@ -2709,6 +2894,63 @@ public class BackendConfigurationCalendarService(
     // de-duplicated array of JS-style weekday ints (0=Sun..6=Sat). Returns
     // an empty array on null/empty/all-invalid input — callers treat empty
     // as "no multi-day expansion, fall back to single-day weekly behavior".
+    /// <summary>
+    /// Period bucket key used for completed-occurrence suppression (#960).
+    /// A completed occurrence freezes its whole recurrence period so a
+    /// re-anchored rule cannot render a phantom not-completed sibling there.
+    ///
+    /// Returns null when period-level suppression must NOT apply, i.e. when the
+    /// rule has more than one occurrence per period and the per-(planning,date)
+    /// complianceDateSet already handles suppression exactly:
+    ///   * Day / every-N-day — one occurrence per day == the date key itself.
+    ///   * multi-day weekly (CSV has 2+ weekdays) — independent per-day
+    ///     occurrences; bucketing by week would wrongly hide live siblings.
+    ///
+    /// Granularity for single-occurrence-per-period kinds:
+    ///   * single-weekday weekly → Monday-aligned ISO week (matches the
+    ///     Monday-aligned stride bucketing in GetOccurrencesInWeek's multi-day
+    ///     branch).
+    ///   * monthly → year+month.
+    ///   * yearly (RepeatType cast 4) → year.
+    /// </summary>
+    private static string? CompletedPeriodKey(
+        Microting.ItemsPlanningBase.Infrastructure.Enums.RepeatType repeatType,
+        string? repeatWeekdaysCsv,
+        DateTime date)
+    {
+        switch ((int)repeatType)
+        {
+            case 2: // Week
+                if (ParseWeekdaysCsv(repeatWeekdaysCsv).Length > 1) return null;
+                // Monday of the date's week (ISO Mon=0..Sun=6).
+                var monday = date.Date.AddDays(-(((int)date.DayOfWeek + 6) % 7));
+                return "W:" + monday.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            case 3: // Month
+                return $"M:{date.Year:D4}-{date.Month:D2}";
+            case 4: // Year (enum has no member; cast used throughout this file)
+                return $"Y:{date.Year:D4}";
+            default: // Day / None — covered exactly by the per-date dedup set.
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// The Nth-weekday-of-month date (e.g. "2nd Tuesday of March 2026"), or
+    /// null when the ordinal spills past the month (e.g. a 5th occurrence in a
+    /// month with only four). Single source of truth shared by the recurrence
+    /// enumerators (GetOccurrencesInWeek / EnumerateOccurrences) and the "all"
+    /// re-pattern relocation (#960) so the two never drift.
+    /// </summary>
+    /// <param name="ordinal">1..5 (1 = first).</param>
+    /// <param name="targetDow">Target day-of-week, 0=Sun..6=Sat.</param>
+    private static DateTime? NthWeekdayOfMonth(int year, int month, int ordinal, int targetDow)
+    {
+        var firstOfMonth = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc);
+        int dowOffset = (targetDow - (int)firstOfMonth.DayOfWeek + 7) % 7;
+        var candidate = firstOfMonth.AddDays(dowOffset + (ordinal - 1) * 7);
+        return candidate.Month != month ? null : candidate;
+    }
+
     private static int[] ParseWeekdaysCsv(string? csv)
     {
         if (string.IsNullOrWhiteSpace(csv)) return [];
@@ -2830,18 +3072,16 @@ public class BackendConfigurationCalendarService(
                     int targetDow = dayOfWeekOverride ?? (int)startDate.DayOfWeek; // 0=Sun..6=Sat
                     while (true)
                     {
-                        var firstOfMonth = new DateTime(candidateMonth.Year, candidateMonth.Month, 1, 0, 0, 0, DateTimeKind.Utc);
-                        int dowOffset = (targetDow - (int)firstOfMonth.DayOfWeek + 7) % 7;
-                        var candidate = firstOfMonth.AddDays(dowOffset + (ordinal - 1) * 7);
+                        var candidate = NthWeekdayOfMonth(candidateMonth.Year, candidateMonth.Month, ordinal, targetDow);
                         // If ordinal spills into the next month (e.g. 5th occurrence
                         // in a month that only has 4), skip this month.
-                        if (candidate.Month != candidateMonth.Month)
+                        if (candidate == null)
                         {
                             candidateMonth = candidateMonth.AddMonths(repeatEvery);
                             continue;
                         }
-                        if (candidate >= rangeEnd) break;
-                        if (candidate >= rangeStart) yield return candidate;
+                        if (candidate.Value >= rangeEnd) break;
+                        if (candidate.Value >= rangeStart) yield return candidate.Value;
                         candidateMonth = candidateMonth.AddMonths(repeatEvery);
                     }
                 }
@@ -2973,18 +3213,16 @@ public class BackendConfigurationCalendarService(
                     int targetDow = dayOfWeekOverride ?? (int)startDate.DayOfWeek; // 0=Sun..6=Sat
                     for (var i = 0; i < 3; i++)
                     {
-                        var firstOfMonth = new DateTime(candidateMonth.Year, candidateMonth.Month, 1, 0, 0, 0, DateTimeKind.Utc);
-                        int dowOffset = (targetDow - (int)firstOfMonth.DayOfWeek + 7) % 7;
-                        var candidate = firstOfMonth.AddDays(dowOffset + (ordinal - 1) * 7);
+                        var candidate = NthWeekdayOfMonth(candidateMonth.Year, candidateMonth.Month, ordinal, targetDow);
                         // Skip months where the ordinal spills into the next month.
-                        if (candidate.Month != candidateMonth.Month)
+                        if (candidate == null)
                         {
                             candidateMonth = candidateMonth.AddMonths(repeatEvery);
                             continue;
                         }
-                        if (candidate > weekEnd) break;
-                        if (candidate >= weekStart)
-                            occurrences.Add(candidate);
+                        if (candidate.Value > weekEnd) break;
+                        if (candidate.Value >= weekStart)
+                            occurrences.Add(candidate.Value);
                         candidateMonth = candidateMonth.AddMonths(repeatEvery);
                     }
                 }

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/calendar-ui-enhancements.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/calendar-ui-enhancements.page.ts
@@ -1071,4 +1071,44 @@ export class CalendarUiEnhancementsPage {
       `(expected < 2px — sticky regressed).`
     ).toBeLessThan(2);
   }
+
+  /**
+   * The currently displayed label of the "Gentag" (Repeat) select in the
+   * create/edit modal (`id="calendarEventRepeat"`). Reads the ng-select's
+   * selected-value label. Used to assert the label tracks the date (#960).
+   */
+  async getRepeatSelectLabel(): Promise<string> {
+    const label = this.page.locator('#calendarEventRepeat .ng-value-label').first();
+    await label.waitFor({ state: 'visible', timeout: 5000 });
+    return ((await label.textContent()) ?? '').trim();
+  }
+
+  /**
+   * Open the event date-picker and move the selected date by one day (prefers
+   * +1 day; falls back to -1 at month end) so the weekday changes. Returns the
+   * day numbers clicked from/to. Used to drive the #960 re-anchor assertion:
+   * for a single-anchor rule the "Gentag" label must follow the new weekday.
+   */
+  async shiftEventDateByOneDay(): Promise<void> {
+    await this.openEventDatePicker();
+    const grid = this.getMiniPickerOverlay();
+    const selected = grid.locator('.day-cell.selected').first();
+    const selText = ((await selected.textContent()) ?? '').trim();
+    const n = parseInt(selText, 10);
+
+    for (const day of [n + 1, n - 1]) {
+      if (day < 1) continue;
+      const cell = grid
+        .locator('.day-cell:not(.other-month):not(.disabled)')
+        .filter({ hasText: new RegExp(`^${day}$`) })
+        .first();
+      if (await cell.count()) {
+        await cell.click();
+        break;
+      }
+    }
+    // onMiniDateSelected closes the overlay; wait for it to detach.
+    await this.getMiniPickerOverlay().waitFor({ state: 'hidden', timeout: 5000 });
+    await this.page.waitForTimeout(300);
+  }
 }

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/p/calendar-edit-scope.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/p/calendar-edit-scope.spec.ts
@@ -338,4 +338,64 @@ test.describe.serial('Calendar edit scope', () => {
     expect(await calendarPage.getEventTitleText(baseTitle)).toContain(baseTitle);
     await expect(calendarPage.findEventBlock(overrideTitle)).toHaveCount(0);
   });
+
+  // #960 — editing the DATE of a monthly Nth-weekday series must re-derive the
+  // "Gentag" (Repeat) label to follow the new weekday. Pre-fix the label stayed
+  // pinned to the loaded rule meta (e.g. "1st Friday") even after moving the
+  // date to a different weekday, silently persisting the stale pattern on save.
+  test('edit date re-anchors monthly "Gentag" label to the new weekday (#960)', async ({ page }) => {
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    const title = `S5-${generateRandmString(5)}`;
+
+    // Create a MONTHLY (Nth-weekday) event on Friday of week +1 at 09:00.
+    await calendarPage.openCreateModalAtSlot(4, 9);
+    await page.locator('#calendarEventTitle').fill(title);
+
+    const eform = page.locator('#calendarEventEform');
+    await eform.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+
+    const planningTag = page.locator('#calendarEventPlanningTag');
+    await planningTag.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+
+    const assignee = page.locator('#calendarEventAssignee');
+    await assignee.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.locator('#calendarEventTitle').click();
+    await page.waitForTimeout(300);
+
+    // Monthly on the Nth weekday (index 3 in the repeat dropdown = 'monthlyByDay').
+    await calendarPage.selectRepeatPreset('monthlyByDay');
+
+    const createResp = page.waitForResponse(
+      r => r.url().includes('/api/backend-configuration-pn/calendar/tasks')
+        && !r.url().includes('/tasks/week')
+        && r.request().method() === 'POST',
+      { timeout: 30000 }
+    );
+    await page.locator('#calendarEventSaveBtn').click();
+    await createResp;
+    await page.waitForTimeout(1500);
+    await calendarPage.findEventBlock(title).waitFor({ state: 'visible', timeout: 10000 });
+
+    // Reopen the series in edit mode → the repeat select reconstructs the
+    // synthesized "customCurrent" monthly-Nth-weekday option, whose label is
+    // derived from the loaded rule meta (the Friday weekday).
+    await calendarPage.openEditModal(title);
+    const before = await calendarPage.getRepeatSelectLabel();
+    expect(before.length).toBeGreaterThan(0);
+
+    // Move the date by one day → the weekday changes. The re-anchor fix must
+    // update the "Gentag" label to the new weekday; pre-fix it stayed pinned.
+    await calendarPage.shiftEventDateByOneDay();
+    const after = await calendarPage.getRepeatSelectLabel();
+
+    expect(after).not.toEqual(before);
+  });
 });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -418,9 +418,16 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       this.isLoadingTemplate = false;
     });
 
-    // When date changes, rebuild repeat options and regenerate time slots
+    // When date changes, rebuild repeat options and regenerate time slots.
+    // Re-anchor the custom rule to the new date first so single-anchor kinds
+    // (e.g. "monthly on the 1st Friday") follow the new weekday/day-of-month
+    // instead of keeping the stale anchor — the "Gentag" label must track the
+    // date (#960). Multi-anchor/anchorless kinds are returned unchanged.
     this.dateControl.valueChanges.subscribe(date => {
       if (date) {
+        if (this.customRepeatMeta) {
+          this.customRepeatMeta = this.repeatService.reanchorMetaToDate(this.customRepeatMeta, date);
+        }
         this.repeatOptions = this.repeatService.buildRepeatSelectOptions(date, this.customRepeatMeta);
         this.timeSlots = this.generateTimeSlots();
       }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
@@ -1069,4 +1069,125 @@ describe('CalendarRepeatService', () => {
       expect(reconstructed?.weekday).toBe(2);
     });
   });
+
+  // ─── reanchorMetaToDate ────────────────────────────────────────────────────
+  // When the edit-modal date changes, the "Gentag" rule must follow the new
+  // date for single-anchor kinds (the start date IS the anchor). #960.
+
+  describe('reanchorMetaToDate', () => {
+    // JS getDay(): Sun=0, Mon=1, ... Thu=4, Fri=5.
+    const THU = new Date(2026, 6, 2);  // 1st Thursday of July 2026 (getDate=2)
+
+    it('monthlyByDay: 1st Friday → 1st Thursday (the exact reported case)', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyByDay', ordinalWeek: 1, weekday: 5, endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, THU);
+      expect(out.kind).toBe('monthlyByDay');
+      expect(out.weekday).toBe(4);
+      expect(out.ordinalWeek).toBe(1);
+    });
+
+    it('monthlyByDay: a 3rd-week date yields ordinalWeek 3', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyByDay', ordinalWeek: 1, weekday: 5, endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, new Date(2026, 6, 15));  // 15th
+      expect(out.ordinalWeek).toBe(3);
+      expect(out.weekday).toBe(new Date(2026, 6, 15).getDay());
+    });
+
+    it('monthlyByDay: the 29th yields ordinalWeek 5 (boundary)', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyByDay', ordinalWeek: 1, weekday: 5, endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, new Date(2026, 6, 29));  // 29th
+      expect(out.ordinalWeek).toBe(5);
+    });
+
+    it('everyNMonthByDay: re-anchors while preserving interval n', () => {
+      const meta: CalendarRepeatMeta = {kind: 'everyNMonthByDay', n: 3, ordinalWeek: 1, weekday: 5, endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, THU);
+      expect(out.kind).toBe('everyNMonthByDay');
+      expect(out.n).toBe(3);
+      expect(out.weekday).toBe(4);
+      expect(out.ordinalWeek).toBe(1);
+    });
+
+    it('weeklyOne: Friday → Thursday', () => {
+      const meta: CalendarRepeatMeta = {kind: 'weeklyOne', weekday: 5, endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, THU);
+      expect(out.kind).toBe('weeklyOne');
+      expect(out.weekday).toBe(4);
+    });
+
+    it('everyNWeekOne: re-anchors weekday, preserving n', () => {
+      const meta: CalendarRepeatMeta = {kind: 'everyNWeekOne', n: 2, weekday: 5, endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, THU);
+      expect(out.weekday).toBe(4);
+      expect(out.n).toBe(2);
+    });
+
+    it('monthlyDom: day 15 → day 20', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyDom', dom: 15, endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, new Date(2026, 6, 20));
+      expect(out.kind).toBe('monthlyDom');
+      expect(out.dom).toBe(20);
+    });
+
+    it('everyNMonthDom: re-anchors dom, preserving n', () => {
+      const meta: CalendarRepeatMeta = {kind: 'everyNMonthDom', n: 2, dom: 15, endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, new Date(2026, 6, 20));
+      expect(out.dom).toBe(20);
+      expect(out.n).toBe(2);
+    });
+
+    it('yearlyOne: re-anchors both month and day-of-month', () => {
+      const meta: CalendarRepeatMeta = {kind: 'yearlyOne', month: 0, dom: 1, endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, THU);  // July (month 6), day 2
+      expect(out.kind).toBe('yearlyOne');
+      expect(out.month).toBe(6);
+      expect(out.dom).toBe(2);
+    });
+
+    it('everyNYear: re-anchors month+dom, preserving n', () => {
+      const meta: CalendarRepeatMeta = {kind: 'everyNYear', n: 2, month: 0, dom: 1, endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, THU);
+      expect(out.month).toBe(6);
+      expect(out.dom).toBe(2);
+      expect(out.n).toBe(2);
+    });
+
+    it('preserves endMode/afterCount/untilTs (non-anchor fields)', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyByDay', ordinalWeek: 1, weekday: 5, endMode: 'after', afterCount: 7};
+      const out = service.reanchorMetaToDate(meta, THU);
+      expect(out.endMode).toBe('after');
+      expect(out.afterCount).toBe(7);
+    });
+
+    it('multi-weekday weekly sets are returned unchanged (no single anchor)', () => {
+      const meta: CalendarRepeatMeta = {kind: 'weeklyMulti', weekdays: [1, 3, 5], endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, THU);
+      expect(out).toEqual(meta);
+    });
+
+    it('daily / everyNd / alwaysRepeat-style kinds are returned unchanged', () => {
+      const daily: CalendarRepeatMeta = {kind: 'daily', endMode: 'never'};
+      expect(service.reanchorMetaToDate(daily, THU)).toEqual(daily);
+      const everyNd: CalendarRepeatMeta = {kind: 'everyNd', n: 3, endMode: 'never'};
+      expect(service.reanchorMetaToDate(everyNd, THU)).toEqual(everyNd);
+      const weeklyAll: CalendarRepeatMeta = {kind: 'weeklyAll', endMode: 'never'};
+      expect(service.reanchorMetaToDate(weeklyAll, THU)).toEqual(weeklyAll);
+    });
+
+    it('does not mutate the input meta', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyByDay', ordinalWeek: 1, weekday: 5, endMode: 'never'};
+      service.reanchorMetaToDate(meta, THU);
+      expect(meta.weekday).toBe(5);
+      expect(meta.ordinalWeek).toBe(1);
+    });
+
+    it('round-trip: re-anchored meta drives buildRepeatSelectOptions customCurrent', () => {
+      const meta: CalendarRepeatMeta = {kind: 'monthlyByDay', ordinalWeek: 1, weekday: 5, endMode: 'never'};
+      const out = service.reanchorMetaToDate(meta, THU);
+      const opts = service.buildRepeatSelectOptions(THU, out);
+      const current = opts.find(o => o.value === 'customCurrent');
+      expect(current?.meta?.weekday).toBe(4);
+      expect(current?.meta?.ordinalWeek).toBe(1);
+    });
+  });
 });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
@@ -779,6 +779,48 @@ export class CalendarRepeatService {
     return null;
   }
 
+  /**
+   * Re-derive a repeat rule's anchor fields from a new start date (#960).
+   *
+   * For single-anchor recurrences the start date *is* the anchor, so when the
+   * edit-modal date changes the rule must follow it: a "1st Friday" monthly
+   * rule moved to a Thursday becomes "1st Thursday", a weekly-on-Friday rule
+   * becomes weekly-on-Thursday, etc. The interval `n` and the end-mode trio
+   * (`endMode`/`afterCount`/`untilTs`) are preserved.
+   *
+   * Multi-anchor or anchorless kinds (multi-weekday weekly sets, daily,
+   * every-N-day, all-days weekly) have no single date-derived anchor and are
+   * returned unchanged. Returns a NEW object — never mutates the input.
+   */
+  reanchorMetaToDate(meta: CalendarRepeatMeta, date: Date): CalendarRepeatMeta {
+    switch (meta.kind) {
+      case 'weeklyOne':
+      case 'everyNWeekOne':
+        return {...meta, weekday: date.getDay()};
+
+      case 'monthlyByDay':
+      case 'everyNMonthByDay':
+        return {
+          ...meta,
+          weekday: date.getDay(),
+          ordinalWeek: Math.ceil(date.getDate() / 7),
+        };
+
+      case 'monthlyDom':
+      case 'everyNMonthDom':
+        return {...meta, dom: date.getDate()};
+
+      case 'yearlyOne':
+      case 'everyNYear':
+        return {...meta, month: date.getMonth(), dom: date.getDate()};
+
+      default:
+        // daily / everyNd / weeklyMulti / weeklyAll / everyNWeek{Multi,All}:
+        // no single date-derived anchor — leave untouched.
+        return meta;
+    }
+  }
+
   /** Convert a custom repeat config to a CalendarRepeatMeta */
   buildMetaFromCustomConfig(
     step: number,


### PR DESCRIPTION
Closes #960.

## What & why
Two related calendar fixes plus a hard immutability invariant. Design spec: `docs/superpowers/specs/2026-06-05-calendar-edit-repeat-reanchor-completed-immutability-design.md`.

### 1. FE — the reported bug (R1)
Editing a recurring task's date did not re-derive the **"Gentag"** (Repeat) label for single-anchor rules: "monthly on the 1st Friday" stayed Friday after moving the date to a Thursday, silently persisting the stale Friday pattern on save.

- New pure `CalendarRepeatService.reanchorMetaToDate(meta, date)` recomputes the anchor (weekday / ordinal-week / day-of-month / month) for single-anchor kinds, preserving interval `n` + end-mode. Multi-day weekly / daily / always-repeat are returned unchanged.
- Wired into the edit-modal `dateControl.valueChanges` handler so the label follows the date.

### 2. BE — completed-occurrence immutability (R2)
A completed occurrence (backing SDK `Case.Status==100`) now **freezes its whole recurrence period**. `GetTasksForWeek` builds a per-(planning, period) `completedPeriodSet` and skips any re-anchored rule occurrence in a completed period — in both the recurrence-emit loop and the orphan-anchor render pass — killing the phantom not-completed sibling that appeared next to a pinned completed occurrence under `all`/`thisAndFollowing`.

`CompletedPeriodKey` picks month / ISO-week (Monday-aligned, matching the existing stride bucketing) / year granularity, and returns null for daily & multi-day-weekly (those are covered exactly by the existing per-(planning, date) dedup, so a completed weekday does **not** hide its live siblings).

### 3. BE — "all" re-patterns non-completed (R4)
Under `scope=all` with a date change, deployed-but-**not**-completed past Compliance rows are relocated to the new-pattern date within their own period; **completed rows are frozen** (skipped). A shared `NthWeekdayOfMonth` helper is now used by both recurrence enumerators and the relocation so the date math can never drift.

| Scope | Completed past | Non-completed past | Clicked + future |
|---|---|---|---|
| `this` | unchanged | n/a | only clicked occurrence |
| `thisAndFollowing` | frozen | frozen (old-pattern anchors) | new pattern |
| `all` | **frozen** | **moved** to new pattern | new pattern |

**No `-base` / DB / migration changes.**

## Tests
- **FE unit** (`calendar-repeat.service.spec.ts`): 15 `reanchorMetaToDate` cases incl. the exact reported case (1st Friday → 1st Thursday), ordinal boundaries, every-N variants, non-anchor kinds unchanged, no-mutation, and a round-trip through `buildRepeatSelectOptions`.
- **BE integration** (`CalendarCompletedPeriodSuppressionTests.cs`, Testcontainers + real SDK core): completed month shows exactly one (completed) tile with no phantom sibling; future month renders the rule normally; `all`-scope date change relocates the deployed-not-completed past row to the new pattern while the completed row's `Deadline` stays frozen.
- **Playwright e2e** (`p/calendar-edit-scope.spec.ts`): editing a monthly series' date re-anchors the Gentag label to the new weekday.

Regression: existing `CalendarCompleteOccurrenceTests` (multi-day weekly — completing one day keeps the others), `CalendarUpdateTaskScopeTests`, `CalendarOccurrencesWeekTests`, `CalendarOrphanRenderComplianceTests`, `CalendarComplianceMoveTests`, `CalendarActionableOnlyTests`, `CalendarYearlyMoveTests`, `CalendarOccurrenceExceptionTests` all pass.

## Out of scope (per spec)
- Yearly Nth-weekday backfill gap (`EnumerateOccurrences` has no Year branch — #952 follow-up).
- Date-picker disabling past dates (separate UX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)