### PR TITLE
feat(calendar): completed tasks → #5c7829 background + white check, no dimming/strikethrough

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.html
@@ -9,6 +9,7 @@
     <div
       class="schedule-item"
       *ngFor="let task of group.tasks"
+      [class.completed]="task.completed"
       [style.border-left-color]="task.color"
       (click)="onTaskClicked(task, $event)"
     >

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.scss
@@ -38,6 +38,22 @@
         background: var(--bg-soft, #f1f3f4);
       }
 
+      // Completed task (SDK case Status == 100): solid green row, full opacity,
+      // white text/check (set above + on .completion-btn.done). padding-right
+      // gives the green fill symmetric breathing room (base row has none).
+      &.completed {
+        background: #5c7829;
+        padding-right: 12px;
+
+        .task-time { color: rgba(255, 255, 255, 0.85); }
+
+        // Light grey chips fail contrast on the green row — give them a
+        // translucent-white pill with white text instead.
+        .task-tags .tag { background: rgba(255, 255, 255, 0.25); color: #fff; }
+
+        &:hover { background: #4f6823; }
+      }
+
       .completion-btn {
         background: none;
         border: none;
@@ -53,12 +69,12 @@
           height: 20px;
         }
 
-        // Mirror the week-grid block's completed state — green check_circle
-        // (#61BA5B == $eform-green) and inert (no further click-through).
+        // Completed: white check_circle on the green (#5c7829) completed row,
+        // and inert (no further click-through).
         &.done {
           cursor: default;
           mat-icon {
-            color: #61BA5B;
+            color: #fff;
           }
         }
       }
@@ -76,9 +92,10 @@
         .task-title {
           font-weight: 500;
 
+          // Completed rows are green-filled (see .schedule-item.completed
+          // below) — white text, no dim, no strike-through.
           &.completed {
-            text-decoration: line-through;
-            opacity: 0.6;
+            color: #fff;
           }
         }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
@@ -26,13 +26,13 @@
     opacity: 0;
   }
 
-  // Completed tasks keep the SAME colour as active (not-completed) tasks — the
-  // completion is signalled purely by the strike-through and the green check
-  // mark (set in the template), not by any colour change. The tile is a solid,
-  // opaque board colour just like an active one, so it never lets a stacked
-  // active tile bleed through.
+  // Completed tasks (SDK case Status == 100) get a solid green tile (#966-style
+  // done cue): #5c7829 background, white check (set on .completion-btn.done
+  // below), NO strike-through, full opacity. The !important overrides the inline
+  // board-colour background, mirroring .gcal-task--inactive. Kept fully opaque so
+  // a stacked active tile can't bleed through.
   &.completed {
-    text-decoration: line-through;
+    background-color: #5c7829 !important;
   }
 
   // Inactive ("nedtonet" / status === false) tasks are intentionally de-
@@ -46,6 +46,23 @@
     color: #6b7280;
 
     .task-time { color: #9aa0a6; }
+  }
+
+  // A completed occurrence is a terminal state and outranks the inactive
+  // (status === false) grey treatment when both apply to the same tile.
+  &.gcal-task--inactive.completed {
+    background-color: #5c7829 !important;
+    border-color: #fff;
+    color: #fff;
+
+    .task-time { color: #fff; }
+  }
+
+  // ...and it should hover like a normal (active) completed tile, not inherit
+  // the inactive tile's brightness-dip press cue below.
+  &.gcal-task--inactive.completed:hover {
+    opacity: 0.9;
+    filter: none;
   }
 
   // Inactive tiles must stay fully opaque on hover too — element-opacity dimming
@@ -135,15 +152,11 @@
       height: 16px;
     }
 
-    // Completed task (SDK case Status == 100): turn the check_circle glyph
-    // green so users can spot completion at a glance. The tile keeps its normal
-    // colour (same as an active task) and only gains a line-through via
-    // .task-block.completed above,
-    // so this green check is the primary completion cue.
-    // #61BA5B matches the project's $eform-green palette token (used
-    // elsewhere in the frontend); grep $eform-green to find the source.
+    // Completed task (SDK case Status == 100): white check_circle on the solid
+    // #5c7829 tile (set on .task-block.completed). White reads cleanly on the
+    // dark green and matches the white card text.
     &.done mat-icon {
-      color: #61BA5B;
+      color: #fff;
     }
   }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.html
@@ -5,6 +5,7 @@
          [class.today-col]="isToday(day)">
       <div class="all-day-chip"
            *ngFor="let task of getAllDayTasksForColumn(i)"
+           [class.completed]="task.completed"
            [style.background-color]="task.color"
            (click)="onAllDayTaskClicked($event, task, i)">
         <span *ngIf="isAdmin" class="task-id">{{ task.id }}</span> {{ task.title }}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
@@ -55,6 +55,14 @@
       opacity: 0.85;
     }
 
+    // Completed all-day task (SDK case Status == 100): solid green chip,
+    // matching the completed timed-tile treatment. The !important overrides the
+    // inline board-colour background. (All-day chips carry no completion icon by
+    // existing design, so only the background changes here.)
+    &.completed {
+      background-color: #5c7829 !important;
+    }
+
     .task-id {
       opacity: 0.7;
       font-size: 0.85em;


### PR DESCRIPTION
## Summary

When a calendar task is **completed** (SDK case `Status == 100`, surfaced as `task.completed`), it now gets one consistent "done" treatment across **every calendar surface**:

- **Background → `#5c7829`** (solid green)
- **`check_circle` icon → white** (was green `#61BA5B`)
- **No dimming** (removes the `opacity: 0.6` the schedule view applied)
- **No strikethrough** on the task name or from–to time

Implements the request: *"Når en opgave er udført, skal baggrundsfarven på opgaven i kalenderen skifte til #5c7829. Ikon check_circle skal vises i farven hvid. Udførte opgaver skal ikke nedtones og opgavenavn og fra-til tidspunkt skal ikke overstreges."*

## Changes (frontend only)

| File | Change |
|---|---|
| `calendar-task-block.component.scss` | week/day tile: `.completed` → `#5c7829` bg (was strikethrough); white check; completed outranks the grey inactive treatment incl. hover |
| `calendar-week-grid.component.{html,scss}` | all-day chip: `[class.completed]` hook + `#5c7829` bg |
| `calendar-schedule-view.component.{html,scss}` | list row: row-level `[class.completed]` → green row, white text/check, removed `opacity:0.6` + strikethrough; legible tag chips on green |

## Out of scope / unchanged

- **Active** (not-done) and **inactive** (`status === false`, grey "nedtonet") tasks are untouched.
- Tile borders/layout/stacking, drag/resize/complete behavior, the one-way "done" rule, and the definition of "completed".
- No TS, model, API, or backend changes. All-day chips carry no completion icon by existing design (not added here).

## Testing

CSS + one template hook. Both edited SCSS files compile standalone; the full Angular dev build is clean. The Playwright calendar e2e shards in CI render all three views. Visual reference: design spec + mockup (`docs/superpowers/specs/2026-06-07-calendar-completed-task-styling-design.md`, `calendar-completed-task-mockup.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)