### PR TITLE
feat: seed 14 new eform XMLs and set 01. Standard as calendar default

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -211,6 +211,62 @@
       <EmbeddedResource Include="Resources\eForms\Kvittering.xml">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </EmbeddedResource>
+      <None Remove="Resources\eForms\01. Standard.xml" />
+      <EmbeddedResource Include="Resources\eForms\01. Standard.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\02. Flydelag beholder.xml" />
+      <EmbeddedResource Include="Resources\eForms\02. Flydelag beholder.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\03. Konstruktion beholder.xml" />
+      <EmbeddedResource Include="Resources\eForms\03. Konstruktion beholder.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\04. Aktivitet beholder.xml" />
+      <EmbeddedResource Include="Resources\eForms\04. Aktivitet beholder.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\05. Kontrol telt.xml" />
+      <EmbeddedResource Include="Resources\eForms\05. Kontrol telt.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\06. Numerisk.xml" />
+      <EmbeddedResource Include="Resources\eForms\06. Numerisk.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\09. Medarbejder (APV-new).xml" />
+      <EmbeddedResource Include="Resources\eForms\09. Medarbejder (APV-new).xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\10. Anhugningsgrej (APV).xml" />
+      <EmbeddedResource Include="Resources\eForms\10. Anhugningsgrej (APV).xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\11. Brandslukkere (APV).xml" />
+      <EmbeddedResource Include="Resources\eForms\11. Brandslukkere (APV).xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\12. Elværktøj (APV).xml" />
+      <EmbeddedResource Include="Resources\eForms\12. Elværktøj (APV).xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\14. Hejseredskaber og spil (APV).xml" />
+      <EmbeddedResource Include="Resources\eForms\14. Hejseredskaber og spil (APV).xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\15. Løfteredskaber (APV).xml" />
+      <EmbeddedResource Include="Resources\eForms\15. Løfteredskaber (APV).xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\16. Maskiner (APV).xml" />
+      <EmbeddedResource Include="Resources\eForms\16. Maskiner (APV).xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <None Remove="Resources\eForms\17. Stiger (APV).xml" />
+      <EmbeddedResource Include="Resources\eForms\17. Stiger (APV).xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </EmbeddedResource>
       <None Remove="Resources\eForms\Gyllebeholder - Aktivitet i beholder.xml" />
     </ItemGroup>
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Data/Seed/Data/BackendConfigurationSeedEforms.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Data/Seed/Data/BackendConfigurationSeedEforms.cs
@@ -62,6 +62,62 @@ public static class BackendConfigurationSeedEforms
 		item = new KeyValuePair<string, List<string>>("Kvittering", headers);
 		theList.Add(item);
 
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("01. Standard", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("02. Flydelag beholder", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("03. Konstruktion beholder", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("04. Aktivitet beholder", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("05. Kontrol telt", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("06. Numerisk", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("09. Medarbejder (APV-new)", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("10. Anhugningsgrej (APV)", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("11. Brandslukkere (APV)", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("12. Elværktøj (APV)", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("14. Hejseredskaber og spil (APV)", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("15. Løfteredskaber (APV)", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("16. Maskiner (APV)", headers);
+		theList.Add(item);
+
+		headers = ["", "", ""];
+		item = new KeyValuePair<string, List<string>>("17. Stiger (APV)", headers);
+		theList.Add(item);
+
 		return theList;
 	}
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/01. Standard.xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/01. Standard.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142874</Id>
+  <Repeated>0</Repeated>
+  <Label>01. Standard|01. Standard|01. Standard|01. Стандарт|01. Standard|01. Standard|01. Standard|01. Vakio|01. Standard</Label>
+  <StartDate>2026-05-26</StartDate>
+  <EndDate>2036-05-26</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142874</Id>
+      <Label>01. Standard|01. Standard|01. Standard|01. Стандарт|01. Standard|01. Standard|01. Standard|01. Vakio|01. Standard</Label>
+      <Description><![CDATA[]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="Picture">
+          <Id>378100</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>0</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>378101</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/02. Flydelag beholder.xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/02. Flydelag beholder.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142875</Id>
+  <Repeated>0</Repeated>
+  <Label>02. Flydelag beholder|02. Floating layer tank|02. Schwimmschicht Behälter|02. Резервуар із плаваючим шаром|02. Zbiornik z warstwą pływającą|02. Flytedekke beholder|02. Flytskikt behållare|02. Kelluvapinta-allas|02. Rezervor cu strat flotant</Label>
+  <StartDate>2026-05-27</StartDate>
+  <EndDate>2036-05-27</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142875</Id>
+      <Label>02. Flydelag beholder|02. Floating layer tank|02. Schwimmschicht Behälter|02. Резервуар із плаваючим шаром|02. Zbiornik z warstwą pływającą|02. Flytedekke beholder|02. Flytskikt behållare|02. Kelluvapinta-allas|02. Rezervor cu strat flotant</Label>
+      <Description><![CDATA[]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="SingleSelect">
+          <Id>378104</Id>
+          <Label>Er flydelaget skorpet og fri for sprækker med blank gylleoverflade?|Is the floating crust intact and free of cracks with a shiny slurry surface visible?|Ist die Schwimmschicht verkrustet und frei von Rissen mit glänzender Gülle-Oberfläche?|Чи вкрилося плаваюче покриття кіркою та чи вільне від тріщин із блискучою поверхнею гною?|Czy warstwa pływająca jest pokryta skorupą i wolna od pęknięć z błyszczącą powierzchnią gnojownicy?|Er flytedekket skorpedannet og fritt for sprekker med blank gjødseloverflate?|Är flytskiktet skorporat och fritt från sprickor med en blank gödselyta synlig?|Onko kelluva kerros kuorettunut ja vapaa halkeamista, ja onko lieteliete pintana kiiltävä?|Este stratul flotant crăpat și liber de fisuri cu o suprafață lucioasă de gunoi de grajd vizibilă?</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>0</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[Ja|Yes|Ja|Так|Tak|Ja|Ja|Kyllä|Da]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Nej|No|Nein|Ні|Nie|Nei|Nej|Ei|Nu]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>378105</Id>
+          <Label>Er overdækningen tæt, sammenhængende og stabil i blæsevejr?|Is the floating crust tight, continuous/cohesive, and stable in windy weather?|Ist die Abdeckung dicht, zusammenhängend und stabil bei windigem Wetter?|Чи є покриття щільним, суцільним і стабільним у вітряну погоду?|Czy pokrywa jest szczelna, spójna i stabilna w wietrzną pogodę?|Er overdekket tett, sammenhengende og stabilt i blåsevær?|Är täckningen tät, sammanhängande och stabil i blåsigt väder?|Onko peitto tiivis, yhtenäinen ja vakaa tuulisella säällä?|Este acoperișul etanș, continuu și stabil pe vreme vântoasă?</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[Ja|Yes|Ja|Так|Tak|Ja|Ja|Kyllä|Da]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Nej|No|Nein|Ні|Nie|Nei|Nej|Ei|Nu]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>378106</Id>
+          <Label>Har overdækningen en tør overflade i tørvejr?|Does the crust have a dry surface in dry weather?|Hat die Abdeckung eine trockene Oberfläche bei trockenem Wetter?|Чи має покриття суху поверхню в суху погоду?|Czy pokrywa ma suchą powierzchnię podczas suchej pogody?|Har overdekket en tørr overflate i tørt vær?|Har täckningen en torr yta i torrt väder?|Onko peitolla kuiva pinta kuivalla säällä?|Are acoperișul o suprafață uscată pe vreme uscată?</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[Ja|Yes|Ja|Так|Tak|Ja|Ja|Kyllä|Da]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Nej|No|Nein|Ні|Nie|Nei|Nej|Ei|Nu]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>378107</Id>
+          <Label>Vælg % overflade med tilfredsstillende flydelag|Select % of surface with satisfactory floating layer/crust|Wählen Sie % Oberfläche mit zufriedenstellender Schwimmschicht|Виберіть % поверхні з задовільним плаваючим шаром|Wybierz % powierzchni z zadowalającą warstwą pływającą|Velg % overflate med tilfredsstillende flytedekke|Välj % yta med tillfredsställande flytskikt|Valitse % pinta-alasta, jolla on tyydyttävä kelluva kerros|Selectați % suprafață cu strat flotant satisfăcător</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[100 %|100 %|100 %|100 %|100 %|100 %|100 %|100 %|100 %]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[90 %|90 %|90 %|90 %|90 %|90 %|90 %|90 %|90 %]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[80 %|80 %|80 %|80 %|80 %|80 %|80 %|80 %|80 %]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>4</Key>
+              <Value><![CDATA[70 %|70 %|70 %|70 %|70 %|70 %|70 %|70 %|70 %]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>4</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>5</Key>
+              <Value><![CDATA[60 %|60 %|60 %|60 %|60 %|60 %|60 %|60 %|60 %]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>5</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>6</Key>
+              <Value><![CDATA[50 %|50 %|50 %|50 %|50 %|50 %|50 %|50 %|50 %]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>6</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>7</Key>
+              <Value><![CDATA[40 %|40 %|40 %|40 %|40 %|40 %|40 %|40 %|40 %]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>7</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>8</Key>
+              <Value><![CDATA[30 %|30 %|30 %|30 %|30 %|30 %|30 %|30 %|30 %]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>8</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>9</Key>
+              <Value><![CDATA[20 %|20 %|20 %|20 %|20 %|20 %|20 %|20 %|20 %]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>9</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>10</Key>
+              <Value><![CDATA[10 %|10 %|10 %|10 %|10 %|10 %|10 %|10 %|10 %]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>10</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>11</Key>
+              <Value><![CDATA[0 %|0 %|0 %|0 %|0 %|0 %|0 %|0 %|0 %]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>11</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>12</Key>
+              <Value><![CDATA[---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>12</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>378108</Id>
+          <Label>Vælg årsag til manglende flydelag|Select the reason for missing floating layer|Grund für fehlendes Schwimmdecke auswählen|Виберіть причину відсутності плаваючого шару|Wybierz przyczynę braku warstwy pływającej|Velg årsak til manglende flytelag|Välj orsak till saknat flytlager|Valitse syy puuttuvalle kelluvalle kerrokselle|Selectați motivul pentru stratul plutitor lipsă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>4</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[Beholder tom|Tank empty|Behälter leer|Резервуар порожній|Zbiornik pusty|Beholder tom|Behållare tom|Säiliö tyhjä|Rezervor gol ]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Beholder omrørt|Tank agitated / stirred|Behälter umgerührt|Резервуар перемішаний|Zbiornik wymieszany|Beholder omrørt|Behållare omrörd|Säiliö sekoitettu|Rezervor agitat / amestecat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Flyttet til anden beholder|Slurry transferred to another tank|In einen anderen Behälter umgepumpt|Перекачано до іншого резервуара|Przeniesiono do innego zbiornika|Flyttet til annen beholder|Flyttad till annan behållare|Siirretty toiseen säiliöön|Transferat în alt rezervor]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>4</Key>
+              <Value><![CDATA[Gylle udbragt|Slurry applied to fields|Gülle ausgebracht|Гній внесено на поля|Gnojowica wywieziona na pola|Gjødsel spredt|Gödsel spridd|Lanta levitetty pelloille|Gunoi de grajd aplicat pe câmpuri]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>4</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>5</Key>
+              <Value><![CDATA[Halm tilført|Straw added|Stroh hinzugefügt|Солому додано|Dodano słomę|Halm tilsatt|Halm tillfört|Olkia lisätty|Paie adăugate]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>5</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>6</Key>
+              <Value><![CDATA[Modtaget biogasgylle|Received biogas digestate|Biogasgülle erhalten|Отримано біогазовий дигестат|Odebrano poferment biogazowy|Mottatt biogassgjødsel|Mottaget biogasgödsel|Vastaanotettu biokaasumädäte|Digestat biogaz primit]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>6</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>7</Key>
+              <Value><![CDATA[---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>7</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>378102</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>5</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>378103</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>6</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/03. Konstruktion beholder.xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/03. Konstruktion beholder.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142876</Id>
+  <Repeated>0</Repeated>
+  <Label>03. Konstruktion beholder|03. Construction tank|03. Konstruktion Behälter|03. Конструкція резервуара|03. Konstrukcja zbiornika|03. Konstruksjon beholder|03. Konstruktion behållare|03. Rakenne säiliö|03. Construcție rezervor</Label>
+  <StartDate>2026-05-27</StartDate>
+  <EndDate>2036-05-27</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142876</Id>
+      <Label>03. Konstruktion beholder|03. Construction tank|03. Konstruktion Behälter|03. Конструкція резервуара|03. Konstrukcja zbiornika|03. Konstruksjon beholder|03. Konstruktion behållare|03. Rakenne säiliö|03. Construcție rezervor</Label>
+      <Description><![CDATA[<br>]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="CheckBox">
+          <Id>378109</Id>
+          <Label>Kabler OK|Cables OK|Kabel OK|Кабелі OK|Kable OK|Kabler OK|Kablar OK|Kaapelit OK|Cabluri OK</Label>
+          <Description><![CDATA[Der må ikke være synlige skader på kablerne.|There shall be no visible damage to the cables.|Es dürfen keine sichtbaren Schäden an den Kabeln vorhanden sein.|На кабелях не повинно бути видимих пошкоджень.|Na kablach nie mogą być widoczne uszkodzenia.|Det skal ikke være synlige skader på kablene.|Det får inte finnas synliga skador på kablarna.|Kaapeleissa ei saa olla näkyviä vaurioita.|Nu trebuie să existe deteriorări vizibile ale cablurilor.]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378113</Id>
+          <Label>Kabelomslutning OK|Cable enclosure OK|Kabelummantelung OK|Кабельна оболонка OK|Osłona kabla OK|Kabelomslutning OK|Kabelomslutning OK|Kaapelin suojakotelo OK|Înveliș cablu OK</Label>
+          <Description><![CDATA[Huller på kabelomslutning kan oftest ses ved, at fedtet er løbet ud af omslutningen og har skabt mørke pletter på beholderen.|Holes in the cable enclosure are most commonly identified by grease leaking out and forming dark stains on the tank surface.|Löcher in der Kabelummantelung sind meist daran zu erkennen, dass Fett aus der Ummantelung ausgetreten ist und dunkle Flecken auf dem Behälter hinterlassen hat.|Отвори в кабельній оболонці найчастіше можна виявити за тим, що мастило витекло з оболонки та утворило темні плями на резервуарі.|Otwory w osłonie kabla można najczęściej rozpoznać po tym, że smar wyciekł z osłony i pozostawił ciemne plamy na zbiorniku.|Hull i kabelomslutningen kan oftest sees ved at fettet har lekket ut av omslutningen og dannet mørke flekker på beholderen.|Hål i kabelomslutningen kan oftast ses genom att fettet har läckt ut ur omslutningen och bildat mörka fläckar på behållaren.|Kaapelin suojakotelon reiät voidaan useimmiten havaita siitä, että rasva on valunut suojakotelosta ulos ja muodostanut tummia tahroja säiliöön.|Găurile în învelișul cablului pot fi cel mai adesea identificate prin faptul că unsoarea a scurs din înveliș și a creat pete întunecate pe rezervor.]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378114</Id>
+          <Label>Fugemassen OK|Sealant OK|Dichtmasse OK|Герметик OK|Uszczelniacz OK|Fugemassen OK|Fogmassan OK|Tiivistemassa OK|Masa de etanșare OK</Label>
+          <Description><![CDATA[Fugemassen må ikke være mørnet.|The sealant must not have deteriorated.|Die Dichtmasse darf nicht weich/zersetzt sein.|Герметик не повинен бути розм'якшеним.|Uszczelniacz nie może być zmiękczony/zdegradowany.|Fugemassen må ikke være mørnet.|Fogmassan får inte vara mjuknad/nedbruten.|Tiivistemassa ei saa olla pehmentynyt/hajonnut.|Masa de etanșare nu trebuie să fie înmuiată/deteriorată.]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>378110</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>4</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>378111</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>5</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/04. Aktivitet beholder.xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/04. Aktivitet beholder.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142877</Id>
+  <Repeated>0</Repeated>
+  <Label>04. Aktivitet beholder|04. Activity tank|04. Aktivität Behälter|04. Активність резервуара|04. Aktywność zbiornika|04. Aktivitet beholder|04. Aktivitet behållare|04. Toiminta säiliö|04. Activitate rezervor</Label>
+  <StartDate>2026-05-27</StartDate>
+  <EndDate>2036-05-27</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142877</Id>
+      <Label>04. Aktivitet beholder|04. Activity tank|04. Aktivität Behälter|04. Активність резервуара|04. Aktywność zbiornika|04. Aktivitet beholder|04. Aktivitet behållare|04. Toiminta säiliö|04. Activitate rezervor</Label>
+      <Description><![CDATA[]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="SingleSelect">
+          <Id>378117</Id>
+          <Label>Vælg gyllebeholder|Select tank|Güllebebälter auswählen|Вибрати резервуар для гноївки|Wybierz zbiornik na gnojowicę|Velg gjødselbeholder|Välj gödselbehållare|Valitse lietelantasäiliö|Selectați rezervorul de gunoi de grajd</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>0</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[Beholder 1|Tank 1|Behälter 1|Резервуар 1|Zbiornik 1|Beholder 1|Behållare 1|Säiliö 1|Rezervor 1]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Beholder 2|Tank 2|Behälter 2|Резервуар 2|Zbiornik 2|Beholder 2|Behållare 2|Säiliö 2|Rezervor 2]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>378122</Id>
+          <Label>Aktivitet i beholder|Activity in tank|Aktivität im Behälter|Активність у резервуарі|Aktywność w zbiorniku|Aktivitet i beholder|Aktivitet i behållare|Toiminta säiliössä|Activitate în rezervor</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Beholder omrørt|Tank stirred|Behälter umgerührt|Резервуар перемішано|Zbiornik wymieszany|Beholder omrørt|Behållare omrörd|Säiliö sekoitettu|Rezervor amestecat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Gylle udbragt|Slurry spread|Gülle ausgebracht|Гноївку внесено|Gnojowica rozrzucona|Gjødsel spredt|Gödsel spritt|Lietelanta levitetty|Gunoi de grajd împrăștiat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>4</Key>
+              <Value><![CDATA[Beholder tom|Tank empty|Behälter leer|Резервуар порожній|Zbiornik pusty|Beholder tom|Behållare tom|Säiliö tyhjä|Rezervor gol]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>4</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>5</Key>
+              <Value><![CDATA[Halm tilført|Straw added|Stroh hinzugefügt|Солому додано|Dodano słomę|Halm tilsatt|Halm tillfört|Olkia lisätty|Paie adăugate]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>5</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>6</Key>
+              <Value><![CDATA[Flyttet til anden beholder|Moved to another tank|In einen anderen Behälter umgefüllt|Переміщено до іншого резервуара|Przeniesiono do innego zbiornika|Flyttet til annen beholder|Flyttad till en annan behållare|Siirretty toiseen säiliöön|Mutat în alt rezervor]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>6</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>7</Key>
+              <Value><![CDATA[Modtaget biogas-gylle|Received biogas slurry|Biogasgülle empfangen|Отримано біогазову гноївку|Odebrano gnojowicę biogazową|Mottatt biogassgjødsel|Mottagen biogasgödsel|Vastaanotettu biokaasuliete|Primit nămol de biogaz]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>7</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>8</Key>
+              <Value><![CDATA[Tilført gylle|Supplied slurry|Gülle zugeführt|Гноївку додано|Dostarczona gnojowica|Tilført gjødsel|Tillfört gödsel|Lisätty lietelantaa|Gunoi de grajd adăugat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>8</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>378119</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>378118</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/05. Kontrol telt.xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/05. Kontrol telt.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142878</Id>
+  <Repeated>0</Repeated>
+  <Label>05. Kontrol telt|05. Check tent|05. Kontrollzelt|05. Контрольний намет|05. Namiot kontrolny|05. Kontrolltelt|05. Kontrolltält|05. Tarkistusteltta|05. Cort de control</Label>
+  <StartDate>2026-05-27</StartDate>
+  <EndDate>2036-05-27</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142878</Id>
+      <Label>05. Kontrol telt|05. Check tent|05. Kontrollzelt|05. Контрольний намет|05. Namiot kontrolny|05. Kontrolltelt|05. Kontrolltält|05. Tarkistusteltta|05. Cort de control</Label>
+      <Description><![CDATA[]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="CheckBox">
+          <Id>378124</Id>
+          <Label>Tank 1: Telt OK|Tank 1: Tent OK|Tank 1: Zelt OK|Резервуар 1: Намет OK|Zbiornik 1: Namiot OK|Tank 1: Telt OK|Tank 1: Tält OK|Säiliö 1: Teltta OK|Rezervor 1: Cort OK</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>0</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378126</Id>
+          <Label>Tank 2: Telt OK|Tank 2: Tent OK|Tank 2: Zelt OK|Резервуар 2: Намет OK|Zbiornik 2: Namiot OK|Tank 2: Telt OK|Tank 2: Tält OK|Säiliö 2: Teltta OK|Rezervor 2: Cort OK</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>378128</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>378127</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/06. Numerisk.xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/06. Numerisk.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142879</Id>
+  <Repeated>0</Repeated>
+  <Label>06. Numerisk|06. Numerical|06. Numerisch|06. Числовий|06. Numeryczny|06. Numerisk|06. Numerisk|06. Numeerinen|06. Numeric</Label>
+  <StartDate>2026-05-27</StartDate>
+  <EndDate>2036-05-27</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142879</Id>
+      <Label>06. Numerisk|06. Numerical|06. Numerisch|06. Числовий|06. Numeryczny|06. Numerisk|06. Numerisk|06. Numeerinen|06. Numeric</Label>
+      <Description><![CDATA[]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="Number">
+          <Id>378130</Id>
+          <Label>Aflæsning|Reading|Ablesung|Показання|Odczyt|Avlesning|Avläsning|Lukema|Citire</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>0</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <MinValue/>
+          <MaxValue/>
+          <Value/>
+          <DecimalCount>3</DecimalCount>
+          <UnitName/>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>378132</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>378131</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/09. Medarbejder (APV-new).xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/09. Medarbejder (APV-new).xml
@@ -1,0 +1,630 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142196</Id>
+  <Repeated>0</Repeated>
+  <Label>09. Medarbejder (APV-new)|09. Worker (APV-new)|09. Mitarbeiter (APV-new)|09. Працівник (APV-new)|09. Pracownik (APV-new)|09. Medarbeider (APV-new)|09. Medarbetare (APV-new)|09. Työntekijä (APV-new)|09. Angajat (APV-new)</Label>
+  <StartDate>2020-12-04</StartDate>
+  <EndDate>2030-12-04</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142196</Id>
+      <Label>09. Medarbejder (APV-new)|09. Worker (APV-new)|09. Mitarbeiter (APV-new)|09. Працівник (APV-new)|09. Pracownik (APV-new)|09. Medarbeider (APV-new)|09. Medarbetare (APV-new)|09. Työntekijä (APV-new)|09. Angajat (APV-new)</Label>
+      <Description><![CDATA[<br>]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="SingleSelect">
+          <Id>372091</Id>
+          <Label>01. Fald til lavere niveau|01. Fall to lower level|01. Sturz auf ein niedrigeres Niveau|01. Падіння на нижчий рівень|01. Upadek na niższy poziom|01. Fall til lavere nivå|01. Fall till lägre nivå|01. Putoaminen alemmalle tasolle|01. Cădere la un nivel inferior</Label>
+          <Description><![CDATA[Er der sikkerhedsudstyr/værnemidler til brug ved arbejde med fx stiger, plansiloer eller bygningen?<br>|<br>Is there safety equipment / Personal Protective Equipment available for work involving e.g. ladders, bunker silos or the building?|<br>Gibt es Sicherheitsausrüstung/Schutzausrüstung für die Arbeit mit z. B. Leitern, Flachsilos oder dem Gebäude?|<br>Чи є захисне спорядження/засоби індивідуального захисту для роботи, наприклад, зі сходами, горизонтальними силосами або будівлею?|<br>Czy dostępny jest sprzęt ochronny/środki ochrony indywidualnej do pracy np. z drabinami, silosami płaskimi lub budynkiem?|<br>Finnes det sikkerhetsutstyr/verneutstyr til bruk ved arbeid med f.eks. stiger, plansilo eller bygningen?|<br>Finns det säkerhetsutrustning/skyddsutrustning för arbete med t.ex. stegar, plansilos eller byggnaden?|<br>Onko turvallisuusvarusteet/henkilönsuojaimet saatavilla työskentelyyn esimerkiksi tikkaiden, aumasiiloin tai rakennuksen kanssa?|<br>Există echipamente de securitate/mijloace de protecție personală pentru utilizare la lucrul cu, de exemplu, scări, silozuri plate sau clădirea?]]></Description>
+          <DisplayOrder>0</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372092</Id>
+          <Label>02. Ulykker med maskiner|02. Accidents with machines|02. Unfälle mit Maschinen|02. Нещасні випадки з машинами|02. Wypadki z maszynami|02. Ulykker med maskiner|02. Olyckor med maskiner|02. Onnettomuudet koneiden kanssa|02. Accidente cu mașini</Label>
+          <Description><![CDATA[Er der sikkerhedsudstyr/værnemidler til brug ved arbejde med de maskiner, du bruger til fx høst, foder tilberedning eller gyllehåndtering?<br>|<br>Is there safety equipment / Personal Protective Equipment for working with the machines you use for e.g. harvesting, feed preparation or slurry handling?|<br>Gibt es Sicherheitsausrüstung/Schutzausrüstung für die Arbeit mit den Maschinen, die Sie z. B. für die Ernte, Futterzubereitung oder Gülleverarbeitung verwenden?|<br>Чи є захисне спорядження/засоби індивідуального захисту для роботи з машинами, які ви використовуєте, наприклад, для збирання врожаю, приготування корму або переробки рідкого гною?|<br>Czy dostępny jest sprzęt ochronny/środki ochrony indywidualnej do pracy z maszynami używanymi np. do zbiorów, przygotowania paszy lub obsługi gnojowicy?|<br>Finnes det sikkerhetsutstyr/verneutstyr til bruk ved arbeid med maskinene du bruker til f.eks. høsting, fôrtilberedning eller gjødselhåndtering?|<br>Finns det säkerhetsutrustning/skyddsutrustning för arbete med de maskiner du använder för t.ex. skörd, foderberedning eller gödselhantering?|<br>Onko turvallisuusvarusteet/henkilönsuojaimet saatavilla työskentelyyn koneiden kanssa, joita käytät esimerkiksi sadonkorjuuseen, rehun valmistukseen tai lietelantakäsittelyyn?|<br>Există echipamente de securitate/mijloace de protecție personală pentru utilizare la lucrul cu mașinile pe care le folosiți, de exemplu, pentru recoltare, pregătirea furajelor sau gestionarea gunoiului de grajd lichid?]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372093</Id>
+          <Label>03. Akut fysisk overbelastning|03. Acute physical overload|03. Akute körperliche Überlastung|03. Гостре фізичне перевантаження|03. Ostre przeciążenie fizyczne|03. Akutt fysisk overbelastning|03. Akut fysisk överbelastning|03. Akuutti fyysinen ylikuormitus|03. Suprasolicitare fizică acută</Label>
+          <Description><![CDATA[Er der sikkerheds- og hjælpeudstyr til brug ved arbejde med tunge løft eller tunge skub af materialer på bedriften for at undgå akut overbelastning af kroppen?<br>|<br>Is there safety and assistive equipment for heavy lifting or heavy pushing of materials on the farm to avoid acute physical overload?|<br>Gibt es Sicherheits- und Hilfsmittel für die Arbeit mit schweren Hebe- oder Schiebevorgängen von Materialien auf dem Betrieb, um eine akute körperliche Überlastung zu vermeiden?|<br>Чи є захисне та допоміжне обладнання для роботи з важким підніманням або важким штовханням матеріалів на фермі, щоб уникнути гострого фізичного перевантаження?|<br>Czy dostępny jest sprzęt ochronny i pomocniczy do pracy z ciężkim podnoszeniem lub ciężkim pchaniem materiałów w gospodarstwie, aby uniknąć ostrego przeciążenia fizycznego?|<br>Finnes det sikkerhets- og hjelpeutstyr til bruk ved arbeid med tunge løft eller tunge skyv av materialer på gården for å unngå akutt fysisk overbelastning?|<br>Finns det säkerhets- och hjälputrustning för arbete med tunga lyft eller tunga skjutningar av material på gården för att undvika akut fysisk överbelastning?|<br>Onko turvallisuus- ja apuvälineitä saatavilla raskaiden nostojen tai raskaiden työntöjen tekemiseen tilalla, jotta voidaan välttää akuutti fyysinen ylikuormitus?|<br>Există echipamente de securitate și auxiliare pentru utilizare la lucrul cu ridicarea sau împingerea greutăților de materiale în fermă, pentru a evita suprasolicitarea fizică acută?]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372094</Id>
+          <Label>04. Fald og snublen|04. Fall and stumble|04. Sturz und Stolpern|04. Падіння та спотикання|04. Upadki i potknięcia|04. Fall og snubling|04. Fall och snubbling|04. Kaatuminen ja kompastuminen|04. Căderi și împiedicări</Label>
+          <Description><![CDATA[Er du instrueret i arbejdsrutiner og arbejdsgange for at mindske risikoen for, at du kan falde, snuble eller glide over fx rod eller paller i laden, maskinhuset eller udendørs?<br>|<br>Have you been instructed in work routines and procedures to reduce the risk of falling, tripping or slipping over e.g. clutter or pallets in the barn, machine shed or outdoors?|<br>Wurden Sie in Arbeitsroutinen und Arbeitsabläufen unterwiesen, um das Risiko zu verringern, dass Sie über z.B. Unordnung oder Paletten in der Scheune, der Maschinenhalle oder im Freien stolpern, straucheln oder ausrutschen?<br>|<br>Чи були ви проінструктовані щодо робочих процедур і регламентів для зменшення ризику падіння, спотикання або ковзання, наприклад, через безлад або піддони в стайні, машинному сараї або на вулиці?<br>|<br>Czy zostałeś przeszkolony w zakresie rutynowych procedur i procesów roboczych w celu zmniejszenia ryzyka upadku, potknięcia lub poślizgnięcia się, np. na nieładzie lub paletach w stodole, budynku maszyn lub na zewnątrz?<br>|<br>Er du blitt opplært i arbeidsrutiner og arbeidsprosedyrer for å redusere risikoen for å falle, snuble eller gli over f.eks. rot eller paller i låven, maskinbygget eller utendørs?<br>|<br>Har du blivit instruerad i arbetsrutiner och arbetsprocesser för att minska risken för att falla, snubbla eller halka på t.ex. röra eller pallar i ladan, maskinhuset eller utomhus?<br>|<br>Onko sinulle annettu ohjeita työmenetelmistä ja -prosesseista, joiden avulla vähennetään kaatumis-, kompastumis- tai liukastumisriskiä esimerkiksi epäjärjestyksen tai lavojen takia navetassa, konehalissa tai ulkona?<br>|<br>Ați fost instruit cu privire la rutinele și procedurile de lucru pentru a reduce riscul de a cădea, împiedica sau aluneca, de exemplu, pe dezordine sau paleți în grajd, în remiza de mașini sau în aer liber?<br>]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372095</Id>
+          <Label>05. Ulykker med håndværktøj|05. Accidents with hand tools|05. Unfälle mit Handwerkzeug|05. Нещасні випадки з ручним інструментом|05. Wypadki z narzędziami ręcznymi|05. Ulykker med håndverktøy|05. Olyckor med handverktyg|05. Tapaturmat käsityökalujen kanssa|05. Accidente cu unelte de mână</Label>
+          <Description><![CDATA[Er du instrueret i arbejdsrutiner og arbejdsgange for at mindske risikoen for at skære dig eller at få fingrene i klemme, når du arbejder med håndværktøj som fx motorsave, vinkelslibere og boremaskiner?<br>|<br>Have you been instructed in work routines to reduce the risk of cutting yourself or getting your fingers caught when working with hand tools such as chainsaws, angle grinders and drills?|<br>Wurden Sie in Arbeitsroutinen und Arbeitsabläufen unterwiesen, um das Risiko zu verringern, sich zu schneiden oder die Finger einzuklemmen, wenn Sie mit Handwerkzeugen wie z.B. Motorsägen, Winkelschleifern und Bohrmaschinen arbeiten?<br>|<br>Чи були ви проінструктовані щодо робочих процедур і регламентів для зменшення ризику порізів або защемлення пальців під час роботи з ручними інструментами, такими як бензопили, кутові шліфувальники та дрилі?<br>|<br>Czy zostałeś przeszkolony w zakresie rutynowych procedur i procesów pracy w celu zmniejszenia ryzyka skaleczenia lub przyciśnięcia palców podczas pracy z narzędziami ręcznymi, takimi jak pilarki łańcuchowe, szlifierki kątowe i wiertarki?<br>|<br>Er du blitt opplært i arbeidsrutiner og arbeidsprosedyrer for å redusere risikoen for å skjære deg eller få fingrene i klem når du arbeider med håndverktøy som motorsager, vinkelslipere og bormaskiner?<br>|<br>Har du blivit instruerad i arbetsrutiner och arbetsprocesser för att minska risken för att skära dig eller få fingrarna i kläm när du arbetar med handverktyg som t.ex. motorsågar, vinkelslipar och borrmaskiner?<br>|<br>Onko sinulle annettu ohjeita työmenetelmistä ja -prosesseista, joiden avulla vähennetään riskiä viiltää itsesi tai puristaa sormesi käsityökaluilla, kuten moottorisahoilla, kulmahiomakonilla tai porakoneilla, työskentelemisen aikana?<br>|<br>Ați fost instruit cu privire la rutinele și procedurile de lucru pentru a reduce riscul de a vă tăia sau de a vă prinde degetele atunci când lucrați cu unelte de mână, cum ar fi ferăstraie cu lanț, polizoare unghiulare și mașini de găurit?<br>]]></Description>
+          <DisplayOrder>4</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372096</Id>
+          <Label>06. Intern færdsel|06. Internal traffic|06. Interner Verkehr|06. Внутрішній рух транспорту|06. Ruch wewnętrzny|06. Intern ferdsel|06. Intern trafik|06. Sisäinen liikenne|06. Trafic intern</Label>
+          <Description><![CDATA[Er der risiko for, at du kan blive påkørt eller klemt af fx traktorer, knækstyrede frontlæssere og fladvogne, når du færdes på ejendommen?<br>|<br>Is there a risk of being hit or crushed by e.g. tractors, articulated front loaders and flatbed trailers when moving around the property?|<br>Besteht das Risiko, dass Sie z.B. von Traktoren, knickgelenkten Frontladern oder Flachbettwagen angefahren oder eingeklemmt werden, wenn Sie sich auf dem Betriebsgelände bewegen?<br>|<br>Чи існує ризик того, що вас може збити або притиснути, наприклад, трактором, шарнірно-зчленованим фронтальним навантажувачем або платформним причепом під час пересування по господарству?<br>|<br>Czy istnieje ryzyko potrącenia lub przygniecenia przez np. traktory, przegubowe ładowarki czołowe lub naczepy platformowe podczas poruszania się po terenie gospodarstwa?<br>|<br>Er det risiko for at du kan bli påkjørt eller klemt av f.eks. traktorer, knekkstyrede frontlastere og flatvogner når du ferdes på eiendommen?<br>|<br>Finns det risk för att du kan bli påkörd eller klämd av t.ex. traktorer, ledsagade frontlastare och flaktrailers när du rör dig på fastigheten?<br>|<br>Onko olemassa riski, että sinut voidaan ajaa yli tai puristaa, esimerkiksi traktorin, nivelvarsikauhakuormaajan tai lavaperävaunun toimesta, kun liikut tilalla?<br>|<br>Există riscul de a fi lovit sau strivit de, de exemplu, tractoare, încărcătoare frontale articulate și remorci cu platformă atunci când vă deplasați pe proprietate?<br>]]></Description>
+          <DisplayOrder>5</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372097</Id>
+          <Label>07. Dårlige arbejdsstillinger|07. Poor working positions|07. Ungünstige Arbeitshaltungen|07. Незручні робочі пози|07. Nieergonomiczne pozycje przy pracy|07. Dårlige arbeidsstillinger|07. Dåliga arbetsställningar|07. Huonot työasennot|07. Poziții de lucru incomode</Label>
+          <Description><![CDATA[Er der hjælperedskaber til brug ved arbejde med bl.a. foroverbøjet ryg, løftede arme, på knæ eller i andre dårlige arbejdsstillinger?<br>|<br>Are there assistive devices for working with e.g. forward-bent back, raised arms, on knees or other poor working postures?|<br>Gibt es Hilfsmittel für die Arbeit mit u.a. gebeugtem Rücken, erhobenen Armen, auf den Knien oder in anderen ungünstigen Arbeitshaltungen?<br>|<br>Чи є допоміжні засоби для роботи, зокрема із зігнутою спиною, піднятими руками, на колінах або в інших незручних робочих позах?<br>|<br>Czy dostępne są pomoce robocze do pracy m.in. z pochylonym do przodu tułowiem, uniesionymi ramionami, na kolanach lub w innych nieergonomicznych pozycjach roboczych?<br>|<br>Finnes det hjelpemidler til bruk ved arbeid med bl.a. foroverbøyd rygg, løftede armer, på kne eller i andre dårlige arbeidsstillinger?<br>|<br>Finns det hjälpmedel för arbete med bl.a. framåtböjd rygg, lyfta armar, på knä eller i andra dåliga arbetsställningar?<br>|<br>Onko saatavilla apuvälineitä työskentelyyn esimerkiksi eteenpäin taivuttuneessa asennossa, kädet ylhäällä, polvillaan tai muissa huonoissa työasennoissa?<br>|<br>Există dispozitive de asistență pentru lucrul cu, printre altele, spatele aplecat înainte, brațele ridicate, în genunchi sau în alte poziții de lucru incomode?<br>]]></Description>
+          <DisplayOrder>6</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372098</Id>
+          <Label>08. Ensidigt, belastende arbejde|08. One-sided, stressful work|08. Einseitige, belastende Arbeit|08. Одностороннє, навантажуюче навантаження|08. Jednostronna, obciążająca praca|08. Ensformig, belastende arbeid|08. Ensidigt, belastande arbete|08. Yksipuolinen, kuormittava työ|08. Muncă unilaterală și solicitantă</Label>
+          <Description><![CDATA[Er du instrueret i arbejdsrutiner og arbejdsgange for at undgå at udsætte kroppen for samme belastning over længere tid, f.eks. ved maskinkørsel i højsæson, kastrering af mange smågrise eller aftørring/afrensning af yvere?<br>|<br>Have you been instructed in work routines to avoid prolonged exposure of the body to repetitive strain, for example during peak-season machine work, castrating large numbers of piglets, or drying/cleaning of udders?|<br>Wurden Sie in Arbeitsroutinen und Arbeitsabläufen unterwiesen, um zu vermeiden, den Körper über längere Zeit derselben Belastung auszusetzen, z.B. bei Maschinenarbeiten in der Hochsaison, Kastrieren vieler Ferkel oder dem Abtrocknen/Reinigen von Eutern?<br>|<br>Чи були ви проінструктовані щодо робочих процедур і регламентів, щоб уникнути тривалого впливу одноманітного навантаження на тіло, наприклад, при роботі на машині у сезон пік, кастрації великої кількості поросят або обтиранні/чищенні вим'я?<br>|<br>Czy zostałeś przeszkolony w zakresie rutynowych procedur i procesów pracy w celu uniknięcia narażania ciała na to samo obciążenie przez dłuższy czas, np. przy obsłudze maszyn w sezonie szczytowym, kastracji wielu prosiąt lub wycieraniu/czyszczeniu wymion?<br>|<br>Er du blitt opplært i arbeidsrutiner og arbeidsprosedyrer for å unngå å utsette kroppen for samme belastning over lengre tid, f.eks. ved maskinkjøring i høysesong, kastrering av mange smågriser eller avtørking/rensing av jur?<br>|<br>Har du blivit instruerad i arbetsrutiner och arbetsprocesser för att undvika att utsätta kroppen för samma belastning under längre tid, t.ex. vid maskinkörning i högsäsong, kastrering av många smågrisar eller avtorkning/rengöring av juver?<br>|<br>Onko sinulle annettu ohjeita työmenetelmistä ja -prosesseista, joiden avulla vältetään kehon altistaminen samalle kuormitukselle pitkäksi aikaa, esimerkiksi konetyön aikana huippukaudella, monien porsaiden kastraation yhteydessä tai utareiden kuivaamisen/puhdistamisen yhteydessä?<br>|<br>Ați fost instruit cu privire la rutinele și procedurile de lucru pentru a evita expunerea prelungită a corpului la același tip de solicitare, de exemplu, la operarea utilajelor în sezonul de vârf, castrarea unui număr mare de purcei sau ștergerea/curățarea ugerelor?<br>]]></Description>
+          <DisplayOrder>7</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372099</Id>
+          <Label>09. Beredskabsplan|09. Emergency plan|09. Notfallplan|09. План дій у надзвичайних ситуаціях|09. Plan awaryjny|09. Beredskapsplan|09. Beredskapsplan|09. Hätäsuunnitelma|09. Plan de urgență</Label>
+          <Description><![CDATA[Har du fået gennemgået/selv læst bedriftens beredskabsplan?<br>|<br>Have you had the company’s emergency plan reviewed with you / read it yourself?|<br>Haben Sie den Notfallplan des Betriebs durchgesehen / selbst gelesen?|<br>Чи ознайомилися ви з планом екстреної готовності підприємства / самостійно його прочитали?|<br>Czy zapoznałeś się z planem awaryjnym zakładu / przeczytałeś go samodzielnie?|<br>Har du fått gjennomgått/selv lest bedriftens beredskapsplan?|<br>Har du fått genomgångna/själv läst företagets beredskapsplan?|<br>Oletko käynyt läpi / itse lukenut yrityksen valmiussuunnitelman?|<br>Ți s-a prezentat/ai citit singur planul de urgență al întreprinderii?]]></Description>
+          <DisplayOrder>8</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372100</Id>
+          <Label>10. Løft, træk og skub|10. Lift, pull and push|10. Heben, Ziehen und Schieben|10. Підйом, тяга і штовхання|10. Podnoszenie, ciągnięcie i pchanie|10. Løft, trekk og skyv|10. Lyft, drag och skjut|10. Nosto, veto ja työntö|10. Ridicat, tras și împins</Label>
+          <Description><![CDATA[10. Er der mulighed for at benytte motoriseret hjælperedskab ved arbejde med tunge løft eller tunge skub af materialer på bedriften for at undgå akut overbelastning af kroppen?<br>|<br>Is it possible to use motorized assistive devices for heavy lifting or heavy pushing of materials on the farm to prevent acute physical strain?|<br>Besteht die Möglichkeit, motorisierte Hilfsmittel für schwere Hebe- oder Schiebearbeiten mit Materialien auf dem Betrieb einzusetzen, um eine akute Überlastung des Körpers zu vermeiden?<br>|<br>Чи є можливість використовувати механізовані допоміжні засоби для важких підйомів або переміщення важких матеріалів на господарстві, щоб запобігти гострому перевантаженню тіла?<br>|<br>Czy istnieje możliwość korzystania z mechanicznych pomocy roboczych przy pracy z ciężkimi uniesieniami lub ciężkimi pchnięciami materiałów na terenie gospodarstwa w celu uniknięcia ostrego przeciążenia ciała?<br>|<br>Er det mulighet for å benytte motoriserte hjelpemidler ved arbeid med tunge løft eller tunge skyv av materialer på bedriften for å unngå akutt overbelastning av kroppen?<br>|<br>Finns det möjlighet att använda motoriserade hjälpmedel vid arbete med tunga lyft eller tunga skjutningar av material på gården för att undvika akut överbelastning av kroppen?<br>|<br>Onko mahdollista käyttää moottoroituja apuvälineitä raskaiden nostojen tai raskaiden materiaalien työntämiseen tilalla, jotta vältetään kehon akuutti ylikuormitus?<br>|<br>Există posibilitatea de a utiliza dispozitive de asistență motorizate pentru ridicarea sau împingerea materialelor grele în cadrul fermei, pentru a preveni suprasolicitarea acută a corpului?<br>]]></Description>
+          <DisplayOrder>9</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372101</Id>
+          <Label>11. Støj|11. Noise|11. Lärm|11. Шум|11. Hałas|11. Støy|11. Buller|11. Melu|11. Zgomot</Label>
+          <Description><![CDATA[Er der sikkerhedsudstyr/værnemidler til brug ved arbejde med vinkelslibere, motorsave og højtryksrensere eller andre meget støjende maskiner?<br>|<br>Is there safety equipment / Personal Protective Equipment for working with angle grinders, chainsaws, pressure washers or other very noisy machines?|<br>Gibt es Sicherheitsausrüstung / persönliche Schutzausrüstung für die Arbeit mit Winkelschleifern, Kettensägen, Hochdruckreinigern oder anderen sehr lauten Maschinen?|<br>Чи є засоби безпеки / засоби індивідуального захисту для роботи з кутовими шліфувальними машинами, бензопилами, мийками високого тиску або іншими дуже гучними машинами?|<br>Czy dostępny jest sprzęt bezpieczeństwa / środki ochrony indywidualnej do pracy z szlifierkami kątowymi, piłami łańcuchowymi, myjkami ciśnieniowymi lub innymi bardzo głośnymi maszynami?|<br>Er det sikkerhetsutstyr / personlig verneutstyr for arbeid med vinkelslipmaskiner, motorsager, høytrykksspylere eller andre svært støyende maskiner?|<br>Finns det säkerhetsutrustning / personlig skyddsutrustning för arbete med vinkelslipar, motorsågar, högtryckstvättar eller andra mycket bullriga maskiner?|<br>Onko saatavilla turvavarusteet / henkilönsuojaimet kulmahiomakoneiden, moottorisahojen, painepesurien tai muiden erittäin meluisten koneiden kanssa työskentelyä varten?|<br>Există echipamente de siguranță / echipamente individuale de protecție pentru lucrul cu polizoare unghiulare, ferăstraie cu lanț, aparate de spălat cu presiune sau alte mașini foarte zgomotoase?]]></Description>
+          <DisplayOrder>10</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372102</Id>
+          <Label>12. Arbejdsmængde|12. Workload|12. Arbeitsbelastung|12. Обсяг роботи|12. Obciążenie pracą|12. Arbeidsmengde|12. Arbetsbörda|12. Työmäärä|12. Volumul de muncă</Label>
+          <Description><![CDATA[Føler du dig ofte stresset i forbindelse med arbejdsopgaver?<br>|<br>Do you often feel stressed in connection with your work tasks?|<br>Fühlen Sie sich bei Ihren Arbeitsaufgaben oft gestresst?|<br>Чи часто ви відчуваєте стрес у зв'язку з робочими завданнями?|<br>Czy często czujesz się zestresowany/-a w związku z zadaniami w pracy?|<br>Føler du deg ofte stresset i forbindelse med arbeidsoppgaver?|<br>Känner du dig ofta stressad i samband med dina arbetsuppgifter?|<br>Tunnetko usein stressiä työtehtäviisi liittyen?|<br>Te simți adesea stresat(ă) în legătură cu sarcinile de serviciu?]]></Description>
+          <DisplayOrder>11</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372103</Id>
+          <Label>13. Hjælp og støtte|13. Help and support|13. Hilfe und Unterstützung|13. Допомога та підтримка|13. Pomoc i wsparcie|13. Hjelp og støtte|13. Hjälp och stöd|13. Apu ja tuki|13. Ajutor și sprijin</Label>
+          <Description><![CDATA[Mangler du hjælp og støtte fra din nærmeste leder?<br>|<br>Do you lack help and support from your immediate supervisor?|<br>Fehlt Ihnen Hilfe und Unterstützung von Ihrem unmittelbaren Vorgesetzten?|<br>Чи відчуваєте ви брак допомоги та підтримки від свого безпосереднього керівника?|<br>Czy brakuje ci pomocy i wsparcia od twojego bezpośredniego przełożonego?|<br>Mangler du hjelp og støtte fra din nærmeste leder?|<br>Saknar du hjälp och stöd från din närmaste chef?|<br>Puuttuuko sinulta lähiesimiehesi apu ja tuki?|<br>Îți lipsesc ajutorul și sprijinul din partea supervizorului tău direct?]]></Description>
+          <DisplayOrder>12</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372104</Id>
+          <Label>14. Mobning|14. Bullying|14. Mobbing|14. Цькування|14. Mobbing|14. Mobbing|14. Mobbning|14. Kiusaaminen|14. Hărțuire / Bullying</Label>
+          <Description><![CDATA[Er der nogen på arbejdspladsen, der bliver udsat for mobning?<br>|<br>Is anyone at the workplace exposed to bullying?|<br>Gibt es jemanden am Arbeitsplatz, der von Mobbing betroffen ist?|<br>Чи є на робочому місці хтось, хто зазнає цькування?|<br>Czy jest ktoś w miejscu pracy, kto jest narażony na mobbing?|<br>Er det noen på arbeidsplassen som blir utsatt for mobbing?|<br>Finns det någon på arbetsplatsen som utsätts för mobbning?|<br>Onko työpaikalla ketään, joka joutuu kiusaamisen kohteeksi?|<br>Există cineva la locul de muncă care este expus la hărțuire / bullying?]]></Description>
+          <DisplayOrder>13</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372105</Id>
+          <Label>15. Infektionsrisiko|15. Risk of infection|15. Infektionsrisiko|15. Ризик інфікування|15. Ryzyko zakażenia|15. Infeksjonsrisiko|15. Infektionsrisk|15. Tartuntariski|15. Risc de infecție</Label>
+          <Description><![CDATA[Er der risiko for infektioner eller luftvejsbelastninger når du arbejder?<br>|<br>Is there a risk of infections or respiratory strain when you work?|<br>Besteht bei Ihrer Arbeit das Risiko von Infektionen oder Atemwegsbelastungen?|<br>Чи існує ризик інфікування або навантаження на дихальні шляхи під час роботи?|<br>Czy podczas pracy istnieje ryzyko infekcji lub obciążenia układu oddechowego?|<br>Er det risiko for infeksjoner eller luftveisbelastninger når du arbeider?|<br>Finns det risk för infektioner eller luftvägsbelastningar när du arbetar?|<br>Onko työssäsi riski saada infektioita tai hengitysteiden rasitusta?|<br>Există riscul de infecții sau de solicitare a căilor respiratorii atunci când lucrezi?]]></Description>
+          <DisplayOrder>14</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372106</Id>
+          <Label>16. Farlige stoffer og materialer|16. Hazardous substances and materials|16. Gefährliche Stoffe und Materialien|16. Небезпечні речовини та матеріали|16. Niebezpieczne substancje i materiały|16. Farlige stoffer og materialer|16. Farliga ämnen och material|16. Vaaralliset aineet ja materiaalit|16. Substanțe și materiale periculoase</Label>
+          <Description><![CDATA[Er der sikkerhedsudstyr til brug ved arbejde med faremærkede produkter som fx bekæmpelsesmidler, desinficeringsmidler, rengøringsmidler, flydende ammoniak, gødning eller med andre produkter, der kan indeholde farlige stoffer og materialer?<br>|<br>Is there safety equipment for working with hazardous labeled products such as pesticides, disinfectants, cleaning agents, liquid ammonia, fertilizer or other products that may contain dangerous substances and materials?|<br>Gibt es Sicherheitsausrüstung für die Arbeit mit gefahrgekennzeichneten Produkten wie z. B. Pestiziden, Desinfektionsmitteln, Reinigungsmitteln, flüssigem Ammoniak, Düngemitteln oder anderen Produkten, die gefährliche Stoffe und Materialien enthalten können?|<br>Чи є засоби захисту для роботи з продуктами, маркованими як небезпечні, такими як засоби захисту рослин, дезінфікуючі засоби, миючі засоби, рідкий аміак, добрива або інші продукти, що можуть містити небезпечні речовини та матеріали?|<br>Czy dostępny jest sprzęt ochronny do pracy z produktami oznaczonymi jako niebezpieczne, takimi jak środki ochrony roślin, środki dezynfekcyjne, środki czyszczące, ciekły amoniak, nawozy lub inne produkty, które mogą zawierać niebezpieczne substancje i materiały?|<br>Er det sikkerhetsutstyr for arbeid med faremerkte produkter som for eksempel bekjempelsesmidler, desinfeksjonsmidler, rengjøringsmidler, flytende ammoniakk, gjødsel eller andre produkter som kan inneholde farlige stoffer og materialer?|<br>Finns det säkerhetsutrustning för arbete med faromärkta produkter såsom bekämpningsmedel, desinfektionsmedel, rengöringsmedel, flytande ammoniak, gödningsmedel eller andra produkter som kan innehålla farliga ämnen och material?|<br>Onko saatavilla suojavarusteet vaarallisiksi merkittyjen tuotteiden, kuten torjunta-aineiden, desinfiointiaineiden, puhdistusaineiden, nestemäisen ammoniakin, lannoitteiden tai muiden vaarallisia aineita ja materiaaleja sisältävien tuotteiden kanssa työskentelyä varten?|<br>Există echipamente de siguranță pentru lucrul cu produse etichetate ca periculoase, precum pesticide, dezinfectanți, agenți de curățare, amoniac lichid, îngrășăminte sau alte produse care pot conține substanțe și materiale periculoase?]]></Description>
+          <DisplayOrder>15</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372107</Id>
+          <Label>17. Støv, gasser og røg|17. Dust, gases and fumes|17. Staub, Gase und Rauch|17. Пил, гази та дим|17. Pyły, gazy i dymy|17. Støv, gasser og røyk|17. Damm, gaser och rök|17. Pöly, kaasut ja savu|17. Praf, gaze și fum</Label>
+          <Description><![CDATA[Er der sikkerhedsudstyr til brug ved arbejde, hvor du bliver udsat for støv, gas eller røg fra flis, hø, halm, korn, gylle, udstødning eller svejsning?<br>|<br>Is there safety equipment for work where you are exposed to dust, gas or smoke from wood chips, hay, straw, grain, slurry, exhaust or welding?|<br>Gibt es Sicherheitsausrüstung für Arbeiten, bei denen Sie Staub, Gas oder Rauch von Hackschnitzeln, Heu, Stroh, Getreide, Gülle, Abgasen oder Schweißarbeiten ausgesetzt sind?|<br>Чи є захисне спорядження для роботи, під час якої ви піддаєтеся впливу пилу, газу або диму від деревної тріски, сіна, соломи, зерна, гною, вихлопних газів або зварювання?|<br>Czy dostępny jest sprzęt ochronny do pracy, podczas której jesteś narażony/-a na pył, gaz lub dym pochodzący z wiórów drzewnych, siana, słomy, zboża, gnojowicy, spalin lub spawania?|<br>Er det sikkerhetsutstyr for arbeid der du blir utsatt for støv, gass eller røyk fra flis, høy, halm, korn, gylle, eksosutslipp eller sveising?|<br>Finns det säkerhetsutrustning för arbete där du utsätts för damm, gas eller rök från flis, hö, halm, spannmål, flytgödsel, avgaser eller svetsning?|<br>Onko saatavilla suojavarusteita töihin, joissa altistut pölylle, kaasulle tai savulle hakkeesta, heinästä, oljesta, viljasta, lietelannasta, pakokaasuista tai hitsauksesta?|<br>Există echipamente de siguranță pentru lucrul în care ești expus la praf, gaz sau fum provenite din așchii de lemn, fân, paie, cereale, nămol, gaze de eșapament sau sudură?]]></Description>
+          <DisplayOrder>16</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372108</Id>
+          <Label>18. Våde eller fugtige hænder|18. Wet or damp hands|18. Nasse oder feuchte Hände|18. Мокрі або вологі руки|18. Mokre lub wilgotne dłonie|18. Våte eller fuktige hender|18. Våta eller fuktiga händer|18. Märät tai kosteat kädet|18. Mâini ude sau umede</Label>
+          <Description><![CDATA[Arbejder du med våde eller fugtige hænder i mere end 2 timer om dagen?<br>|<br>Do you work with wet or damp hands for more than 2 hours a day?|<br>Arbeiten Sie mehr als 2 Stunden täglich mit nassen oder feuchten Händen?|<br>Чи працюєте ви з мокрими або вологими руками більше 2 годин на день?|<br>Czy pracujesz z mokrymi lub wilgotnymi dłońmi przez więcej niż 2 godziny dziennie?|<br>Arbeider du med våte eller fuktige hender i mer enn 2 timer om dagen?|<br>Arbetar du med våta eller fuktiga händer i mer än 2 timmar om dagen?|<br>Työskenteletkö märillä tai kosteilla käsillä yli 2 tuntia päivässä?|<br>Lucrezi cu mâini ude sau umede mai mult de 2 ore pe zi?]]></Description>
+          <DisplayOrder>17</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372109</Id>
+          <Label>19. Helkropsvibrationer|19. Whole body vibrations|19. Ganzkörpervibrationen|19. Вібрації всього тіла|19. Wibracje całego ciała|19. Helkroppsvibrasjoner|19. Helkroppsvibrationer|19. Koko kehon tärinä|19. Vibrații ale întregului corp</Label>
+          <Description><![CDATA[<br>Kører du med traktorer, høst materiel, minilæssere og andre maskiner, der udsætter dig for kraftige vibrationer?|<br>Do you operate tractors, harvesting equipment, mini loaders and other machines that expose you to strong vibrations?|<br><br>Fahren Sie Traktoren, Erntemaschinen, Minilader und andere Maschinen, die Sie starken Vibrationen aussetzen?|<br><br>Чи керуєте ви тракторами, збиральною технікою, міні-навантажувачами та іншими машинами, які піддають вас сильним вібраціям?|<br><br>Czy obsługujesz traktory, sprzęt do zbioru plonów, miniładowarki i inne maszyny, które narażają cię na silne wibracje?|<br><br>Kjører du traktorer, høstutstyr, miniladere og andre maskiner som utsetter deg for kraftige vibrasjoner?|<br><br>Kör du traktorer, skördemaskiner, minilastare och andra maskiner som utsätter dig för kraftiga vibrationer?|<br><br>Ajaako sinä traktoreita, sadonkorjuulaitteita, pienkuormaajia ja muita koneita, jotka altistavat sinut voimakkaille tärinöille?|<br><br>Conduceți tractoare, echipamente de recoltare, miniîncărcătoare și alte mașini care vă expun la vibrații puternice?]]></Description>
+          <DisplayOrder>18</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372110</Id>
+          <Label>20. Hånd-armvibrationer|20. Hand-arm vibrations|20. Hand-Arm-Vibrationen|20. Вібрації рук та рук (кисть-рука)|20. Wibracje dłoni i ramion|20. Hånd-armvibrasjoner|20. Hand-armvibrationer|20. Käsi-käsivarsi-tärinä|20. Vibrații mână-braț</Label>
+          <Description><![CDATA[<br>Har du snurrende eller følelsesløse fingre, når du har arbejdet med meget vibrerende værktøj som fx motorsave, højtryksrensere og vinkelslibere?|<br>Do you experience tingling or numb fingers after working with highly vibrating tools such as chainsaws, pressure washers and angle grinders?|<br><br>Haben Sie kribbelnde oder tauben Finger, wenn Sie mit stark vibrierenden Werkzeugen wie Kettensägen, Hochdruckreinigern und Winkelschleifern gearbeitet haben?|<br><br>Чи відчуваєте ви поколювання або оніміння пальців після роботи з дуже вібруючими інструментами, такими як бензопили, мийки високого тиску та кутові шліфмашини?|<br><br>Czy odczuwasz mrowienie lub drętwienie palców po pracy z mocno wibrującymi narzędziami, takimi jak piły łańcuchowe, myjki wysokociśnieniowe i szlifierki kątowe?|<br><br>Har du snurrende eller numne fingre etter å ha arbeidet med sterkt vibrerende verktøy som motorsager, høytrykksspylere og vinkelslipere?|<br><br>Har du stickande eller domnade fingrar när du har arbetat med kraftigt vibrerande verktyg som motorsågar, högtryckstvätt och vinkelslip?|<br><br>Onko sinulla pistelyä tai tunnottomuutta sormissa, kun olet työskennellyt voimakkaasti tärisevien työkalujen, kuten moottorisahojen, painepesurien ja kulmahiomakoneiden, kanssa?|<br><br>Aveți furnicături sau degete amorțite după ce ați lucrat cu scule care vibrează intens, cum ar fi ferăstraie cu lanț, aparate de spălat cu presiune și polizoare unghiulare?]]></Description>
+          <DisplayOrder>19</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>372112</Id>
+          <Label>21. Arbejdsforholdende generelt|21. Working conditions in general|21. Allgemeine Arbeitsbedingungen|21. Умови праці загалом|21. Warunki pracy ogólnie|21. Arbeidsforholdene generelt|21. Arbetsförhållandena generellt|21. Työolot yleisesti|21. Condițiile de muncă în general</Label>
+          <Description><![CDATA[Alt i alt oplever jeg, at arbejdsforholdende er gode på min arbejdsplads<br>|<br>Overall, I experience that the working conditions are good at my workplace.|<br>Insgesamt erlebe ich, dass die Arbeitsbedingungen an meinem Arbeitsplatz gut sind|<br>Загалом я відчуваю, що умови праці на моєму робочому місці хороші|<br>Ogólnie uważam, że warunki pracy w moim miejscu pracy są dobre|<br>Alt i alt opplever jeg at arbeidsforholdene er gode på min arbeidsplass|<br>Sammantaget upplever jag att arbetsförhållandena är goda på min arbetsplats|<br>Kaiken kaikkiaan koen, että työolot ovat hyvät työpaikallani|<br>În general, consider că condițiile de muncă sunt bune la locul meu de muncă]]></Description>
+          <DisplayOrder>20</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[I høj grad|Very much|In hohem Maße|Значною мірою|W dużym stopniu|I høy grad|I hög grad|Suuressa määrin|În mare măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[I mindre grad|Not so much|In geringerem Maße|Меншою мірою|W mniejszym stopniu|I mindre grad|I mindre grad|Vähemmässä määrin|În mai mică măsură]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Slet ikke|Not at all|Überhaupt nicht|Зовсім ні|Wcale nie|Slett ikke|Inte alls|Ei lainkaan|Deloc]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>372113</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>21</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/10. Anhugningsgrej (APV).xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/10. Anhugningsgrej (APV).xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142880</Id>
+  <Repeated>0</Repeated>
+  <Label>10. Anhugningsgrej (APV)|10. Hooking equipment (APV)|10. Anschlagmittel (APV)|10. Такелажне обладнання (APV)|10. Sprzęt do zawieszania (APV)|10. Løfteredskap (APV)|10. Lyftredskap (APV)|10. Nostoapuvälineet (APV)|10. Echipament de prindere (APV)</Label>
+  <StartDate>2026-05-27</StartDate>
+  <EndDate>2036-05-27</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142880</Id>
+      <Label>10. Anhugningsgrej (APV)|10. Hooking equipment (APV)|10. Anschlagmittel (APV)|10. Такелажне обладнання (APV)|10. Sprzęt do zawieszania (APV)|10. Løfteredskap (APV)|10. Lyftredskap (APV)|10. Nostoapuvälineet (APV)|10. Echipament de prindere (APV)</Label>
+      <Description><![CDATA[]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="CheckBox">
+          <Id>378139</Id>
+          <Label>Opbevaring OK|Storage OK|Lagerung OK|Зберігання OK|Przechowywanie OK|Oppbevaring OK|Förvaring OK|Varastointi OK|Depozitare OK</Label>
+          <Description><![CDATA[Opbevar grejet tørt, luftigt og uden sollys|Store the equipment in a dry, airy place and out of sunlight|Lagern Sie das Gerät trocken, luftig und lichtgeschützt|Зберігайте спорядження в сухому, провітрюваному місці та без прямих сонячних променів|Przechowuj sprzęt w suchym, przewiewnym miejscu i bez dostępu światła słonecznego|Oppbevar utstyret tørt, luftig og uten sollys|Förvara utrustningen torrt, luftigt och utan solljus|Säilytä välineet kuivassa, ilmavassa paikassa ja poissa auringonvalosta|Depozitați echipamentul uscat, aerisit și ferit de lumina soarelui]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378140</Id>
+          <Label>Stand 1 OK|Condition 1 OK|Zustand 1 OK|Стан 1 OK|Stan 1 OK|Stand 1 OK|Skick 1 OK|Kunto 1 OK|Stare 1 OK</Label>
+          <Description><![CDATA[Tjek for åbenlyse skader og brud|Check for obvious damage and breakage|Auf offensichtliche Schäden und Brüche prüfen|Перевірте на наявність явних пошкоджень та зламів|Sprawdź pod kątem oczywistych uszkodzeń i pęknięć|Kontroller for åpenlyse skader og brudd|Kontrollera för uppenbara skador och brott|Tarkista ilmeisten vaurioiden ja murtumien varalta|Verificați dacă există deteriorări evidente și rupturi]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378143</Id>
+          <Label>Stand 2 OK| Condition 2 OK|Zustand 2 OK|Стан 2 OK|Stan 2 OK|Stand 2 OK|Skick 2 OK|Kunto 2 OK|Stare 2 OK</Label>
+          <Description><![CDATA[Tjek om grejet er rent og uden rust|Check that the equipment is clean and free of rust|Prüfen Sie, ob das Gerät sauber und frei von Rost ist|Перевірте, чи спорядження чисте та без іржі|Sprawdź, czy sprzęt jest czysty i wolny od rdzy|Kontroller at utstyret er rent og uten rust|Kontrollera att utrustningen är ren och fri från rost|Tarkista, että välineet ovat puhtaat ja ruosteesta vapaat|Verificați dacă echipamentul este curat și fără rugină]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378138</Id>
+          <Label>Højest belastning OK|Highest load OK|Höchstlast OK|Максимальне навантаження OK|Maksymalne obciążenie OK|Høyest belastning OK|Högsta belastning OK|Suurin kuorma OK|Sarcina maximă OK</Label>
+          <Description><![CDATA[Tjek for metalskilt med angivelse af størst tilladelig belastning|Check for metal signs indicating the maximum permissible load|Prüfen Sie das Metallschild mit Angabe der höchsten zulässigen Last|Перевірте наявність металевої таблички із зазначенням максимально допустимого навантаження|Sprawdź metalową tabliczkę z podaniem maksymalnego dopuszczalnego obciążenia|Kontroller metallskilt med angivelse av største tillatte belastning|Kontrollera metallskylt med angivelse av högsta tillåtna belastning|Tarkista metallikilpi, jossa on ilmoitettu suurin sallittu kuorma|Verificați plăcuța metalică cu indicarea sarcinii maxime admise]]></Description>
+          <DisplayOrder>4</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378141</Id>
+          <Label>Slid OK|Wear OK|Verschleiß OK|Знос OK|Zużycie OK|Slitasje OK|Slitage OK|Kuluminen OK|Uzură OK</Label>
+          <Description><![CDATA[Tjek om diameter er mindre end anbefalet af leverandøren|Check if diameter is smaller than recommended by the supplier|Prüfen, ob der Durchmesser kleiner ist als vom Lieferanten empfohlen|Перевірте, чи діаметр менший за рекомендований постачальником|Sprawdź, czy średnica jest mniejsza niż zalecana przez dostawcę|Sjekk om diameteren er mindre enn anbefalt av leverandøren|Kontrollera om diametern är mindre än vad leverantören rekommenderar|Tarkista, onko halkaisija pienempi kuin toimittajan suosittelema|Verificați dacă diametrul este mai mic decât cel recomandat de furnizor]]></Description>
+          <DisplayOrder>5</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378142</Id>
+          <Label>Kinker, stikker, kordel el. lignende OK|Knots, sticks, string or similar OK|Knicke, Spleiße, Schnur o. Ä. OK|Вузли, петлі, шнур або подібне OK|Węzły, szpilki, sznurek lub podobne OK|Kinker, stikker, snor el. lignende OK|Knickar, stygn, snöre el. liknande OK|Kinkit, solmut, naru tai vastaava OK|Noduri, înțepături, sfoară sau similar OK</Label>
+          <Description><![CDATA[Tjek for udtrukket løkke, trådbrud mv.|Check for pulled out loops, broken threads, etc.|Auf herausgezogene Schlaufen, Fadenbrüche usw. prüfen|Перевірте на наявність витягнутих петель, обривів ниток тощо|Sprawdź pod kątem wysuniętych pętelek, zerwanych nitek itp.|Sjekk for uttrukket løkke, tråddbrudd mv.|Kontrollera för utdragna öglor, trådbrott m.m.|Tarkista vedetyt silmukat, langan katkeamiset jne.|Verificați pentru bucle trase, rupturi de fir etc.]]></Description>
+          <DisplayOrder>6</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378146</Id>
+          <Label>Revner, snoninger, revner mv. OK|Cracks, twists, tears, etc. OK|Risse, Verdrehungen, Risse usw. OK|Тріщини, скручування, розриви тощо OK|Pęknięcia, skręcenia, rozdarcia itp. OK|Revner, snoninger, rifter mv. OK|Sprickor, vridningar, revor m.m. OK|Halkeamat, vääntymiset, repeämät jne. OK|Fisuri, răsuciri, rupturi etc. OK</Label>
+          <Description><![CDATA[Tjek for skader og undersøg kritiske steder som samlinger og fastgørelser af tovender|Check for damage and examine critical areas such as joints and rope end attachments|Auf Schäden prüfen und kritische Stellen wie Verbindungen und Seilendenbefestigungen untersuchen|Перевірте на наявність пошкоджень і огляньте критичні місця, такі як з'єднання та кріплення кінців мотузки|Sprawdź uszkodzenia i zbadaj krytyczne miejsca, takie jak złącza i mocowania końców lin|Sjekk for skader og undersøk kritiske steder som skjøter og festepunkter for tauender|Kontrollera för skador och undersök kritiska ställen som skarvar och infästningar av taländar|Tarkista vauriot ja tutki kriittiset kohdat, kuten liitokset ja köyden päiden kiinnitykset|Verificați dacă există deteriorări și examinați zonele critice, cum ar fi îmbinările și fixările capetelor de frânghie]]></Description>
+          <DisplayOrder>7</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378147</Id>
+          <Label>Varme, kemisk påvirkning eller råd OK|Heat, chemical exposure or rot OK|Wärme, chemische Einwirkung oder Fäulnis OK|Тепло, хімічний вплив або гниття OK|Ciepło, działanie chemiczne lub gnicie OK|Varme, kjemisk påvirkning eller råte OK|Värme, kemisk påverkan eller röta OK|Lämpö, kemiallinen altistuminen tai mätäneminen OK|Căldură, expunere chimică sau putrezire OK</Label>
+          <Description><![CDATA[Tjek for skader. Må ikke svejses eller loddes.|Check for damage. Do not weld or solder.|Auf Schäden prüfen. Darf nicht geschweißt oder gelötet werden.|Перевірте на наявність пошкоджень. Не зварювати та не паяти.|Sprawdź pod kątem uszkodzeń. Nie wolno spawać ani lutować.|Sjekk for skader. Må ikke sveises eller loddes.|Kontrollera för skador. Får inte svetsas eller lödas.|Tarkista vauriot. Ei saa hitsata tai juottaa.|Verificați dacă există deteriorări. Nu se sudează sau lipește.]]></Description>
+          <DisplayOrder>8</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378148</Id>
+          <Label>Sugekopper (vakuumløfter), anlægsflader (magnetåg) mv. OK|Suction cups (vacuum lifters), contact surfaces (magnetic drag), etc. OK|Saugnäpfe (Vakuumheber), Anlageflächen (Magnetzug) usw. OK|Присоски (вакуумні підйомники), контактні поверхні (магнітне буксирування) тощо OK|Przyssawki (podnośniki próżniowe), powierzchnie styku (przeciąg magnetyczny) itp. OK|Sugekopper (vakuumløftere), anleggsflater (magnetdrag) mv. OK|Sugkoppar (vakuumlyftare), anläggningsytor (magnetdrag) m.m. OK|Imukopit (tyhjiönostimet), kosketuspinnat (magneettiveto) jne. OK|Ventuze (ridicătoare cu vacuum), suprafețe de contact (tracțiune magnetică) etc. OK</Label>
+          <Description><![CDATA[Tjek ledning og materiel for skader|Check the cord and equipment for damage|Leitung und Material auf Schäden prüfen|Перевірте кабель та обладнання на наявність пошкоджень|Sprawdź przewód i sprzęt pod kątem uszkodzeń|Sjekk ledning og materiell for skader|Kontrollera ledning och materiel för skador|Tarkista johto ja varusteet vaurioiden varalta|Verificați cablul și echipamentul pentru deteriorări]]></Description>
+          <DisplayOrder>9</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>378144</Id>
+          <Label>Kan anhugningsgrejet godkendes og mærkes?|Can the hooking equipment be approved and marked?|Kann das Anschlaggerät genehmigt und gekennzeichnet werden?|Чи може гакове обладнання бути схваленим і маркованим?|Czy sprzęt hakowy może zostać zatwierdzony i oznakowany?|Kan anhuggingsutstyret godkjennes og merkes?|Kan anhängningsredskapet godkännas och märkas?|Voidaanko nostoapuväline hyväksyä ja merkitä?|Poate echipamentul de prindere să fie aprobat și marcat?</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>10</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[Ja|Yes|Ja|Так|Tak|Ja|Ja|Kyllä|Da]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Nej, skal repareres|No, needs to be repaired|Nein, muss repariert werden|Ні, потребує ремонту|Nie, wymaga naprawy|Nei, skal repareres|Nej, ska repareras|Ei, tarvitsee korjausta|Nu, trebuie reparat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Nej, skal kasseres|No, must be discarded|Nein, muss ausgesondert werden|Ні, має бути відбраковано|Nie, musi zostać wycofany z użycia|Nei, skal kasseres|Nej, ska kasseras|Ei, on hylättävä|Nu, trebuie casat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>378136</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>11</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>378135</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>12</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/11. Brandslukkere (APV).xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/11. Brandslukkere (APV).xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142881</Id>
+  <Repeated>0</Repeated>
+  <Label>11. Brandslukkere (APV)|11. Fire extinguishers (APV)|11. Feuerlöscher (APV)|11. Вогнегасники (APV)|11. Gaśnice (APV)|11. Brannslukningsapparater (APV)|11. Brandsläckare (APV)|11. Palonsammuttimet (APV)|11. Stingătoare de incendiu (APV)</Label>
+  <StartDate>2026-05-27</StartDate>
+  <EndDate>2036-05-27</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142881</Id>
+      <Label>11. Brandslukkere (APV)|11. Fire extinguishers (APV)|11. Feuerlöscher (APV)|11. Вогнегасники (APV)|11. Gaśnice (APV)|11. Brannslukningsapparater (APV)|11. Brandsläckare (APV)|11. Palonsammuttimet (APV)|11. Stingătoare de incendiu (APV)</Label>
+      <Description><![CDATA[]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="CheckBox">
+          <Id>378153</Id>
+          <Label>Ophængning|Suspension|Aufhängung|Підвіска|Zawieszenie|Oppheng|Upphängning|Ripustus|Suspensie</Label>
+          <Description><![CDATA[Tjek, at den er ok|Check that it is ok|Prüfen, dass es in Ordnung ist|Перевірте, що все в порядку|Sprawdź, czy jest w porządku|Kontroller at den er ok|Kontrollera att den är ok|Tarkista, että se on kunnossa|Verificați că este în regulă]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378154</Id>
+          <Label>Tilgængelighed|Availability|Verfügbarkeit|Доступність|Dostępność|Tilgjengelighet|Tillgänglighet|Saatavuus|Disponibilitate</Label>
+          <Description><![CDATA[Tjek, at der ikke er placeret gods mv. foran håndslukkeren| Check that no goods, etc. have been placed in front of the fire extinguisher|Prüfen, dass keine Waren o. Ä. vor dem Feuerlöscher platziert wurden|Перевірте, що перед вогнегасником не розміщено товари тощо|Sprawdź, czy przed gaśnicą nie zostały umieszczone towary itp.|Kontroller at det ikke er plassert gods mv. foran håndslukkeren|Kontrollera att inga varor m.m. har placerats framför handbrandsläckaren|Tarkista, ettei käsisammuttimen eteen ole sijoitettu tavaroita tms.|Verificați că nu au fost plasate mărfuri etc. în fața stingătorului de incendiu]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378152</Id>
+          <Label>Sikkerhedsskiltning|Safety signs|Sicherheitsbeschilderung|Знаки безпеки|Oznakowanie bezpieczeństwa|Sikkerhetsskiltning|Säkerhetsskyltar|Turvallisuusmerkit|Indicatoare de securitate</Label>
+          <Description><![CDATA[Tjek, at skilte er opsat på væg eller lignende|Check that signs are mounted on the wall or similar|Prüfen, dass Schilder an der Wand oder Ähnlichem angebracht sind|Перевірте, що знаки встановлені на стіні або подібному місці|Sprawdź, czy znaki są zamontowane na ścianie lub podobnym miejscu|Kontroller at skilter er satt opp på vegg eller lignende|Kontrollera att skyltar är uppsatta på vägg eller liknande|Tarkista, että kyltit on kiinnitetty seinälle tai vastaavaan paikkaan|Verificați că indicatoarele sunt montate pe perete sau similar]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378155</Id>
+          <Label>Funktionsklar og intakt|Functional and intact|Funktionsbereit und intakt|Функціонально готовий та цілий|Sprawny i nienaruszony|Funksjonsklar og intakt|Funktionsklar och intakt|Toimintavalmis ja ehjä|Funcțional și intact</Label>
+          <Description><![CDATA[Tjek, at det er ok|Check that it is ok|Prüfen, dass es in Ordnung ist|Перевірте, що воно в порядку|Sprawdź, czy to jest w porządku|Kontroller at det er ok|Kontrollera att det är ok|Tarkista, että se on ok|Verificați că este în regulă]]></Description>
+          <DisplayOrder>4</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378156</Id>
+          <Label>Brugsanvisning på slukker|Instructions for use on extinguisher|Bedienungsanleitung am Feuerlöscher|Інструкція з використання на вогнегаснику|Instrukcja obsługi na gaśnicy|Bruksanvisning på slukker|Bruksanvisning på släckare|Käyttöohje sammuttimessa|Instrucțiuni de utilizare pe stingător</Label>
+          <Description><![CDATA[Tjek, at informationer vedrørende brug af ildslukker kan læses|Check that information regarding the use of the extinguisher can be read|Prüfen, dass Informationen zur Verwendung des Feuerlöschers lesbar sind|Перевірте, що інформація щодо використання вогнегасника може бути прочитана|Sprawdź, czy informacje dotyczące użytkowania gaśnicy są czytelne|Kontroller at informasjon om bruk av brannslukkeren kan leses|Kontrollera att information om användning av brandsläckaren kan läsas|Tarkista, että sammuttimen käyttöä koskevat tiedot ovat luettavissa|Verificați că informațiile privind utilizarea stingătorului de incendiu pot fi citite]]></Description>
+          <DisplayOrder>5</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378157</Id>
+          <Label>Evt. trykmåler|Pressure gauge if necessary|Ggf. Druckmesser|Можливо, манометр|Ew. manometr|Evt. trykkmåler|Ev. tryckmätare|Mahd. painemittari|Eventual manometru</Label>
+          <Description><![CDATA[Tjek, at der vises korrekt driftstryk|Check that the correct operating pressure is displayed|Prüfen, dass der korrekte Betriebsdruck angezeigt wird|Перевірте, що відображається правильний робочий тиск|Sprawdź, czy wyświetlane jest prawidłowe ciśnienie robocze|Kontroller at korrekt driftstrykk vises|Kontrollera att korrekt drifttryck visas|Tarkista, että oikea käyttöpaine näytetään|Verificați că presiunea de lucru corectă este afișată]]></Description>
+          <DisplayOrder>6</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378159</Id>
+          <Label>Ingen synlige beskadigelser|No visible damages|Keine sichtbaren Beschädigungen|Немає видимих пошкоджень|Brak widocznych uszkodzeń|Ingen synlige skader|Inga synliga skador|Ei näkyviä vaurioita|Fără deteriorări vizibile</Label>
+          <Description><![CDATA[Tjek beholder og håndtag|Check container and handle|Behälter und Griff prüfen|Перевірте ємність та ручку|Sprawdź pojemnik i uchwyt|Sjekk beholder og håndtak|Kontrollera behållare och handtag|Tarkista säiliö ja kahva|Verificați recipientul și mânerul]]></Description>
+          <DisplayOrder>7</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378160</Id>
+          <Label>Kontrolvejning af CO2-slukker|Control weighing of CO2 extinguisher|Kontrollwägung des CO2-Feuerlöschers|Контрольне зважування CO2-вогнегасника|Kontrolne ważenie gaśnicy CO2|Kontrollveiing av CO2-slukker|Kontrollvägning av CO2-släckare|CO2-sammuttimen tarkistuspunnitus|Cântărire de control a stingătorului CO2</Label>
+          <Description><![CDATA[Se beholder for vægtangivelse|See container for weight declaration|Behälter auf Gewichtsangabe prüfen|Дивіться на ємність для позначення ваги|Sprawdź pojemnik w celu ustalenia masy|Se beholder for vektangivelse|Se behållare för viktangivelse|Katso painomerkintä säiliöstä|Consultați recipientul pentru indicarea greutății]]></Description>
+          <DisplayOrder>8</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378161</Id>
+          <Label>Plomberingen|The seal|Die Plombierung|Пломба|Plomba|Plomberingen|Plomberingen|Sinetti|Sigiliul</Label>
+          <Description><![CDATA[Tjek om plomberingen er intakt|Check if seal is intact|Überprüfen Sie, ob die Plombierung intakt ist|Перевірте, чи ціла пломба|Sprawdź, czy plomba jest nienaruszona|Sjekk om plomberingen er intakt|Kontrollera om plomberingen är intakt|Tarkista, onko sinetti ehjä|Verificați dacă sigiliul este intact]]></Description>
+          <DisplayOrder>9</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>378158</Id>
+          <Label>Kan ildslukkeren godkendes?|Can the fire extinguisher be approved?|Kann der Feuerlöscher zugelassen werden?|Чи можна схвалити вогнегасник?|Czy gaśnica może zostać zatwierdzona?|Kan brannslukkeren godkjennes?|Kan brandsläckaren godkännas?|Voidaanko sammutin hyväksyä?|Poate fi aprobat extinctorul?</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>10</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[Ja|Yes|Ja|Так|Tak|Ja|Ja|Kyllä|Da]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Nej, skal repareres|No, needs to be repaired|Nein, muss repariert werden|Ні, потребує ремонту|Nie, wymaga naprawy|Nei, skal repareres|Nej, ska repareras|Ei, tarvitsee korjausta|Nu, trebuie reparat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Nej, skal kasseres|No, must be discarded|Nein, muss ausgesondert werden|Ні, має бути відбраковано|Nie, musi zostać wycofany z użycia|Nei, skal kasseres|Nej, ska kasseras|Ei, on hylättävä|Nu, trebuie casat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>378150</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>11</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>378149</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>12</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/12. Elværktøj (APV).xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/12. Elværktøj (APV).xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142882</Id>
+  <Repeated>0</Repeated>
+  <Label>12. Elværktøj (APV)|12. Power tools (APV)|12. Elektrowerkzeug (APV)|12. Електроінструмент (APV)|12. Narzędzia elektryczne (APV)|12. Elektroverktøy (APV)|12. Elverktyg (APV)|12. Sähkötyökalut (APV)|12. Unelte electrice (APV)</Label>
+  <StartDate>2026-05-27</StartDate>
+  <EndDate>2036-05-27</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142882</Id>
+      <Label>12. Elværktøj (APV)|12. Power tools (APV)|12. Elektrowerkzeug (APV)|12. Електроінструмент (APV)|12. Narzędzia elektryczne (APV)|12. Elektroverktøy (APV)|12. Elverktyg (APV)|12. Sähkötyökalut (APV)|12. Unelte electrice (APV)</Label>
+      <Description><![CDATA[]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="CheckBox">
+          <Id>378167</Id>
+          <Label>Ledninger OK|Wires OK|Kabel OK|Дроти OK|Przewody OK|Ledninger OK|Ledningar OK|Johdot OK|Cabluri OK</Label>
+          <Description><![CDATA[Tjek for skader, revner eller huller på ledninger|Check for damage, cracks or holes in wires|Auf Schäden, Risse oder Löcher in den Kabeln prüfen|Перевірте наявність пошкоджень, тріщин або отворів у проводах|Sprawdź pod kątem uszkodzeń, pęknięć lub dziur w przewodach|Sjekk for skader, sprekker eller hull i ledningene|Kontrollera för skador, sprickor eller hål i ledningarna|Tarkista johdoista vauriot, halkeamat tai reiät|Verificați dacă există deteriorări, fisuri sau găuri în cabluri]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378168</Id>
+          <Label>Stik OK|Plug OK|Stecker OK|Штекер OK|Wtyczka OK|Støpsel OK|Kontakt OK|Pistoke OK|Priză OK</Label>
+          <Description><![CDATA[Tjek for skader, revner mm.|Check for damage, cracks etc.|Auf Schäden, Risse usw. prüfen|Перевірте наявність пошкоджень, тріщин тощо|Sprawdź pod kątem uszkodzeń, pęknięć itp.|Sjekk for skader, sprekker mv.|Kontrollera för skador, sprickor m.m.|Tarkista vauriot, halkeamat jne.|Verificați dacă există deteriorări, fisuri etc.]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378166</Id>
+          <Label>Værktøjshus og håndtag OK|Tool house and handle OK|Werkzeuggehäuse und Griff OK|Корпус інструменту та рукоятка OK|Obudowa narzędzia i uchwyt OK|Verktøyhus og håndtak OK|Verktygshus och handtag OK|Työkalun runko ja kahva OK|Carcasa uneltei și mânerul OK</Label>
+          <Description><![CDATA[Tjek for skader, revner, brud mv.|Check for damage, cracks, fractures, etc.|Auf Schäden, Risse, Brüche usw. prüfen|Перевірте наявність пошкоджень, тріщин, зламів тощо|Sprawdź pod kątem uszkodzeń, pęknięć, złamań itp.|Sjekk for skader, sprekker, brudd mv.|Kontrollera för skador, sprickor, brott m.m.|Tarkista vauriot, halkeamat, murtumat jne.|Verificați dacă există deteriorări, fisuri, fracturi etc.]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378169</Id>
+          <Label>Maskine i god stand|Machine in good condition|Maschine in gutem Zustand|Машина в хорошому стані|Maszyna w dobrym stanie|Maskin i god stand|Maskin i gott skick|Kone hyvässä kunnossa|Mașină în stare bună</Label>
+          <Description><![CDATA[Tjek om el-materiellet er rent, fri for fedt og har frie ventilationsåbninger| Check that the electrical equipment is clean, free of grease and has free ventilation openings|Prüfen Sie, ob das Elektrogerät sauber, fettfrei und die Lüftungsöffnungen frei sind|Перевірте, чи є електроустаткування чистим, вільним від жиру та чи є вільні вентиляційні отвори|Sprawdź, czy urządzenie elektryczne jest czyste, wolne od tłuszczu i ma drożne otwory wentylacyjne|Sjekk om elektromateriell er rent, fritt for fett og har frie ventilasjonsåpninger|Kontrollera att elutrustningen är ren, fri från fett och har fria ventilationsöppningar|Tarkista, että sähkölaite on puhdas, rasvatonta ja että tuuletusaukot ovat vapaat|Verificați dacă echipamentul electric este curat, lipsit de grăsime și are orificii de ventilație libere]]></Description>
+          <DisplayOrder>4</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378170</Id>
+          <Label>Ingen tegn på overbelastning|No signs of congestion|Keine Anzeichen von Überlastung|Немає ознак перевантаження|Brak oznak przeciążenia|Ingen tegn på overbelastning|Inga tecken på överbelastning|Ei merkkejä ylikuormituksesta|Niciun semn de supraîncărcare</Label>
+          <Description><![CDATA[Tjek for synlige spor mv.|Check for visible traces etc.|Auf sichtbare Spuren usw. prüfen|Перевірте наявність видимих слідів тощо|Sprawdź pod kątem widocznych śladów itp.|Sjekk for synlige spor mv.|Kontrollera för synliga spår m.m.|Tarkista näkyvät jäljet jne.|Verificați dacă există urme vizibile etc.]]></Description>
+          <DisplayOrder>5</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>378171</Id>
+          <Label>Betjeningsknapper OK|Control buttons OK|Bedienungsknöpfe OK|Кнопки керування OK|Przyciski sterowania OK|Betjeningsknapper OK|Manövreringsknappar OK|Käyttöpainikkeet OK|Butoane de comandă OK</Label>
+          <Description><![CDATA[Tjek at START/STOP knapper og andre kontakter virker efter hensigten|Check that START/STOP buttons and other switches work as intended|Überprüfen Sie, ob START/STOP-Tasten und andere Schalter wie vorgesehen funktionieren|Перевірте, чи кнопки ПУСК/СТОП та інші перемикачі працюють належним чином|Sprawdź, czy przyciski START/STOP i inne przełączniki działają zgodnie z przeznaczeniem|Sjekk at START/STOPP-knapper og andre brytere fungerer etter hensikten|Kontrollera att START/STOPP-knappar och andra strömbrytare fungerar som avsett|Tarkista, että KÄYNNISTYS/PYSÄYTYS-painikkeet ja muut kytkimet toimivat tarkoitetulla tavalla|Verificați că butoanele START/STOP și alte comutatoare funcționează conform intenției]]></Description>
+          <DisplayOrder>6</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>378172</Id>
+          <Label>Kan elværktøjet godkendes?|Can the power tool be approved?|Kann das Elektrowerkzeug genehmigt werden?|Чи може електроінструмент бути схвалений?|Czy elektronarzędzie może zostać zatwierdzone?|Kan elektroverktøyet godkjennes?|Kan elverktyget godkännas?|Voiko sähkötyökalun hyväksyä?|Poate fi aprobată unealta electrică?</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>7</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[Ja|Yes|Ja|Так|Tak|Ja|Ja|Kyllä|Da]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Nej, skal repareres|No, needs to be repaired|Nein, muss repariert werden|Ні, потребує ремонту|Nie, wymaga naprawy|Nei, skal repareres|Nej, ska repareras|Ei, tarvitsee korjausta|Nu, trebuie reparat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Nej, skal kasseres|No, must be discarded|Nein, muss ausgesondert werden|Ні, має бути відбраковано|Nie, musi zostać wycofany z użycia|Nei, skal kasseres|Nej, ska kasseras|Ei, on hylättävä|Nu, trebuie casat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>378164</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>8</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>378163</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>9</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/14. Hejseredskaber og spil (APV).xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/14. Hejseredskaber og spil (APV).xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142860</Id>
+  <Repeated>0</Repeated>
+  <Label>14. Hejseredskaber og spil (APV)|14. Hoisting equipment and winches (APV)|14. Hebezeuge und Winden (APV)|14. Підіймальне обладнання та лебідки (APV)|14. Urządzenia dźwigowe i wciągarki (APV)|14. Heiseredskaper og vinsjer (APV)|14. Lyftredskap och vinschar (APV)|14. Nostolaitteet ja vinssit (APV)|14. Echipamente de ridicare și trolii (APV)</Label>
+  <StartDate>2024-12-18</StartDate>
+  <EndDate>2034-12-18</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142860</Id>
+      <Label>14. Hejseredskaber og spil (APV)|14. Hoisting equipment and winches (APV)|14. Hebezeuge und Winden (APV)|14. Підіймальне обладнання та лебідки (APV)|14. Urządzenia dźwigowe i wciągarki (APV)|14. Heiseredskaper og vinsjer (APV)|14. Lyftredskap och vinschar (APV)|14. Nostolaitteet ja vinssit (APV)|14. Echipamente de ridicare și trolii (APV)</Label>
+      <Description><![CDATA[]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="CheckBox">
+          <Id>377918</Id>
+          <Label>Instruktionsbog på dansk OK|Instruction manual in Danish OK|Bedienungsanleitung auf Dänisch OK|Інструкція з експлуатації данською мовою OK|Instrukcja obsługi w języku duńskim OK|Instruksjonsbok på dansk OK|Instruktionsbok på danska OK|Käyttöohje tanskaksi OK|Manual de instrucțiuni în daneză OK</Label>
+          <Description><![CDATA[Tjek om brugervejledningen er til stede på dansk|Check if the user manual is available in Danish|Prüfen Sie, ob die Bedienungsanleitung auf Dänisch vorhanden ist|Перевірте, чи є посібник користувача датською мовою|Sprawdź, czy instrukcja użytkownika jest dostępna w języku duńskim|Sjekk om brukerveiledningen er tilgjengelig på dansk|Kontrollera om bruksanvisningen finns tillgänglig på danska|Tarkista, onko käyttöohje saatavilla tanskaksi|Verificați dacă manualul utilizatorului este disponibil în daneză]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377919</Id>
+          <Label>Stand OK|Condition OK|Zustand OK|Стан OK|Stan OK|Stand OK|Skick OK|Kunto OK|Stare OK</Label>
+          <Description><![CDATA[Tjek for åbenlyse skader og brud|Check for obvious damage and breakage|Auf offensichtliche Schäden und Brüche prüfen|Перевірте на наявність явних пошкоджень та зламів|Sprawdź pod kątem oczywistych uszkodzeń i pęknięć|Kontroller for åpenlyse skader og brudd|Kontrollera för uppenbara skador och brott|Tarkista ilmeisten vaurioiden ja murtumien varalta|Verificați dacă există deteriorări evidente și rupturi]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377917</Id>
+          <Label>Slid OK|Wear OK|Verschleiß OK|Знос OK|Zużycie OK|Slitasje OK|Slitage OK|Kuluminen OK|Uzură OK</Label>
+          <Description><![CDATA[Tjek om det er mere end anbefalet af leverandøren|Check if it is more than recommended by the supplier|Prüfen Sie, ob es mehr ist als vom Lieferanten empfohlen|Перевірте, чи перевищує це рекомендації постачальника|Sprawdź, czy przekracza zalecenia dostawcy|Sjekk om det er mer enn anbefalt av leverandøren|Kontrollera om det är mer än vad leverantören rekommenderar|Tarkista, onko se enemmän kuin toimittajan suosittelema|Verificați dacă depășește recomandările furnizorului]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377920</Id>
+          <Label>Kinker, stikker, kordel el. lignende OK|Kinks, snags, string, etc. OK|Knicke, Haken, Schnur o. Ä. OK|Перегини, зачіпки, шнур тощо OK|Zagięcia, zaczepy, sznur itp. OK|Kink, haker, snor e.l. OK|Knickar, hakar, snöre e.d. OK|Kinkat, tarttumat, naru tms. OK|Noduri, agățături, șnur etc. OK</Label>
+          <Description><![CDATA[Tjek for udtrukket løkke, trådbrud mv.|Check for pulled-out loops, broken threads, etc.|Prüfen auf herausgezogene Schlaufen, Fadenbrüche usw.|Перевірте на наявність витягнутих петель, обривів ниток тощо|Sprawdź pod kątem wyciągniętych pętelek, zerwanych nici itp.|Sjekk for uttrukne løkker, trådbrudd mv.|Kontrollera efter utdragna öglar, trådbrott m.m.|Tarkista vedetyt silmukat, langankatkokset jne.|Verificați bucle trase, rupturi de fire etc.]]></Description>
+          <DisplayOrder>4</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377921</Id>
+          <Label>Rust og tæring OK|Rust and corrosion OK|Rost und Korrosion OK|Іржа та корозія OK|Rdza i korozja OK|Rust og tæring OK|Rost och korrosion OK|Ruoste ja korroosio OK|Rugină și coroziune OK</Label>
+          <Description><![CDATA[Tjek for tegn på rust og tæring|Check for signs of rust and corrosion|Prüfen auf Anzeichen von Rost und Korrosion|Перевірте наявність ознак іржі та корозії|Sprawdź pod kątem śladów rdzy i korozji|Sjekk for tegn på rust og tæring|Kontrollera efter tecken på rost och korrosion|Tarkista ruosteen ja korroosion merkkien varalta|Verificați semnele de rugină și coroziune]]></Description>
+          <DisplayOrder>5</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377922</Id>
+          <Label>Revner, brud, snoninger mv. OK|Cracks, breaks, kinks, etc. OK|Risse, Brüche, Verdrillungen usw. OK|Тріщини, розриви, скручування тощо OK|Pęknięcia, złamania, skręcenia itp. OK|Sprekker, brudd, snoninger mv. OK|Sprickor, brott, tvinningar m.m. OK|Halkeamat, murtumat, kiertymiset jne. OK|Fisuri, rupturi, răsuciri etc. OK</Label>
+          <Description><![CDATA[Tjek for skader og undersøg kritiske steder som samlinger og tovender|Check for damage and examine critical areas such as joints and rope ends|Prüfen auf Schäden und untersuchen Sie kritische Stellen wie Verbindungen und Seilenden|Перевірте на наявність пошкоджень та огляньте критичні місця, такі як з'єднання та кінці мотузок|Sprawdź uszkodzenia i zbadaj krytyczne miejsca, takie jak złącza i końce lin|Sjekk for skader og undersøk kritiske steder som skjøter og tauender|Kontrollera efter skador och undersök kritiska ställen såsom skarvar och tågändar|Tarkista vauriot ja tutki kriittiset kohdat, kuten liitokset ja köysien päät|Verificați deteriorările și examinați zonele critice, cum ar fi îmbinările și capetele de frânghie]]></Description>
+          <DisplayOrder>6</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>377923</Id>
+          <Label>Kan hejseredskabet godkendes og mærkes?|Can the lifting equipment be approved and marked?|Kann das Hebegerät genehmigt und markiert werden?|Чи може підіймальне обладнання бути схвалене та позначене?|Czy urządzenie dźwigowe może zostać zatwierdzone i oznakowane?|Kan heiseredskapet godkjennes og merkes?|Kan lyftredskapet godkännas och märkas?|Voiko nostolaite hyväksyä ja merkitä?|Poate fi aprobat și marcat echipamentul de ridicare?</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>7</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[Ja|Yes|Ja|Так|Tak|Ja|Ja|Kyllä|Da]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Nej, skal repareres|No, needs to be repaired|Nein, muss repariert werden|Ні, потребує ремонту|Nie, wymaga naprawy|Nei, skal repareres|Nej, ska repareras|Ei, tarvitsee korjausta|Nu, trebuie reparat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Nej, skal kasseres|No, must be discarded|Nein, muss ausgesondert werden|Ні, має бути відбраковано|Nie, musi zostać wycofany z użycia|Nei, skal kasseres|Nej, ska kasseras|Ei, on hylättävä|Nu, trebuie casat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>377915</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>8</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>377914</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>9</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/15. Løfteredskaber (APV).xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/15. Løfteredskaber (APV).xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142862</Id>
+  <Repeated>0</Repeated>
+  <Label>15. Løfteredskaber (APV)|15. Lifting equipment (APV)|15. Hebezeuge (APV)|15. Підіймальне обладнання (APV)|15. Urządzenia dźwigowe (APV)|15. Løfteredskaper (APV)|15. Lyftredskap (APV)|15. Nostolaitteet (APV)|15. Echipamente de ridicare (APV)</Label>
+  <StartDate>2024-12-18</StartDate>
+  <EndDate>2034-12-18</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142862</Id>
+      <Label>15. Løfteredskaber (APV)|15. Lifting equipment (APV)|15. Hebezeuge (APV)|15. Підіймальне обладнання (APV)|15. Urządzenia dźwigowe (APV)|15. Løfteredskaper (APV)|15. Lyftredskap (APV)|15. Nostolaitteet (APV)|15. Echipamente de ridicare (APV)</Label>
+      <Description><![CDATA[]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="CheckBox">
+          <Id>377943</Id>
+          <Label>Instruktionsbog OK|Instruction manual OK|Bedienungsanleitung OK|Інструкція з експлуатації OK|Instrukcja obsługi OK|Instruksjonsbok OK|Instruktionsbok OK|Käyttöohjekirja OK|Manual de instrucțiuni OK</Label>
+          <Description><![CDATA[Tjek om brugervejledningen er til stede på dansk|Check if the user manual is available in Danish|Prüfen Sie, ob die Bedienungsanleitung auf Dänisch vorhanden ist|Перевірте, чи є посібник користувача датською мовою|Sprawdź, czy instrukcja użytkownika jest dostępna w języku duńskim|Sjekk om brukerveiledningen er tilgjengelig på dansk|Kontrollera om bruksanvisningen finns tillgänglig på danska|Tarkista, onko käyttöohje saatavilla tanskaksi|Verificați dacă manualul utilizatorului este disponibil în daneză]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377944</Id>
+          <Label>Hydrauliksystem OK|Hydraulic system OK|Hydrauliksystem OK|Гідравлічна система OK|Układ hydrauliczny OK|Hydraulikksystem OK|Hydrauliksystem OK|Hydraulijärjestelmä OK|Sistem hidraulic OK</Label>
+          <Description><![CDATA[Tjek for utæthed, skader, revner og mørhed|Check for leaks, damage, cracks and tenderness|Auf Undichtigkeiten, Schäden, Risse und Druckempfindlichkeit prüfen|Перевірити на наявність витоків, пошкоджень, тріщин та болючості|Sprawdź pod kątem nieszczelności, uszkodzeń, pęknięć i tkliwości|Kontroller for lekkasje, skader, sprekker og ømhet|Kontrollera för läckage, skador, sprickor och ömhet|Tarkista vuodot, vauriot, halkeamat ja arkuus|Verificați scurgeri, deteriorări, fisuri și sensibilitate la atingere]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377942</Id>
+          <Label>Rust OK|Rust OK|Rost OK|Іржа OK|Rdza OK|Rust OK|Rost OK|Ruoste OK|Rugină OK</Label>
+          <Description><![CDATA[Tjek for tæringer på bærende dele|Check for corrosion on load-bearing parts|Auf Korrosion an tragenden Teilen prüfen|Перевірити наявність корозії на несучих деталях|Sprawdź pod kątem korozji na częściach nośnych|Kontroller for korrosjon på bærende deler|Kontrollera för korrosion på bärande delar|Tarkista korroosio kantavista osista|Verificați coroziunea pe părțile portante]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377945</Id>
+          <Label>Brud, revner og overbelastningsskader OK</Label>
+          <Description><![CDATA[Tjek for skader.]]></Description>
+          <DisplayOrder>4</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377946</Id>
+          <Label>Slid OK|Wear OK|Verschleiß OK|Знос OK|Zużycie OK|Slitasje OK|Slitage OK|Kuluminen OK|Uzură OK</Label>
+          <Description><![CDATA[Tjek om det er mere end anbefalet af leverandøren|Check if it is more than recommended by the supplier|Prüfen Sie, ob es mehr ist als vom Lieferanten empfohlen|Перевірте, чи перевищує це рекомендації постачальника|Sprawdź, czy przekracza zalecenia dostawcy|Sjekk om det er mer enn anbefalt av leverandøren|Kontrollera om det är mer än vad leverantören rekommenderar|Tarkista, onko se enemmän kuin toimittajan suosittelema|Verificați dacă depășește recomandările furnizorului]]></Description>
+          <DisplayOrder>5</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377947</Id>
+          <Label>Varme, kemisk påvirkning eller råd OK|Heat, chemical exposure or rot OK|Wärme, chemische Einwirkung oder Fäulnis OK|Тепло, хімічний вплив або гниття OK|Ciepło, działanie chemiczne lub gnicie OK|Varme, kjemisk påvirkning eller råte OK|Värme, kemisk påverkan eller röta OK|Lämpö, kemiallinen altistuminen tai mätäneminen OK|Căldură, expunere chimică sau putrezire OK</Label>
+          <Description><![CDATA[Tjek for tegn herpå|Check for signs of this|Auf Anzeichen hierfür prüfen|Перевірити на наявність ознак цього|Sprawdź oznaki tego|Kontroller for tegn på dette|Kontrollera för tecken på detta|Tarkista tämän merkit|Verificați semnele acestui lucru]]></Description>
+          <DisplayOrder>6</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377950</Id>
+          <Label>Revner, snoninger, revner mv. OK|Cracks, kinks, tears, etc. OK|Risse, Knicke, Einrisse usw. OK|Тріщини, перекручування, розриви тощо OK|Pęknięcia, skręcenia, rozdarcia itp. OK|Sprekker, kinking, rifter mv. OK|Sprickor, knickar, revor m.m. OK|Halkeamat, mutkat, repeämät jne. OK|Fisuri, îndoituri, rupturi etc. OK</Label>
+          <Description><![CDATA[Tjek for skader og undersøg kritiske steder som samlinger og fastgørelser af tovender|Check for damage and examine critical areas such as joints and rope end attachments|Auf Schäden prüfen und kritische Stellen wie Verbindungen und Seilendenbefestigungen untersuchen|Перевірте на наявність пошкоджень і огляньте критичні місця, такі як з'єднання та кріплення кінців мотузки|Sprawdź uszkodzenia i zbadaj krytyczne miejsca, takie jak złącza i mocowania końców lin|Sjekk for skader og undersøk kritiske steder som skjøter og festepunkter for tauender|Kontrollera för skador och undersök kritiska ställen som skarvar och infästningar av taländar|Tarkista vauriot ja tutki kriittiset kohdat, kuten liitokset ja köyden päiden kiinnitykset|Verificați dacă există deteriorări și examinați zonele critice, cum ar fi îmbinările și fixările capetelor de frânghie]]></Description>
+          <DisplayOrder>7</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377951</Id>
+          <Label>Varme, kemisk påvirkning eller råd OK|Heat, chemical exposure or rot OK|Wärme, chemische Einwirkung oder Fäulnis OK|Тепло, хімічний вплив або гниття OK|Ciepło, działanie chemiczne lub gnicie OK|Varme, kjemisk påvirkning eller råte OK|Värme, kemisk påverkan eller röta OK|Lämpö, kemiallinen altistuminen tai mätäneminen OK|Căldură, expunere chimică sau putrezire OK</Label>
+          <Description><![CDATA[Tjek for skader. Må ikke svejses eller loddes.|Check for damage. Do not weld or solder.|Auf Schäden prüfen. Darf nicht geschweißt oder gelötet werden.|Перевірте на наявність пошкоджень. Не зварювати та не паяти.|Sprawdź pod kątem uszkodzeń. Nie wolno spawać ani lutować.|Sjekk for skader. Må ikke sveises eller loddes.|Kontrollera för skador. Får inte svetsas eller lödas.|Tarkista vauriot. Ei saa hitsata tai juottaa.|Verificați dacă există deteriorări. Nu se sudează sau lipește.]]></Description>
+          <DisplayOrder>8</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>377948</Id>
+          <Label>Kan løfteredskabet godkendes og mærkes?|Can the lifting equipment be approved and marked?|Kann das Hebezeug genehmigt und gekennzeichnet werden?|Чи може підіймальне обладнання бути схвалене та промарковане?|Czy sprzęt do podnoszenia może zostać zatwierdzony i oznakowany?|Kan løfteredskapet godkjennes og merkes?|Kan lyftredskapet godkännas och märkas?|Voiko nostolaite hyväksyä ja merkitä?|Poate echipamentul de ridicare să fie aprobat și marcat?</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>10</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[Ja|Yes|Ja|Так|Tak|Ja|Ja|Kyllä|Da]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Nej, skal repareres|No, needs to be repaired|Nein, muss repariert werden|Ні, потребує ремонту|Nie, wymaga naprawy|Nei, skal repareres|Nej, ska repareras|Ei, tarvitsee korjausta|Nu, trebuie reparat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Nej, skal kasseres|No, must be discarded|Nein, muss ausgesondert werden|Ні, має бути відбраковано|Nie, musi zostać wycofany z użycia|Nei, skal kasseres|Nej, ska kasseras|Ei, on hylättävä|Nu, trebuie casat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>377940</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>11</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>377939</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>12</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/16. Maskiner (APV).xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/16. Maskiner (APV).xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142401</Id>
+  <Repeated>0</Repeated>
+  <Label>16. Maskiner (APV)|16. Machines (APV)|16. Maschinen (APV)|16. Машини (APV)|16. Maszyny (APV)|16. Maskiner (APV)|16. Maskiner (APV)|16. Koneet (APV)|16. Mașini (APV)</Label>
+  <StartDate>2021-05-20</StartDate>
+  <EndDate>2031-05-20</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142401</Id>
+      <Label>16. Maskiner (APV)|16. Machines (APV)|16. Maschinen (APV)|16. Машини (APV)|16. Maszyny (APV)|16. Maskiner (APV)|16. Maskiner (APV)|16. Koneet (APV)|16. Mașini (APV)</Label>
+      <Description><![CDATA[<br>]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="CheckBox">
+          <Id>373708</Id>
+          <Label>Lys, blinklys og bremser OK|Lights, indicators and brakes OK|Beleuchtung, Blinker und Bremsen OK|Фари, покажчики повороту та гальма OK|Światła, kierunkowskazy i hamulce OK|Lys, blinklys og bremser OK|Ljus, blinkers och bromsar OK|Valot, vilkut ja jarrut OK|Lumini, semnalizatoare și frâne OK</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>0</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>373710</Id>
+          <Label>Hydraulik og slanger OK|Hydraulics and hoses OK|Hydraulik und Schläuche OK|Гідравліка та шланги OK|Hydraulika i węże OK|Hydraulikk og slanger OK|Hydraulik och slangar OK|Hydrauliikka ja letkut OK|Hidraulică și furtunuri OK</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>375249</Id>
+          <Label>Sliddele OK|Wear parts OK|Verschleißteile OK|Зношувані деталі OK|Części ścierne OK|Slitedeler OK|Slitdelar OK|Kulutuspyörät OK|Piese de uzură OK</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>373709</Id>
+          <Label>Olie OK|Oil OK|Öl OK|Мастило OK|Olej OK|Olje OK|Olja OK|Öljy OK|Ulei OK</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>373707</Id>
+          <Label>Ingen utætheder|No leaks|Keine Undichtigkeiten|Відсутність витоків|Brak nieszczelności|Ingen lekkasjer|Inga läckage|Ei vuotoja|Fără scurgeri</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>4</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>373702</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>5</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>373701</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>6</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/17. Stiger (APV).xml
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/eForms/17. Stiger (APV).xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Main>
+  <Id>142842</Id>
+  <Repeated>0</Repeated>
+  <Label>17. Stiger (APV)|17. Ladders (APV)|17. Leitern (APV)|17. Сходи (APV)|17. Drabiny (APV)|17. Stiger (APV)|17. Stegar (APV)|17. Tikkaat (APV)|17. Scări (APV)</Label>
+  <StartDate>2023-11-29</StartDate>
+  <EndDate>2033-11-29</EndDate>
+  <Language>da</Language>
+  <MultiApproval>false</MultiApproval>
+  <FastNavigation>false</FastNavigation>
+  <Review>false</Review>
+  <Summary>false</Summary>
+  <DisplayOrder>0</DisplayOrder>
+  <ElementList>
+    <Element type="DataElement">
+      <Id>142842</Id>
+      <Label>17. Stiger (APV)|17. Ladders (APV)|17. Leitern (APV)|17. Сходи (APV)|17. Drabiny (APV)|17. Stiger (APV)|17. Stegar (APV)|17. Tikkaat (APV)|17. Scări (APV)</Label>
+      <Description><![CDATA[]]></Description>
+      <DisplayOrder>0</DisplayOrder>
+      <ReviewEnabled>false</ReviewEnabled>
+      <ManualSync>false</ManualSync>
+      <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+      <DoneButtonDisabled>false</DoneButtonDisabled>
+      <ApprovalEnabled>false</ApprovalEnabled>
+      <DataItemList>
+        <DataItem type="CheckBox">
+          <Id>377769</Id>
+          <Label>Stigebeslag OK|Ladder fittings OK|Leiterhalterungen OK|Кріплення сходів OK|Okucia drabiny OK|Stigebeslag OK|Stegbeslag OK|Tikkaan kiinnikkeet OK|Accesorii scară OK</Label>
+          <Description><![CDATA[Ikke skæve, løse, mv.|Not crooked, loose, etc.|Nicht schief, locker, usw.|Не криві, не loose, тощо|Nie krzywe, luzujące się itp.|Ikke skjeve, løse, mv.|Inte sneda, lösa, m.m.|Ei vinoja, löysiä jne.|Nu strâmbe, slăbite etc.]]></Description>
+          <DisplayOrder>1</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377770</Id>
+          <Label>Kæder OK|Chains OK|Ketten OK|Ланцюги OK|Łańcuchy OK|Kjeder OK|Kedjor OK|Ketjut OK|Lanțuri OK</Label>
+          <Description><![CDATA[Ingen løs befæstning, ikke itu, mv.|No loose fastening, not broken, etc.|Keine losen Befestigungen, nicht kaputt, usw.|Жодних loose кріплень, не зламано тощо|Brak luźnych zamocowań, nie uszkodzone itp.|Ingen løs festing, ikke i stykker, mv.|Inga lösa fästen, inte sönder, m.m.|Ei löysiä kiinnityksiä, ei rikki jne.|Nicio prindere slăbită, nu rupt etc.]]></Description>
+          <DisplayOrder>2</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377768</Id>
+          <Label>Vanger OK|Stringer OK|Holme OK|Тятиви OK|Toczki OK|Vanger OK|Strängar OK|Sivupuut OK|Lonjeroane OK</Label>
+          <Description><![CDATA[Ikke skæve, flækkede, mv.|Not crooked, cracked, etc.|Nicht schief, gespalten, usw.|Не криві, не розщеплені тощо|Nie krzywe, nie pęknięte itp.|Ikke skjeve, flaket, mv.|Inte sneda, splittrade, m.m.|Ei vinoja, haljenneita jne.|Nu strâmbe, crăpate etc.]]></Description>
+          <DisplayOrder>3</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377771</Id>
+          <Label>Trin OK|Steps OK|Stufen OK|Сходинки OK|Szczeble OK|Trinn OK|Steg OK|Askelmat OK|Trepte OK</Label>
+          <Description><![CDATA[Ikke skæve, løse, mv.| Not crooked, loose, etc.|Nicht schief, locker, usw.|Не криві, не розхитані тощо|Nie krzywe, luzujące się itp.|Ikke skjeve, løse, mv.|Inte sneda, lösa, m.m.|Ei vinoja, löysiä jne.|Nu strâmbe, slăbite etc.]]></Description>
+          <DisplayOrder>4</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377772</Id>
+          <Label>Stigedupper OK|Ladder pads OK|Leiterfüße OK|Накладки сходів OK|Stopki drabiny OK|Stigedupper OK|Stegdynor OK|Tikkaiden jalkasuojat OK|Tălpi scară OK</Label>
+          <Description><![CDATA[Ikke skæve, revnede, mv.|Not crooked, cracked, etc.|Nicht schief, gerissen, usw.|Не криві, не потріскані тощо|Nie krzywe, nie popękane itp.|Ikke skjeve, revnede, mv.|Inte sneda, spruckna, m.m.|Ei vinoja, halkeilleja jne.|Nu strâmbe, crăpate etc.]]></Description>
+          <DisplayOrder>5</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377773</Id>
+          <Label>Efterbehandling OK|Subsequent treatment OK|Nachbehandlung OK|Подальша обробка OK|Obróbka wykończeniowa OK|Etterbehandling OK|Efterbehandling OK|Jälkikäsittely OK|Tratament ulterior OK</Label>
+          <Description><![CDATA[F.eks. ingen skader på lakering, mv.| Eg. no damage to paintwork, etc.|Z.B. keine Schäden am Lackierung, usw.|Напр. жодних пошкоджень лакофарбового покриття тощо|Np. brak uszkodzeń lakieru itp.|F.eks. ingen skader på lakkering, mv.|T.ex. inga skador på lackeringen, m.m.|Esim. ei vaurioita lakkauksessa jne.|De ex. nicio deteriorare a vopselei etc.]]></Description>
+          <DisplayOrder>6</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377777</Id>
+          <Label>Ingen tegn på misbrug|No signs of abuse|Keine Anzeichen von Missbrauch|Жодних ознак неналежного використання|Brak śladów nadużycia|Ingen tegn på misbruk|Inga tecken på missbruk|Ei merkkejä väärinkäytöstä|Niciun semn de abuz</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>7</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="CheckBox">
+          <Id>377778</Id>
+          <Label>Ikke vakkelvorn ved brug|Do not wobble when used|Wackelt nicht bei Verwendung|Не хитається під час використання|Nie chwiejne podczas użytkowania|Ikke vakler ved bruk|Vinglar inte vid användning|Ei horju käytössä|Nu se clatină în utilizare</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>8</DisplayOrder>
+          <Selected>false</Selected>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="SingleSelect">
+          <Id>377774</Id>
+          <Label>Kan stigen godkendes?|Can the ladder be approved?|Kann die Leiter abgenommen werden?|Чи може сходи бути схвалені?|Czy drabina może być zatwierdzona?|Kan stigen godkjennes?|Kan stegen godkännas?|Voidaanko tikkaiden hyväksyä?|Poate fi aprobată scara?</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>9</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <KeyValuePairList>
+            <KeyValuePair>
+              <Key>1</Key>
+              <Value><![CDATA[Ja|Yes|Ja|Так|Tak|Ja|Ja|Kyllä|Da]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>1</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>2</Key>
+              <Value><![CDATA[Nej, skal repareres|No, needs to be repaired|Nein, muss repariert werden|Ні, потребує ремонту|Nie, wymaga naprawy|Nei, skal repareres|Nej, ska repareras|Ei, tarvitsee korjausta|Nu, trebuie reparat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>2</DisplayOrder>
+            </KeyValuePair>
+            <KeyValuePair>
+              <Key>3</Key>
+              <Value><![CDATA[Nej, skal kasseres|No, must be discarded|Nein, muss ausgesondert werden|Ні, має бути відбраковано|Nie, musi zostać wycofany z użycia|Nei, skal kasseres|Nej, ska kasseras|Ei, on hylättävä|Nu, trebuie casat]]></Value>
+              <Selected>false</Selected>
+              <DisplayOrder>3</DisplayOrder>
+            </KeyValuePair>
+          </KeyValuePairList>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Picture">
+          <Id>377766</Id>
+          <Label>Foto|Photo|Foto|Фото|Zdjęcie|Foto|Foto|Kuva|Fotografie</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>10</DisplayOrder>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+        <DataItem type="Comment">
+          <Id>377765</Id>
+          <Label>Note|Note|Notiz|Примітка|Notatka|Notat|Anteckning|Huomio|Notă</Label>
+          <Description><![CDATA[]]></Description>
+          <DisplayOrder>11</DisplayOrder>
+          <Multi>1</Multi>
+          <GeolocationEnabled>false</GeolocationEnabled>
+          <Split>false</Split>
+          <Value/>
+          <ReadOnly>false</ReadOnly>
+          <Mandatory>false</Mandatory>
+          <Color>e8eaf6</Color>
+        </DataItem>
+      </DataItemList>
+    </Element>
+  </ElementList>
+</Main>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -327,8 +327,8 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       this.boardControl.setValue(initialBoard?.id ?? null);
       // take(1): seed default once; later refresh emissions must not overwrite the user's selection.
       this.data.eforms.pipe(take(1)).subscribe(list => {
-        const kvittering = list.find(e => e.label === 'Kvittering');
-        this.eformControl.setValue(kvittering?.id ?? list[0]?.id ?? null);
+        const standard = list.find(e => e.label === '01. Standard');
+        this.eformControl.setValue(standard?.id ?? list[0]?.id ?? null);
       });
     }
 


### PR DESCRIPTION
## Summary

- Adds 14 new eform XML files as embedded resources in `BackendConfiguration.Pn.csproj`
- Registers all 14 new forms in `BackendConfigurationSeedEforms.GetForms()` so they are seeded on plugin startup (duplicate-safe via `OriginalId` check)
- Changes the calendar task-create-edit modal default eform from `'Kvittering'` to `'01. Standard'`

## New forms seeded

`01. Standard`, `02. Flydelag beholder`, `03. Konstruktion beholder`, `04. Aktivitet beholder`, `05. Kontrol telt`, `06. Numerisk`, `09. Medarbejder (APV-new)`, `10. Anhugningsgrej (APV)`, `11. Brandslukkere (APV)`, `12. Elværktøj (APV)`, `14. Hejseredskaber og spil (APV)`, `15. Løfteredskaber (APV)`, `16. Maskiner (APV)`, `17. Stiger (APV)`

## Test plan

- [ ] Plugin startup seeds all 14 new forms without errors
- [ ] Duplicate-safe: re-running seeding does not create duplicates
- [ ] Calendar create event defaults to `01. Standard` eform

🤖 Generated with [Claude Code](https://claude.com/claude-code)