### PR TITLE
feat(calendar): monthly repeat sub-type options (Månedligt dag / Månedligt på den første)

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -43,6 +43,8 @@ export const da = {
   'Plan rule': 'Planlæg',
   'Notifications on/off': 'Notifikationer på mobil/tablet',
   'Repeat every': 'Gentagelsesfrekvens',
+  'Monthly day': 'Månedligt dag',
+  'Monthly on the first': 'Månedligt på den første',
   Day: 'Dag',
   Week: 'Uge',
   Month: 'Måned',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -43,6 +43,7 @@ export const da = {
   'Plan rule': 'Planlæg',
   'Notifications on/off': 'Notifikationer på mobil/tablet',
   'Repeat every': 'Gentagelsesfrekvens',
+  'Repeat sub-type': 'Gentagelsestype',
   'Monthly day': 'Månedligt dag',
   'Monthly on the first': 'Månedligt på den første',
   Day: 'Dag',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -42,6 +42,7 @@ export const enUS= {
   'Plan rule': 'Plan rule',
   'Notifications on/off': 'Notifications on/off',
   'Repeat every': 'Repeat every',
+  'Repeat sub-type': 'Repeat sub-type',
   'Monthly day': 'Monthly day',
   'Monthly on the first': 'Monthly on the first',
   Day: 'Day',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -42,6 +42,8 @@ export const enUS= {
   'Plan rule': 'Plan rule',
   'Notifications on/off': 'Notifications on/off',
   'Repeat every': 'Repeat every',
+  'Monthly day': 'Monthly day',
+  'Monthly on the first': 'Monthly on the first',
   Day: 'Day',
   Week: 'Week',
   Month: 'Month',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.html
@@ -23,6 +23,7 @@
 
     <!-- Monthly sub-type row (visible when unit = month) -->
     <div class="monthly-kind-row" *ngIf="unit === 'month'">
+      <span class="repeat-label">{{ 'Repeat sub-type' | translate }}</span>
       <mat-form-field class="monthly-kind-select" appearance="outline">
         <mtx-select
           [(ngModel)]="monthlyKind"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.html
@@ -10,8 +10,45 @@
       </mat-form-field>
       <mat-form-field class="unit-select" appearance="outline">
         <mtx-select
-          [(ngModel)]="unit"
+          [ngModel]="unit"
+          (ngModelChange)="onUnitChange($event)"
           [items]="unitOptions"
+          bindValue="value"
+          bindLabel="label"
+          [clearable]="false"
+          [searchable]="false"
+        ></mtx-select>
+      </mat-form-field>
+    </div>
+
+    <!-- Monthly sub-type row (visible when unit = month) -->
+    <div class="monthly-kind-row" *ngIf="unit === 'month'">
+      <mat-form-field class="monthly-kind-select" appearance="outline">
+        <mtx-select
+          [(ngModel)]="monthlyKind"
+          [items]="monthlyKindOptions"
+          bindValue="value"
+          bindLabel="label"
+          [clearable]="false"
+          [searchable]="false"
+        ></mtx-select>
+      </mat-form-field>
+      <mat-form-field class="monthly-dom-select" appearance="outline"
+                      *ngIf="monthlyKind === 'everyNMonthDom'">
+        <mtx-select
+          [(ngModel)]="monthlyDom"
+          [items]="monthlyDomOptions"
+          bindValue="value"
+          bindLabel="label"
+          [clearable]="false"
+          [searchable]="false"
+        ></mtx-select>
+      </mat-form-field>
+      <mat-form-field class="monthly-weekday-select" appearance="outline"
+                      *ngIf="monthlyKind === 'monthlyFirstWeekday'">
+        <mtx-select
+          [(ngModel)]="monthlyWeekday"
+          [items]="monthlyWeekdayOptions"
           bindValue="value"
           bindLabel="label"
           [clearable]="false"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.scss
@@ -1,4 +1,4 @@
-::host {
+:host {
   display: block;
 }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.scss
@@ -59,16 +59,24 @@
   gap: 12px;
   margin-bottom: 20px;
 
+  .repeat-label {
+    font-size: 14px;
+    color: #3c4043;
+    white-space: nowrap;
+  }
+
   .monthly-kind-select {
-    flex: 0 0 60%;
+    flex: 1;
   }
 
   .monthly-dom-select {
-    flex: 0 0 35%;
+    flex: none;
+    width: 72px;
   }
 
   .monthly-weekday-select {
-    flex: 0 0 35%;
+    flex: none;
+    width: 90px;
   }
 }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.scss
@@ -53,6 +53,25 @@
   }
 }
 
+.monthly-kind-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+
+  .monthly-kind-select {
+    flex: 0 0 60%;
+  }
+
+  .monthly-dom-select {
+    flex: 0 0 35%;
+  }
+
+  .monthly-weekday-select {
+    flex: 0 0 35%;
+  }
+}
+
 .weekday-row {
   display: flex;
   align-items: center;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.ts
@@ -126,8 +126,10 @@ export class CustomRepeatModalComponent implements OnInit {
       const circle = this.weekdays.find(w => w.value === wdVal);
       if (circle) circle.active = true;
 
-      // Seed monthly defaults from start date.
-      this.monthlyDom = Math.min(this.data.date.getDate(), 28);
+      // Default monthlyDom to 1 (the MONTH unit hard-codes day=1 per the
+      // spec — the user selects day-of-month from the picker, but the initial
+      // default is always 1, not the start-date's day).
+      this.monthlyDom = 1;
       this.monthlyWeekday = this.data.date.getDay();
     }
   }
@@ -140,7 +142,7 @@ export class CustomRepeatModalComponent implements OnInit {
     this.unit = val;
     if (val !== 'month') {
       this.monthlyKind = 'everyNMonthDom';
-      this.monthlyDom = Math.min(this.data.date.getDate(), 28);
+      this.monthlyDom = 1;
       this.monthlyWeekday = this.data.date.getDay();
     }
   }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/custom-repeat-modal/custom-repeat-modal.component.ts
@@ -31,6 +31,16 @@ export class CustomRepeatModalComponent implements OnInit {
   untilDateObj: Date | null = null;
   showMiniPicker = false;
 
+  monthlyKind: 'everyNMonthDom' | 'monthlyFirstWeekday' = 'everyNMonthDom';
+  monthlyDom = 1;
+  monthlyWeekday = 1;
+
+  readonly monthlyDomOptions: {value: number; label: string}[] =
+    Array.from({length: 28}, (_, i) => ({value: i + 1, label: String(i + 1)}));
+
+  monthlyKindOptions: {value: string; label: string}[] = [];
+  monthlyWeekdayOptions: {value: number; label: string}[] = [];
+
   unitOptions: {value: string; label: string}[] = [];
 
   weekdays: WeekdayCircle[] = [];
@@ -58,6 +68,19 @@ export class CustomRepeatModalComponent implements OnInit {
       {label: this.translate.instant('Sat').charAt(0), value: 6, active: false},
       {label: this.translate.instant('Sun').charAt(0), value: 0, active: false},
     ];
+
+    this.monthlyKindOptions = [
+      {value: 'everyNMonthDom', label: this.translate.instant('Monthly day')},
+      {value: 'monthlyFirstWeekday', label: this.translate.instant('Monthly on the first')},
+    ];
+
+    // Generate full weekday names in the current locale (Mon=1 … Sun=0, order Mon–Sun).
+    this.monthlyWeekdayOptions = [1, 2, 3, 4, 5, 6, 0].map(v => {
+      // Jan 6 2025 = Monday; offsets give Mon(1)..Sat(6) at Jan 6-11, Sun(0) at Jan 12.
+      const d = new Date(2025, 0, v === 0 ? 12 : 5 + v);
+      const name = d.toLocaleDateString(getCurrentLocale(this.translate), {weekday: 'long'});
+      return {value: v, label: name.charAt(0).toUpperCase() + name.slice(1)};
+    });
 
     // Always seed a sensible untilDate fallback (date + 3 months) so the "På"
     // branch has a value if the user toggles to it later — even when we
@@ -88,16 +111,38 @@ export class CustomRepeatModalComponent implements OnInit {
         this.untilDateObj = new Date(decomposed.untilTs);
         this.untilDate = this.untilDateObj.toISOString().split('T')[0];
       }
+      if (decomposed.monthlyKind) {
+        this.monthlyKind = decomposed.monthlyKind;
+      }
+      if (decomposed.dom != null) {
+        this.monthlyDom = decomposed.dom;
+      }
+      if (decomposed.monthlyWeekday != null) {
+        this.monthlyWeekday = decomposed.monthlyWeekday;
+      }
     } else {
       // Fresh open: pre-select the weekday matching the task date.
       const wdVal = this.data.date.getDay();
       const circle = this.weekdays.find(w => w.value === wdVal);
       if (circle) circle.active = true;
+
+      // Seed monthly defaults from start date.
+      this.monthlyDom = Math.min(this.data.date.getDate(), 28);
+      this.monthlyWeekday = this.data.date.getDay();
     }
   }
 
   toggleWeekday(circle: WeekdayCircle) {
     circle.active = !circle.active;
+  }
+
+  onUnitChange(val: 'day' | 'week' | 'month' | 'year') {
+    this.unit = val;
+    if (val !== 'month') {
+      this.monthlyKind = 'everyNMonthDom';
+      this.monthlyDom = Math.min(this.data.date.getDate(), 28);
+      this.monthlyWeekday = this.data.date.getDay();
+    }
   }
 
   get activeWeekdays(): number[] {
@@ -122,6 +167,9 @@ export class CustomRepeatModalComponent implements OnInit {
       this.endMode === 'after' ? this.afterCount : undefined,
       untilTs,
       this.data.date,
+      this.unit === 'month' ? this.monthlyKind : undefined,
+      this.unit === 'month' ? this.monthlyDom : undefined,
+      this.unit === 'month' ? this.monthlyWeekday : undefined,
     );
     this.dialogRef.close(meta);
   }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -715,6 +715,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
         'daily': 1, 'everyNd': 1,
         'weeklyOne': 2, 'weeklyMulti': 2, 'everyNWeekOne': 2, 'everyNWeekMulti': 2, 'everyNWeekAll': 2,
         'monthlyDom': 3, 'everyNMonthDom': 3, 'monthlyByDay': 3, 'everyNMonthByDay': 3,
