### PR TITLE
fix: block startup on SeedEForms to prevent CI race conditions

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -27,6 +27,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using BackendConfiguration.Pn.Infrastructure.Helpers;
 using BackendConfiguration.Pn.Infrastructure.Models.TaskManagement;
 using Microting.eForm.Infrastructure.Models;

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -172,7 +172,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
         // removes the implicit registration.
         services.AddMemoryCache();
         services.AddControllers();
-        SeedEForms(services);
+        SeedEForms(services).GetAwaiter().GetResult();
         // QuestPDF 2202.8+ is fully open-source; no license configuration needed.
     }
 
@@ -203,7 +203,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
             .ValidateDataAnnotations();
     }
 
-    private static async void SeedEForms(IServiceCollection services)
+    private static async Task SeedEForms(IServiceCollection services)
     {
         var serviceProvider = services.BuildServiceProvider();
 


### PR DESCRIPTION
## Summary

- Changes `SeedEForms` from `async void` (fire-and-forget) to `async Task` + `.GetAwaiter().GetResult()` to ensure seeding completes before the host starts serving requests
- Eliminates the race condition where CI's `wait-on` passed the HTTP health check while 14 eforms were still being written to the DB, causing intermittent 40s Playwright timeouts in property dropdown selection
- Follows the pattern already used by `RunIfNeededAsync()` at line 802 of the same file

## Test plan

- [ ] CI Playwright tests pass (shards c, d, g, l were previously failing)
- [ ] Backend starts and serves requests normally after seeding completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)