### PR TITLE
fix(calendar): edit-modal date move lands on correct weekday + no stale Compliance (#966)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarThisAndFollowingMoveBackReproTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarThisAndFollowingMoveBackReproTests.cs
@@ -1,0 +1,304 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction.
+*/
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+using System.Globalization;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Infrastructure.Models.TaskWizard;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+
+/// <summary>
+/// REPRODUCTION (not a fix) for the reported regression: editing a monthly
+/// "1st Saturday" task's date to Friday (an earlier day in the SAME period)
+/// with scope "thisAndFollowing" lands the routine on Thursday and/or copies it.
+///
+/// Scenario: monthly 1st Saturday, anchored Sat 6 Jun 2026. User edits the
+/// July occurrence (Sat 4 Jul) → Fri 3 Jul, scope=thisAndFollowing.
+/// July 2026: 1st Thu=Jul 2, 1st Fri=Jul 3, 1st Sat=Jul 4.
+///
+/// A UTC+2 browser serialises the picked "Fri 3 Jul" (local-midnight Date)
+/// as 2026-07-02T22:00:00Z (toISOString). On a UTC server the BE reads that
+/// StartDate as Thu 2 Jul (it does NOT apply the AssumeUniversal|AdjustToUniversal
+/// normalisation it uses for OriginalDate), so the series re-anchors to the
+/// 1st THURSDAY.
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
+{
+    private static string IsoUtc(DateTime d) =>
+        DateTime.SpecifyKind(d, DateTimeKind.Utc).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+    private static string Key(DateTime d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    // The fixture shares one MariaDb container across its test methods and
+    // TestBaseSetup only disposes the contexts between tests (no DB reset), so
+    // seeded rows accumulate. GetTasksForWeek then trips on duplicate
+    // dictionary keys once a second test runs. Wipe the tables each test
+    // touches up-front for isolation, mirroring CalendarYearlyMoveTests.
+    [SetUp]
+    public async Task CleanState()
+    {
+        BackendConfigurationPnDbContext!.CalendarOccurrenceExceptionSites.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarOccurrenceExceptionSites);
+        BackendConfigurationPnDbContext.CalendarOccurrenceExceptions.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarOccurrenceExceptions);
+        BackendConfigurationPnDbContext.CalendarConfigurations.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarConfigurations);
+        BackendConfigurationPnDbContext.Compliances.RemoveRange(
+            BackendConfigurationPnDbContext.Compliances);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRulePlannings.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRulePlannings);
+        BackendConfigurationPnDbContext.AreaRuleTranslations.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRuleTranslations);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        BackendConfigurationPnDbContext.AreaRules.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRules);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        BackendConfigurationPnDbContext.Areas.RemoveRange(
+            BackendConfigurationPnDbContext.Areas);
+        BackendConfigurationPnDbContext.Properties.RemoveRange(
+            BackendConfigurationPnDbContext.Properties);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        ItemsPlanningPnDbContext!.Plannings.RemoveRange(ItemsPlanningPnDbContext.Plannings);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        MicrotingDbContext!.Cases.RemoveRange(MicrotingDbContext.Cases);
+        await MicrotingDbContext.SaveChangesAsync();
+    }
+
+    private sealed record Seed(int PropertyId, int ArpId, int SiteId, int PlanningId, int AreaId);
+
+    // Seeds a monthly 1st-Saturday series anchored on Sat 6 Jun 2026.
+    private async Task<Seed> SeedFirstSaturdaySeries()
+    {
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+        var sdkSite = new Site
+        {
+            Name = $"taf-moveback-{Guid.NewGuid()}", MicrotingUid = 9911,
+            LanguageId = language.Id, WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(sdkSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var area = new Area { Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property { Name = $"TafMoveBack-{Guid.NewGuid()}", ItemPlanningTagId = 0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule { AreaId = area.Id, PropertyId = property.Id, EformId = 0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        await BackendConfigurationPnDbContext.AreaRuleTranslations.AddAsync(new AreaRuleTranslation
+        { AreaRuleId = areaRule.Id, LanguageId = language.Id, Name = "Tank 4", WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 });
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var startDate = new DateTime(2026, 6, 6, 0, 0, 0, DateTimeKind.Utc); // 1st Saturday of June 2026
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Month, StartDate = startDate,
+            DayOfMonth = 0, RelatedEFormId = 0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id, ItemPlanningId = planning.Id,
+            StartDate = startDate, Status = true, RepeatType = 3, RepeatEvery = 1,
+            RepeatOrdinalWeek = 1, DayOfWeek = 6, // 1st Saturday (Sat = 6)
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(new CalendarConfiguration
+        { AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 });
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        return new Seed(property.Id, arp.Id, sdkSite.Id, planning.Id, area.Id);
+    }
+
+    private CalendarTaskUpdateRequestModel BuildEdit(Seed s, DateTime startDateUtc, string scope = "thisAndFollowing") => new()
+    {
+        Id = s.ArpId, Scope = scope,
+        OriginalDate = "2026-07-04T00:00:00Z", // clicked occurrence = 1st Saturday of July
+        StartDate = startDateUtc,
+        StartHour = 9.0, Duration = 1.0, Status = 1,
+        RepeatType = 3, RepeatEvery = 1, RepeatOrdinalWeek = 1, DayOfMonth = 0,
+        ComplianceEnabled = false, PropertyId = s.PropertyId, EformId = 0,
+        Sites = [s.SiteId], TagIds = [], Translates = []
+    };
+
+    private async Task<List<string>> JulyWeekTiles(BackendConfigurationCalendarService svc, int propertyId)
+    {
+        var weekStart = new DateTime(2026, 6, 29, 0, 0, 0, DateTimeKind.Utc); // Mon containing Jul 2-4
+        var res = await svc.GetTasksForWeek(new CalendarTaskRequestModel
+        {
+            PropertyId = propertyId, WeekStart = IsoUtc(weekStart),
+            WeekEnd = IsoUtc(weekStart.AddDays(6).AddHours(23).AddMinutes(59)),
+            ActionableOnly = false, BoardIds = [], TagNames = [], SiteIds = []
+        });
+        Assert.That(res.Success, Is.True, res.Message);
+        return res.Model!.Select(t => $"{t.TaskDate}{(t.IsFromCompliance ? "(compliance)" : "")}").OrderBy(x => x).ToList();
+    }
+
+    // ---- Repro 1: tz-shifted StartDate (what a UTC+2 browser sends) → wrong weekday ----
+    [Test]
+    public async Task Repro_ThisAndFollowing_TzShiftedFriday_LandsOnThursday()
+    {
+        var core = await GetCore();
+        var s = await SeedFirstSaturdaySeries();
+        var svc = BuildService(core);
+
+        // 2026-07-02T22:00:00Z == Fri 3 Jul local-midnight in UTC+2 (Denmark).
+        await svc.UpdateTask(BuildEdit(s, new DateTime(2026, 7, 2, 22, 0, 0, DateTimeKind.Utc)));
+
+        var tiles = await JulyWeekTiles(svc, s.PropertyId);
+        TestContext.WriteLine("Rendered July-week tiles (tz-shifted): " + string.Join(", ", tiles));
+
+        // EXPECTED (correct) behaviour: a single tile on Friday 3 Jul.
+        Assert.That(tiles, Does.Contain(Key(new DateTime(2026, 7, 3))),
+            "routine should move to Friday 3 Jul");
+        Assert.That(tiles, Does.Not.Contain(Key(new DateTime(2026, 7, 2))),
+            "routine must NOT land on Thursday 2 Jul");
+    }
+
+    // ---- Control: tz-stable StartDate (Fri 3 Jul 00:00Z) → correct weekday ----
+    [Test]
+    public async Task Control_ThisAndFollowing_TzStableFriday_LandsOnFriday()
+    {
+        var core = await GetCore();
+        var s = await SeedFirstSaturdaySeries();
+        var svc = BuildService(core);
+
+        await svc.UpdateTask(BuildEdit(s, new DateTime(2026, 7, 3, 0, 0, 0, DateTimeKind.Utc)));
+
+        var tiles = await JulyWeekTiles(svc, s.PropertyId);
+        TestContext.WriteLine("Rendered July-week tiles (tz-stable): " + string.Join(", ", tiles));
+
+        Assert.That(tiles, Does.Contain(Key(new DateTime(2026, 7, 3))), "Friday 3 Jul present");
+        Assert.That(tiles, Does.Not.Contain(Key(new DateTime(2026, 7, 2))), "no Thursday");
+        Assert.That(tiles.Count(t => t.StartsWith("2026-07")), Is.EqualTo(1),
+            "exactly one July tile (no copy)");
+    }
+
+    // ---- Repro 2: deployed (not completed) compliance at Jul 4 → duplicate? ----
+    [Test]
+    public async Task Repro_ThisAndFollowing_WithDeployedComplianceAtJul4_NoDuplicate()
+    {
+        var core = await GetCore();
+        var s = await SeedFirstSaturdaySeries();
+
+        // A deployed-but-not-completed occurrence already exists at Sat 4 Jul.
+        var sdkCase = new Microting.eForm.Infrastructure.Data.Entities.Case
+        { SiteId = s.SiteId, Status = 66, WorkflowState = Constants.WorkflowStates.Created };
+        await MicrotingDbContext!.Cases.AddAsync(sdkCase);
+        await MicrotingDbContext.SaveChangesAsync();
+        await BackendConfigurationPnDbContext!.Compliances.AddAsync(new Compliance
+        {
+            PlanningId = s.PlanningId, PropertyId = s.PropertyId, AreaId = s.AreaId,
+            Deadline = new DateTime(2026, 7, 4, 0, 0, 0, DateTimeKind.Utc), StartDate = new DateTime(2026, 6, 4, 0, 0, 0, DateTimeKind.Utc),
+            MicrotingSdkCaseId = sdkCase.Id, MicrotingSdkeFormId = 0, WorkflowState = Constants.WorkflowStates.Created
+        });
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var svc = BuildService(core);
+        // Use the tz-stable Friday to isolate the duplicate from the weekday bug.
+        await svc.UpdateTask(BuildEdit(s, new DateTime(2026, 7, 3, 0, 0, 0, DateTimeKind.Utc)));
+
+        var tiles = await JulyWeekTiles(svc, s.PropertyId);
+        TestContext.WriteLine("Rendered July-week tiles (compliance@Jul4): " + string.Join(", ", tiles));
+
+        Assert.That(tiles.Count(t => t.StartsWith("2026-07")), Is.EqualTo(1),
+            "exactly one July tile after move — original Sat 4 Jul must not remain as a copy");
+    }
+
+    // ---- RC1 parity: the tz-shift bug affects every entry point that reads
+    // StartDate by wall-clock, not just thisAndFollowing. These guard the
+    // "this" and "all" scopes against the same off-by-one. (CreateTask shares
+    // the same NormalizeStartDateToLocalDay entry-point fix but cannot be
+    // rendered here — its ARP is produced by the task wizard, which is mocked.)
+
+    // scope="this" records the move as a per-occurrence exception (NewDate =
+    // StartDate.Date). A tz-shifted StartDate would set NewDate to Thursday.
+    [Test]
+    public async Task Repro_ThisOccurrence_TzShiftedFriday_LandsOnFriday()
+    {
+        var core = await GetCore();
+        var s = await SeedFirstSaturdaySeries();
+        var svc = BuildService(core);
+
+        await svc.UpdateTask(BuildEdit(s, new DateTime(2026, 7, 2, 22, 0, 0, DateTimeKind.Utc), "this"));
+
+        var tiles = await JulyWeekTiles(svc, s.PropertyId);
+        TestContext.WriteLine("Rendered July-week tiles (this, tz-shifted): " + string.Join(", ", tiles));
+
+        Assert.That(tiles, Does.Contain(Key(new DateTime(2026, 7, 3))), "occurrence should move to Friday 3 Jul");
+        Assert.That(tiles, Does.Not.Contain(Key(new DateTime(2026, 7, 2))), "must NOT land on Thursday 2 Jul");
+        Assert.That(tiles.Count(t => t.StartsWith("2026-07")), Is.EqualTo(1), "exactly one July tile");
+    }
+
+    // scope="all" re-anchors the whole series; arp.DayOfWeek is derived from
+    // StartDate.DayOfWeek, so a tz-shifted StartDate re-patterns to "1st
+    // Thursday" instead of "1st Friday".
+    [Test]
+    public async Task Repro_AllScope_TzShiftedFriday_RepatternsToFriday()
+    {
+        var core = await GetCore();
+        var s = await SeedFirstSaturdaySeries();
+        var svc = BuildService(core);
+
+        await svc.UpdateTask(BuildEdit(s, new DateTime(2026, 7, 2, 22, 0, 0, DateTimeKind.Utc), "all"));
+
+        var tiles = await JulyWeekTiles(svc, s.PropertyId);
+        TestContext.WriteLine("Rendered July-week tiles (all, tz-shifted): " + string.Join(", ", tiles));
+
+        Assert.That(tiles, Does.Contain(Key(new DateTime(2026, 7, 3))), "series should re-pattern to 1st Friday 3 Jul");
+        Assert.That(tiles, Does.Not.Contain(Key(new DateTime(2026, 7, 2))), "must NOT re-pattern to 1st Thursday 2 Jul");
+    }
+
+    private BackendConfigurationCalendarService BuildService(eFormCore.Core core)
+    {
+        var language = MicrotingDbContext!.Languages.First();
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        userService.GetCurrentUserLanguage().Returns(Task.FromResult(language));
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+        var taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        taskWizardService.DeleteTask(Arg.Any<int>()).Returns(Task.FromResult(new OperationResult(true)));
+        taskWizardService.UpdateTask(Arg.Any<TaskWizardCreateModel>()).Returns(Task.FromResult(new OperationResult(true)));
+        return new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(), userService,
+            BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext!, taskWizardService,
+            NullLogger<BackendConfigurationCalendarService>.Instance);
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -979,6 +979,13 @@ public class BackendConfigurationCalendarService(
     {
         try
         {
+            // Recover the user's intended local day before any .Date/.DayOfWeek
+            // read (#966) — see NormalizeStartDateToLocalDay. The weekday this
+            // derives (createModel.StartDate.DayOfWeek) is persisted as the
+            // series anchor below, so a tz-shifted value would re-anchor the
+            // recurrence to the wrong weekday.
+            createModel.StartDate = NormalizeStartDateToLocalDay(createModel.StartDate);
+
             // Validate: cannot create task in the past
             var taskDateTime = createModel.StartDate.AddHours(createModel.StartHour);
             if (taskDateTime < DateTime.UtcNow)
@@ -1110,10 +1117,38 @@ public class BackendConfigurationCalendarService(
         }
     }
 
+    // A browser at a non-zero UTC offset serialises a picked local-midnight
+    // date via Date.toISOString() as an instant shifted by that offset — a
+    // UTC+2 user picking "Fri 3 Jul" sends 2026-07-02T22:00:00.000Z. Reading
+    // .Date/.DayOfWeek off that raw value yields the WRONG calendar day (Thu 2
+    // Jul) and re-anchors a recurring series to the wrong weekday (#966).
+    // OriginalDate is immune because the FE sends it at midnight UTC and the BE
+    // parses it AssumeUniversal|AdjustToUniversal — StartDate carried a
+    // wall-clock time and skipped that normalisation, the asymmetry that is the
+    // bug. The server cannot know the browser offset, but a picked date always
+    // means a midnight, so round to the NEAREST midnight (UTC) to recover the
+    // intended local day. This is correct for every inhabited browser offset
+    // (UTC−11 … UTC+14): their local midnight serialises within 12h of a UTC
+    // midnight, so it rounds back to the intended day. Only the uninhabited
+    // UTC−12 boundary (local midnight == exactly T12:00Z) would round forward a
+    // day. A value already at midnight (a tz-stable instant, or the date-only
+    // string the FE now sends) is unchanged. Applied once at each entry point so
+    // every downstream .Date/.DayOfWeek read sees the corrected day.
+    private static DateTime NormalizeStartDateToLocalDay(DateTime startDate)
+    {
+        var shifted = DateTime.SpecifyKind(startDate, DateTimeKind.Utc).AddHours(12);
+        return new DateTime(shifted.Year, shifted.Month, shifted.Day, 0, 0, 0, DateTimeKind.Utc);
+    }
+
     public async Task<OperationResult> UpdateTask(CalendarTaskUpdateRequestModel updateModel)
     {
         try
         {
+            // Recover the user's intended local day before any .Date/.DayOfWeek
+            // read (#966). Covers all scopes (this/thisAndFollowing/all) and the
+            // wizard StartDate handed off below.
+            updateModel.StartDate = NormalizeStartDateToLocalDay(updateModel.StartDate);
+
             // Validate: cannot update task to the past
             var taskDateTime = updateModel.StartDate.AddHours(updateModel.StartHour);
             if (taskDateTime < DateTime.UtcNow)
@@ -1597,6 +1632,60 @@ public class BackendConfigurationCalendarService(
         foreach (var stale in staleExceptions)
         {
             await stale.Delete(backendConfigurationPnDbContext);
+        }
+
+        // #966 (RC2) — mirror the MoveTask #954 fix for the edit-modal path: a
+        // date move re-anchors the recurrence but leaves the moved-from
+        // occurrence's deployed Compliance row at its old Deadline, so the
+        // compliance loop keeps painting a tile on the old day while the
+        // recurrence paints one on the new day — a duplicate "copy". The "all"
+        // scope already relocates via RelocateNonCompletedComplianceRowsToNewPattern
+        // (#960); only this thisAndFollowing path was missing it. Carry the
+        // source occurrence's non-completed Compliance row to the new anchor so a
+        // single tile remains (the dedup gate then suppresses the recurrence tile
+        // on that day). Only when the date actually changed; completed rows
+        // (backing SDK Case Status==100) are frozen (R2). A 3-day window +
+        // in-memory .Date match avoids DateTime.Kind drift (mirrors MoveTask /
+        // IsTaskOccurrenceCompleted). Keyed on arp.ItemPlanningId (not the
+        // planning row, which the backfill above only needs for description), so
+        // a deployed Compliance still relocates even if its Planning is missing
+        // — matching MoveTask, which gates only on the move having happened.
+        if (dateChanged)
+        {
+            var windowStart = originalDate.AddDays(-1);
+            var windowEnd = originalDate.AddDays(2);
+            var complianceAtOriginalDate = (await backendConfigurationPnDbContext.Compliances
+                    .Where(x => x.PlanningId == arp.ItemPlanningId)
+                    .Where(x => x.Deadline >= windowStart && x.Deadline < windowEnd)
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .ToListAsync())
+                .Where(c => c.Deadline.Date == originalDate)
+                .ToList();
+
+            var caseIds = complianceAtOriginalDate
+                .Select(c => c.MicrotingSdkCaseId)
+                .Where(id => id > 0)
+                .Distinct()
+                .ToList();
+            var completedCaseIds = new HashSet<int>();
+            if (caseIds.Count > 0)
+            {
+                var sdkCore = await coreHelper.GetCore().ConfigureAwait(false);
+                await using var sdkDbContext = sdkCore.DbContextHelper.GetDbContext();
+                completedCaseIds = (await sdkDbContext.Cases
+                    .Where(c => caseIds.Contains(c.Id) && c.Status == 100)
+                    .Select(c => c.Id)
+                    .ToListAsync()).ToHashSet();
+            }
+
+            foreach (var compliance in complianceAtOriginalDate
+                         .Where(c => !(c.MicrotingSdkCaseId > 0
+                                       && completedCaseIds.Contains(c.MicrotingSdkCaseId))))
+            {
+                compliance.Deadline = newAnchor.Date;
+                compliance.UpdatedByUserId = userService.UserId;
+                await compliance.Update(backendConfigurationPnDbContext);
+            }
         }
 
         return new OperationResult(true,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -733,7 +733,12 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
     const payload: any = {
       // Backend CalendarTaskCreateRequestModel fields
       translates: [{name: this.titleControl.value, languageId: 1}],
-      startDate: taskDate,
+      // Send the date-only string (local Y-M-D), NOT the raw Date — a raw Date
+      // is JSON-serialised via toISOString(), which shifts a local-midnight pick
+      // by the browser's UTC offset (UTC+2 "Fri 3 Jul" → 2026-07-02T22:00Z) and
+      // re-anchors the series to the wrong weekday on the backend (#966). This
+      // mirrors how originalDate/taskDate are already sent as date-only strings.
+      startDate: dateStr,
       startHour,
       duration,
       sites: this.assigneeControl.value ?? [],


### PR DESCRIPTION
Fixes #966.

A monthly "1st Saturday" routine, edited via the task modal — changing the date from Sat 4 Jul to **Fri 3 Jul** with scope **"This and following"** — ended up **copied onto Thursday 2 Jul** instead of cleanly **moved to Friday 3 Jul**. Two independent defects combined in this flow.

## RC1 — timezone off-by-one in `StartDate`
A browser at a positive UTC offset serialises a picked local-midnight date via `Date.toISOString()` shifted by the offset (UTC+2 "Fri 3 Jul" → `2026-07-02T22:00:00Z`). The backend read `StartDate` by wall-clock (`.Date`/`.DayOfWeek`), landing on **Thursday** and re-anchoring the series to the wrong weekday. `OriginalDate` was immune because it is sent at midnight UTC and parsed `AssumeUniversal|AdjustToUniversal` — `StartDate` carried a wall-clock time and skipped that normalisation. Fixed at both layers:

- **FE** (`task-create-edit-modal.component.ts`): the modal sends `startDate` as the already-computed **date-only string**, not a raw `Date` (so `toISOString()` can't shift it). Mirrors how `originalDate`/`taskDate` are already sent.
- **BE** (`BackendConfigurationCalendarService.cs`): new `NormalizeStartDateToLocalDay` rounds `StartDate` to the **nearest UTC midnight** at every entry point — `CreateTask` and `UpdateTask` (covering the `this`/`thisAndFollowing`/`all` scopes) — before any `.Date`/`.DayOfWeek` read. Correct for every inhabited browser offset (UTC−11 … UTC+14).

## RC2 — stale Compliance "copy"
The edit-modal `thisAndFollowing` path never relocated the moved-from occurrence's deployed `Compliance` row, leaving a duplicate tile. This mirrors the **MoveTask #954** relocation (and the `all`-scope `RelocateNonCompletedComplianceRowsToNewPattern`, #960): carry the source occurrence's non-completed `Compliance` row to the new anchor, with completed (`Status==100`) rows left frozen (R2) and a 3-day window + in-memory `.Date` match to avoid `DateTime.Kind` drift.

## Tests
`CalendarThisAndFollowingMoveBackReproTests` (Testcontainers + real SDK core):
- Control (tz-stable Friday) stays green; the two repros — RC1 wrong weekday, RC2 duplicate — were watched fail then flip green.
- Added RC1 **parity tests** for the `this` and `all` scopes with the `…T22:00Z` wire value.
- Added a per-test DB cleanup `[SetUp]` (mirroring `CalendarYearlyMoveTests`) so the fixture is reliable in a combined run.

Regression suites all green locally: `CalendarUpdateTaskScopeTests` (8), `CalendarYearlyMoveTests` (3), `CalendarCompletedPeriodSuppressionTests` (3), `CalendarComplianceMoveTests` (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)