+        'monthlyFirstWeekday': 3, 'everyNMonthFirstWeekday': 3,
         'yearlyOne': 4, 'everyNYear': 4,
       };
       resolvedRepeatType = kindMap[meta.kind] ?? 0;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
@@ -253,7 +253,7 @@ describe('CalendarRepeatService', () => {
       expect(meta.month).toBe(2);
     });
 
-    it('monthly custom stays anchored to day 1 regardless of start date (#933 scope)', () => {
+    it('no dom argument falls back to dom=1', () => {
       const date = new Date(2026, 5, 15); // 15 June 2026
       const meta = service.buildMetaFromCustomConfig(
         1, 'month', [], 'never', undefined, undefined, date,
@@ -1189,5 +1189,136 @@ describe('CalendarRepeatService', () => {
       expect(current?.meta?.weekday).toBe(4);
       expect(current?.meta?.ordinalWeek).toBe(1);
     });
+  });
+});
+
+// ── New monthly kinds + dom fix ───────────────────────────────────────────────
+
+describe('CalendarRepeatService — monthly kinds', () => {
+  let service: CalendarRepeatService;
+
+  beforeEach(() => {
+    service = new CalendarRepeatService(translateStub);
+  });
+
+  // ── buildMetaFromCustomConfig ──────────────────────────────────────────────
+
+  it('buildMeta: everyNMonthDom step=1 sets kind=monthlyDom and correct dom', () => {
+    const meta = service.buildMetaFromCustomConfig(
+      1, 'month', [], 'never', undefined, undefined, undefined,
+      'everyNMonthDom', 15, undefined,
+    );
+    expect(meta.kind).toBe('monthlyDom');
+    expect(meta.dom).toBe(15);
+  });
+
+  it('buildMeta: everyNMonthDom step=2 sets kind=everyNMonthDom and n=2', () => {
+    const meta = service.buildMetaFromCustomConfig(
+      2, 'month', [], 'never', undefined, undefined, undefined,
+      'everyNMonthDom', 28, undefined,
+    );
+    expect(meta.kind).toBe('everyNMonthDom');
+    expect(meta.n).toBe(2);
+    expect(meta.dom).toBe(28);
+  });
+
+  it('buildMeta: monthlyFirstWeekday step=1 sets kind, ordinalWeek=1, weekday', () => {
+    const meta = service.buildMetaFromCustomConfig(
+      1, 'month', [], 'never', undefined, undefined, undefined,
+      'monthlyFirstWeekday', undefined, 3,
+    );
+    expect(meta.kind).toBe('monthlyFirstWeekday');
+    expect(meta.ordinalWeek).toBe(1);
+    expect(meta.weekday).toBe(3);
+  });
+
+  it('buildMeta: monthlyFirstWeekday step=2 sets kind=everyNMonthFirstWeekday', () => {
+    const meta = service.buildMetaFromCustomConfig(
+      2, 'month', [], 'never', undefined, undefined, undefined,
+      'monthlyFirstWeekday', undefined, 5,
+    );
+    expect(meta.kind).toBe('everyNMonthFirstWeekday');
+    expect(meta.n).toBe(2);
+    expect(meta.ordinalWeek).toBe(1);
+    expect(meta.weekday).toBe(5);
+  });
+
+  it('buildMeta: monthly with no monthlyKind defaults to DOM kind', () => {
+    const meta = service.buildMetaFromCustomConfig(
+      1, 'month', [], 'never', undefined, undefined, undefined,
+      undefined, 10, undefined,
+    );
+    expect(meta.kind).toBe('monthlyDom');
+    expect(meta.dom).toBe(10);
+  });
+
+  // ── decomposeCustomMeta ───────────────────────────────────────────────────
+
+  it('decompose: monthlyDom returns monthlyKind=everyNMonthDom and dom', () => {
+    const decomposed = service.decomposeCustomMeta({
+      kind: 'monthlyDom', dom: 20, endMode: 'never',
+    });
+    expect(decomposed.unit).toBe('month');
+    expect(decomposed.step).toBe(1);
+    expect(decomposed.monthlyKind).toBe('everyNMonthDom');
+    expect(decomposed.dom).toBe(20);
+  });
+
+  it('decompose: everyNMonthDom returns correct step and dom', () => {
+    const decomposed = service.decomposeCustomMeta({
+      kind: 'everyNMonthDom', n: 3, dom: 7, endMode: 'never',
+    });
+    expect(decomposed.step).toBe(3);
+    expect(decomposed.monthlyKind).toBe('everyNMonthDom');
+    expect(decomposed.dom).toBe(7);
+  });
+
+  it('decompose: monthlyFirstWeekday returns monthlyKind and weekday', () => {
+    const decomposed = service.decomposeCustomMeta({
+      kind: 'monthlyFirstWeekday', ordinalWeek: 1, weekday: 2, endMode: 'never',
+    });
+    expect(decomposed.unit).toBe('month');
+    expect(decomposed.monthlyKind).toBe('monthlyFirstWeekday');
+    expect(decomposed.monthlyWeekday).toBe(2);
+  });
+
+  it('decompose: everyNMonthFirstWeekday returns correct step and weekday', () => {
+    const decomposed = service.decomposeCustomMeta({
+      kind: 'everyNMonthFirstWeekday', n: 2, ordinalWeek: 1, weekday: 4, endMode: 'never',
+    });
+    expect(decomposed.step).toBe(2);
+    expect(decomposed.monthlyKind).toBe('monthlyFirstWeekday');
+    expect(decomposed.monthlyWeekday).toBe(4);
+  });
+
+  // ── round-trip ────────────────────────────────────────────────────────────
+
+  it('round-trip: everyNMonthDom dom=15', () => {
+    const meta = service.buildMetaFromCustomConfig(
+      1, 'month', [], 'never', undefined, undefined, undefined,
+      'everyNMonthDom', 15, undefined,
+    );
+    const back = service.decomposeCustomMeta(meta);
+    expect(back.monthlyKind).toBe('everyNMonthDom');
+    expect(back.dom).toBe(15);
+  });
+
+  it('round-trip: monthlyFirstWeekday weekday=1 (Monday)', () => {
+    const meta = service.buildMetaFromCustomConfig(
+      1, 'month', [], 'never', undefined, undefined, undefined,
+      'monthlyFirstWeekday', undefined, 1,
+    );
+    const back = service.decomposeCustomMeta(meta);
+    expect(back.monthlyKind).toBe('monthlyFirstWeekday');
+    expect(back.monthlyWeekday).toBe(1);
+  });
+
+  it('buildMeta: monthlyFirstWeekday weekday=0 (Sunday) — nullish coalescing handles falsy zero', () => {
+    const meta = service.buildMetaFromCustomConfig(
+      1, 'month', [], 'never', undefined, undefined, undefined,
+      'monthlyFirstWeekday', undefined, 0,
+    );
+    expect(meta.kind).toBe('monthlyFirstWeekday');
+    expect(meta.weekday).toBe(0);
   });
 });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
@@ -499,10 +499,16 @@ export class CalendarRepeatService {
     endMode: 'never' | 'after' | 'until';
     afterCount?: number;
     untilTs?: number;
+    dom?: number;
+    monthlyKind?: 'everyNMonthDom' | 'monthlyFirstWeekday';
+    monthlyWeekday?: number;
   } {
     let step = 1;
     let unit: 'day' | 'week' | 'month' | 'year' = 'week';
     let weekdays: number[] = [];
+    let dom: number | undefined;
+    let monthlyKind: 'everyNMonthDom' | 'monthlyFirstWeekday' | undefined;
+    let monthlyWeekday: number | undefined;
 
     switch (meta.kind) {
       case 'daily':
@@ -536,15 +542,27 @@ export class CalendarRepeatService {
         break;
       case 'monthlyDom':
         step = 1; unit = 'month'; weekdays = [];
+        dom = meta.dom ?? 1; monthlyKind = 'everyNMonthDom';
         break;
       case 'everyNMonthDom':
         step = meta.n ?? 1; unit = 'month'; weekdays = [];
+        dom = meta.dom ?? 1; monthlyKind = 'everyNMonthDom';
         break;
       case 'monthlyByDay':
         step = 1; unit = 'month'; weekdays = [];
+        dom = meta.dom ?? 1; monthlyKind = 'everyNMonthDom';
         break;
       case 'everyNMonthByDay':
         step = meta.n ?? 1; unit = 'month'; weekdays = [];
+        dom = meta.dom ?? 1; monthlyKind = 'everyNMonthDom';
+        break;
+      case 'monthlyFirstWeekday':
+        step = 1; unit = 'month'; weekdays = [];
+        monthlyKind = 'monthlyFirstWeekday'; monthlyWeekday = meta.weekday;
+        break;
+      case 'everyNMonthFirstWeekday':
+        step = meta.n ?? 1; unit = 'month'; weekdays = [];
+        monthlyKind = 'monthlyFirstWeekday'; monthlyWeekday = meta.weekday;
         break;
       case 'yearlyOne':
         step = 1; unit = 'year'; weekdays = [];
@@ -564,6 +582,9 @@ export class CalendarRepeatService {
       endMode: meta.endMode ?? 'never',
       afterCount: meta.afterCount,
       untilTs: meta.untilTs,
+      dom,
+      monthlyKind,
+      monthlyWeekday,
     };
   }
 
@@ -658,6 +679,14 @@ export class CalendarRepeatService {
       case 'monthlyDom':
         // New path: Nth-weekday-of-month rule — takes priority over legacy dayOfMonth.
         if (task.repeatOrdinalWeek != null && task.dayOfWeek != null) {
+          if (task.repeatOrdinalWeek === 1) {
+            return {
+              kind: n === 1 ? 'monthlyFirstWeekday' : 'everyNMonthFirstWeekday', n,
+              ordinalWeek: 1,
+              weekday: task.dayOfWeek,
+              endMode, afterCount, untilTs,
+            } as CalendarRepeatMeta;
+          }
           return {
             kind: n === 1 ? 'monthlyByDay' : 'everyNMonthByDay', n,
             ordinalWeek: task.repeatOrdinalWeek,
@@ -689,6 +718,14 @@ export class CalendarRepeatService {
           case 3:
             // New path: Nth-weekday-of-month rule — takes priority over legacy dayOfMonth.
             if (task.repeatOrdinalWeek != null && task.dayOfWeek != null) {
+              if (task.repeatOrdinalWeek === 1) {
+                return {
+                  kind: n === 1 ? 'monthlyFirstWeekday' : 'everyNMonthFirstWeekday', n,
+                  ordinalWeek: 1,
+                  weekday: task.dayOfWeek,
+                  endMode, afterCount, untilTs,
+                } as CalendarRepeatMeta;
+              }
               return {
                 kind: n === 1 ? 'monthlyByDay' : 'everyNMonthByDay', n,
                 ordinalWeek: task.repeatOrdinalWeek,
@@ -814,6 +851,10 @@ export class CalendarRepeatService {
       case 'everyNYear':
         return {...meta, month: date.getMonth(), dom: date.getDate()};
 
+      case 'monthlyFirstWeekday':
+      case 'everyNMonthFirstWeekday':
+        return {...meta, weekday: date.getDay()};
+
       default:
         // daily / everyNd / weeklyMulti / weeklyAll / everyNWeek{Multi,All}:
         // no single date-derived anchor — leave untouched.
@@ -829,7 +870,10 @@ export class CalendarRepeatService {
     endMode: 'never' | 'after' | 'until',
     afterCount?: number,
     untilTs?: number,
-    date?: Date
+    date?: Date,
+    monthlyKind?: 'everyNMonthDom' | 'monthlyFirstWeekday',
+    dom?: number,
+    monthlyWeekday?: number,
   ): CalendarRepeatMeta {
     const base: Partial<CalendarRepeatMeta> = {endMode, afterCount, untilTs, n: step};
 
@@ -846,9 +890,21 @@ export class CalendarRepeatService {
         weekdays: weekdays.length !== 1 ? weekdays : undefined,
       } as CalendarRepeatMeta;
     } else if (unit === 'month') {
-      // Custom monthly intentionally anchors to day 1 (the user sets a specific
-      // day-of-month elsewhere); keep that — #933 is scoped to the yearly branch.
-      return {...base, kind: step === 1 ? 'monthlyDom' : 'everyNMonthDom', dom: 1} as CalendarRepeatMeta;
+      if (monthlyKind === 'monthlyFirstWeekday') {
+        const wd = monthlyWeekday ?? (date ? date.getDay() : 1);
+        return {
+          ...base,
+          kind: step === 1 ? 'monthlyFirstWeekday' : 'everyNMonthFirstWeekday',
+          ordinalWeek: 1,
+          weekday: wd,
+        } as CalendarRepeatMeta;
+      } else {
+        return {
+          ...base,
+          kind: step === 1 ? 'monthlyDom' : 'everyNMonthDom',
+          dom: dom ?? 1,
+        } as CalendarRepeatMeta;
+      }
     } else {
       // Anchor the day-of-month + month to the selected start date instead of
       // hard-coding January 1 regardless of the chosen date (#933).

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.ts
@@ -414,7 +414,9 @@ export class CalendarRepeatService {
       }
 
       case 'monthlyByDay':
-      case 'everyNMonthByDay': {
+      case 'everyNMonthByDay':
+      case 'monthlyFirstWeekday':
+      case 'everyNMonthFirstWeekday': {
         const ordinal = meta.ordinalWeek ?? 1;
         const wd = meta.weekday ?? 0;
         const currentLang = this.translate.currentLang || this.translate.defaultLang;
@@ -778,6 +780,9 @@ export class CalendarRepeatService {
     if (meta.kind === 'monthlyByDay' || meta.kind === 'everyNMonthByDay') {
       return 0;
     }
+    if (meta.kind === 'monthlyFirstWeekday' || meta.kind === 'everyNMonthFirstWeekday') {
+      return 0;
+    }
     return null;
   }
 
@@ -790,6 +795,9 @@ export class CalendarRepeatService {
     if (!meta) return null;
     if (meta.kind === 'monthlyByDay' || meta.kind === 'everyNMonthByDay') {
       return meta.ordinalWeek ?? null;
+    }
+    if (meta.kind === 'monthlyFirstWeekday' || meta.kind === 'everyNMonthFirstWeekday') {
+      return meta.ordinalWeek ?? 1;
     }
     return null;
   }
@@ -812,6 +820,9 @@ export class CalendarRepeatService {
     // falling back to its legacy start-weekday-only path (#922).
     if (meta.kind === 'weeklyAll' || meta.kind === 'everyNWeekAll') {
       return '0,1,2,3,4,5,6';
+    }
+    if (meta.kind === 'monthlyFirstWeekday' || meta.kind === 'everyNMonthFirstWeekday') {
+      return meta.weekday != null ? String(meta.weekday) : null;
     }
     return null;
   }


### PR DESCRIPTION
## Summary
- Adds a **Gentagelsestype** row to the custom-repeat-modal when unit = Måned
- Primary dropdown: **Månedligt dag** (repeat on a specific calendar day 1–28) or **Månedligt på den første** (repeat on the first occurrence of a specific weekday)
- Secondary picker changes based on selection: day number 1–28 or weekday name (Mandag–Søndag)
- Row disappears when unit is not Måned
- i18n keys added to da.ts and enUS.ts

## Test plan
- [ ] Open custom-repeat-modal with unit = Måned
- [ ] Verify Gentagelsestype row appears with both dropdown options
- [ ] Select "Månedligt dag" — verify day 1–28 picker appears
- [ ] Select "Månedligt på den første" — verify weekday picker appears (pre-filled from start date)
- [ ] Switch unit to Uge/Dag — verify row disappears
- [ ] Save task with each sub-type and verify correct recurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)