### PR TITLE
feat(reportsv2): rename Udført dato + remove employee no column

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -280,7 +280,7 @@ export const da = {
   'Create new employee': 'Opret ny medarbejder',
   'New employee': 'Ny medarbejder',
   Timeregistration: 'Timeregistrering',
-  'Submitted date': 'Indsendt dato',
+  'Submitted date': 'Udført dato',
   'Edit employee': 'Rediger medarbejder',
   Always: 'Altid',
   Completed: 'Afsluttet',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/reports/components/report-table/report-table.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/reports/components/report-table/report-table.component.ts
@@ -59,7 +59,6 @@ export class ReportTableComponent implements OnInit, OnChanges, OnDestroy, After
     {header: this.translateService.stream('Property name'), field: 'propertyName'},
     {header: this.translateService.stream('Submitted date'), field: 'microtingSdkCaseDoneAt', type: 'date', typeParameter: {format: 'dd.MM.y', timezone: 'utc'}},
     {header: this.translateService.stream('Done by'), field: 'doneBy'},
-    {header: this.translateService.stream('Employee no'), field: 'employeeNo'},
     {header: this.translateService.stream('Area'), field: 'itemName'},
     {header: this.translateService.stream('Pictures'), field: 'imagesCount', type: 'button', buttons: [
         {
@@ -79,7 +78,6 @@ export class ReportTableComponent implements OnInit, OnChanges, OnDestroy, After
     {header: this.translateService.stream('Submitted date'), field: 'microtingSdkCaseDoneAt', type: 'date', typeParameter: {format: 'dd.MM.y HH:mm', timezone: 'utc'}},
     {header: this.translateService.stream('Server time'), field: 'serverTime', type: 'date', typeParameter: {format: 'dd.MM.y HH:mm', timezone: 'utc'}},
     {header: this.translateService.stream('Done by'), field: 'doneBy'},
-    {header: this.translateService.stream('Employee no'), field: 'employeeNo'},
     {header: this.translateService.stream('Area'), field: 'itemName'},
     {header: this.translateService.stream('Pictures'), field: 'imagesCount', type: 'button', buttons: [
         {


### PR DESCRIPTION
## Summary

- **Rename translation**: Danish `'Indsendt dato'` → `'Udført dato'` for the `Submitted date` key in `da.ts`. This affects the reportsv2 table header, case page, compliance case page, and compliance case modal.
- **Remove column**: Drop `Medarbejder nummer` (employeeNo) from both `tableHeaders` and `adminTableHeaders` in `report-table.component.ts`.

## Test plan

- [ ] Open reportsv2 table in Danish locale — header now reads "Udført dato" instead of "Indsendt dato"
- [ ] Confirm "Medarbejder nummer" column no longer appears for both regular and admin table views
- [ ] Smoke-check compliance case page and modal show updated label

🤖 Generated with [Claude Code](https://claude.com/claude-code)