### PR TITLE
feat(calendar): per-language Title & Description in the task modal (auto-translated)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarMultiLanguageTitleDescriptionTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarMultiLanguageTitleDescriptionTests.cs
@@ -1,0 +1,182 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction.
+*/
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+using System.Globalization;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+
+/// <summary>
+/// Verifies the calendar read path surfaces per-language Title AND Description
+/// (AreaRuleTranslation.Name / .Description, added in base 10.0.42). A task with
+/// Danish/English/German translations must render in the CALLER's language and
+/// expose all translations for edit-mode prefill.
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarMultiLanguageTitleDescriptionTests : TestBaseSetup
+{
+    private static string IsoUtc(DateTime d) =>
+        DateTime.SpecifyKind(d, DateTimeKind.Utc).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+    [SetUp]
+    public async Task CleanState()
+    {
+        BackendConfigurationPnDbContext!.AreaRuleTranslations.RemoveRange(BackendConfigurationPnDbContext.AreaRuleTranslations);
+        BackendConfigurationPnDbContext.CalendarConfigurations.RemoveRange(BackendConfigurationPnDbContext.CalendarConfigurations);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        BackendConfigurationPnDbContext.AreaRulePlannings.RemoveRange(BackendConfigurationPnDbContext.AreaRulePlannings);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        BackendConfigurationPnDbContext.AreaRules.RemoveRange(BackendConfigurationPnDbContext.AreaRules);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        BackendConfigurationPnDbContext.Areas.RemoveRange(BackendConfigurationPnDbContext.Areas);
+        BackendConfigurationPnDbContext.Properties.RemoveRange(BackendConfigurationPnDbContext.Properties);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        ItemsPlanningPnDbContext!.Plannings.RemoveRange(ItemsPlanningPnDbContext.Plannings);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+    }
+
+    private sealed record Langs(int Da, int En, int De);
+
+    // Ensure da/en/de languages exist; return their ids.
+    private async Task<Langs> EnsureLanguages()
+    {
+        async Task<int> Ensure(string name, string code)
+        {
+            var existing = await MicrotingDbContext!.Languages
+                .FirstOrDefaultAsync(x => x.LanguageCode == code);
+            if (existing != null) return existing.Id;
+            var lang = new Language { Name = name, LanguageCode = code, IsActive = true };
+            await MicrotingDbContext.Languages.AddAsync(lang);
+            await MicrotingDbContext.SaveChangesAsync();
+            return lang.Id;
+        }
+        return new Langs(await Ensure("Dansk", "da"), await Ensure("English", "en-US"), await Ensure("Deutsch", "de-DE"));
+    }
+
+    [Test]
+    public async Task GetTasksForWeek_ReturnsCallerLanguageTitleDescription_AndAllTranslations()
+    {
+        var core = await GetCore();
+        var langs = await EnsureLanguages();
+
+        var sdkSite = new Site
+        {
+            Name = $"ml-site-{Guid.NewGuid()}", MicrotingUid = 7711,
+            LanguageId = langs.De, WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext!.Sites.AddAsync(sdkSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var area = new Area { Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property { Name = $"MlProp-{Guid.NewGuid()}", ItemPlanningTagId = 0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule { AreaId = area.Id, PropertyId = property.Id, EformId = 0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // Three per-language translations, each carrying BOTH name and description.
+        foreach (var (langId, name, desc) in new[]
+                 {
+                     (langs.Da, "Tank 4 inspektion", "Kontrollér ventiler og noter tryk."),
+                     (langs.En, "Tank 4 inspection", "Check valves and note the pressure."),
+                     (langs.De, "Tank 4 Inspektion", "Ventile prüfen und den Druck notieren."),
+                 })
+        {
+            await BackendConfigurationPnDbContext.AreaRuleTranslations.AddAsync(new AreaRuleTranslation
+            { AreaRuleId = areaRule.Id, LanguageId = langId, Name = name, Description = desc, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 });
+        }
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var startDate = new DateTime(2026, 6, 6, 0, 0, 0, DateTimeKind.Utc); // 1st Saturday of June 2026
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Month, StartDate = startDate,
+            DayOfMonth = 0, Description = "Kontrollér ventiler og noter tryk.", RelatedEFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id, ItemPlanningId = planning.Id,
+            StartDate = startDate, Status = true, RepeatType = 3, RepeatEvery = 1,
+            RepeatOrdinalWeek = 1, DayOfWeek = 6, // 1st Saturday
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(new CalendarConfiguration
+        { AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 });
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // Caller language = German.
+        var svc = BuildService(core, langs.De);
+        var weekStart = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc); // Mon containing Sat 6 Jun
+        var res = await svc.GetTasksForWeek(new CalendarTaskRequestModel
+        {
+            PropertyId = property.Id, WeekStart = IsoUtc(weekStart),
+            WeekEnd = IsoUtc(weekStart.AddDays(6).AddHours(23).AddMinutes(59)),
+            ActionableOnly = false, BoardIds = [], TagNames = [], SiteIds = []
+        });
+
+        Assert.That(res.Success, Is.True, res.Message);
+        var tile = res.Model!.SingleOrDefault(t => t.TaskDate == "2026-06-06");
+        Assert.That(tile, Is.Not.Null, "expected one tile on Sat 6 Jun");
+
+        // Rendered in the caller (German) language.
+        Assert.That(tile!.Title, Is.EqualTo("Tank 4 Inspektion"), "title in caller language");
+        Assert.That(tile.DescriptionHtml, Is.EqualTo("Ventile prüfen und den Druck notieren."), "description in caller language");
+
+        // All three translations exposed for edit-mode prefill, each with name + description.
+        Assert.That(tile.Translations.Count, Is.EqualTo(3));
+        var en = tile.Translations.Single(t => t.LanguageId == langs.En);
+        Assert.That(en.Name, Is.EqualTo("Tank 4 inspection"));
+        Assert.That(en.Description, Is.EqualTo("Check valves and note the pressure."));
+        var da = tile.Translations.Single(t => t.LanguageId == langs.Da);
+        Assert.That(da.Description, Is.EqualTo("Kontrollér ventiler og noter tryk."));
+    }
+
+    private BackendConfigurationCalendarService BuildService(eFormCore.Core core, int callerLanguageId)
+    {
+        var language = MicrotingDbContext!.Languages.First(x => x.Id == callerLanguageId);
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        userService.GetCurrentUserLanguage().Returns(Task.FromResult(language));
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+        var taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        return new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(), userService,
+            BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext!, taskWizardService,
+            NullLogger<BackendConfigurationCalendarService>.Instance);
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/SQL/420_eform-backend-configuration-plugin.sql
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/SQL/420_eform-backend-configuration-plugin.sql
@@ -564,6 +564,7 @@ DROP TABLE IF EXISTS `AreaRuleTranslations`;
 CREATE TABLE `AreaRuleTranslations` (
   `Id` int(11) NOT NULL AUTO_INCREMENT,
   `Name` varchar(250) DEFAULT NULL,
+  `Description` longtext DEFAULT NULL,
   `LanguageId` int(11) NOT NULL,
   `AreaRuleId` int(11) NOT NULL,
   `CreatedAt` datetime(6) NOT NULL,

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -281,7 +281,7 @@
     <PackageReference Include="Microting.EformAngularFrontendBase" Version="10.0.35" />
     <PackageReference Include="Microting.eFormApi.BasePn" Version="10.0.28" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
-    <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.41" />
+    <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.42" />
     <PackageReference Include="Microting.eFormCaseTemplateBase" Version="10.0.32" />
     <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.33" />
     <PackageReference Include="Microting.TimePlanningBase" Version="10.0.50" />

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/PropertiesController.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/PropertiesController.cs
@@ -132,7 +132,7 @@ public class PropertiesController : Controller
 
     [HttpGet]
     [Route("get-linked-sites")]
-    public async Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedSites(int? propertyId, bool compliance)
+    public async Task<OperationDataResult<List<SiteLanguageDictionaryModel>>> GetLinkedSites(int? propertyId, bool compliance)
     {
         return await _backendConfigurationPropertiesService.GetLinkedSites(propertyId, compliance);
     }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microting.eForm.Infrastructure.Models;
 
 namespace BackendConfiguration.Pn.Infrastructure.Models.Calendar;
 
@@ -41,6 +42,14 @@ public class CalendarTaskResponseModel
     public int? SdkCaseId { get; set; }
     public int? ItemPlanningTagId { get; set; }
     public string? DescriptionHtml { get; set; }
+
+    /// <summary>
+    /// Per-language Title + Description for the task's AreaRule, so the edit
+    /// modal can pre-fill the multi-language fields. Empty for compliance/orphan
+    /// rows that have no AreaRule. The single Title/DescriptionHtml above remain
+    /// the caller-language values used for rendering.
+    /// </summary>
+    public List<CommonTranslationsModel> Translations { get; set; } = [];
     public List<CalendarTaskAttachmentDto> Attachments { get; set; } = new();
 
     /// <summary>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Properties/SiteLanguageDictionaryModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Properties/SiteLanguageDictionaryModel.cs
@@ -1,0 +1,15 @@
+namespace BackendConfiguration.Pn.Infrastructure.Models.Properties;
+
+using Microting.eFormApi.BasePn.Infrastructure.Models.Common;
+
+/// <summary>
+/// A linked-site dictionary entry that also carries the worker's SDK language id,
+/// so the calendar task modal can derive which languages the assigned workers use
+/// (multi-language Title/Description). Extends <see cref="CommonDictionaryModel"/>
+/// so existing consumers that read only Id/Name keep working; the extra
+/// LanguageId is simply an additional JSON field for callers that want it.
+/// </summary>
+public class SiteLanguageDictionaryModel : CommonDictionaryModel
+{
+    public int LanguageId { get; set; }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -503,6 +503,15 @@ public class BackendConfigurationCalendarService(
                     .Select(t => t.Name)
                     .FirstOrDefault() ?? arp.AreaRule?.AreaRuleTranslations?.FirstOrDefault()?.Name ?? "";
 
+                // Per-language title+description for edit-mode prefill, plus the
+                // caller-language description (same selection as the title above).
+                var translations = arp.AreaRule?.AreaRuleTranslations?
+                    .Where(t => t.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(t => new CommonTranslationsModel { Id = t.Id, LanguageId = t.LanguageId, Name = t.Name, Description = t.Description })
+                    .ToList() ?? [];
+                var description = translations.FirstOrDefault(t => t.LanguageId == userLanguageId)?.Description
+                    ?? translations.FirstOrDefault()?.Description ?? planning.Description;
+
                 var tags = allArpTags
                     .Where(x => x.AreaRulePlanningId == arp.Id)
                     .Select(x => planningTagNames.TryGetValue(x.ItemPlanningTagId, out var name) ? name : null)
@@ -589,7 +598,8 @@ public class BackendConfigurationCalendarService(
                         ExceptionId = exception?.Id,
                         EformId = arp.AreaRule?.EformId,
                         ItemPlanningTagId = arp.ItemPlanningTagId,
-                        DescriptionHtml = planning.Description,
+                        DescriptionHtml = description,
+                        Translations = translations,
                         Attachments = MapAttachments(arp)
                     };
 
@@ -692,7 +702,8 @@ public class BackendConfigurationCalendarService(
                             ExceptionId = orphan.Id,
                             EformId = arp.AreaRule?.EformId,
                             ItemPlanningTagId = arp.ItemPlanningTagId,
-                            DescriptionHtml = planning.Description,
+                            DescriptionHtml = description,
+                            Translations = translations,
                             Attachments = MapAttachments(arp)
                         };
 
@@ -722,6 +733,13 @@ public class BackendConfigurationCalendarService(
                     .Where(t => t.LanguageId == userLanguageId)
                     .Select(t => t.Name)
                     .FirstOrDefault() ?? arp.AreaRule?.AreaRuleTranslations?.FirstOrDefault()?.Name ?? "";
+
+                var translations = arp.AreaRule?.AreaRuleTranslations?
+                    .Where(t => t.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(t => new CommonTranslationsModel { Id = t.Id, LanguageId = t.LanguageId, Name = t.Name, Description = t.Description })
+                    .ToList() ?? [];
+                var description = translations.FirstOrDefault(t => t.LanguageId == userLanguageId)?.Description
+                    ?? translations.FirstOrDefault()?.Description ?? movedPlanning.Description;
 
                 var movedTags = allArpTags
                     .Where(x => x.AreaRulePlanningId == arp.Id)
@@ -773,7 +791,8 @@ public class BackendConfigurationCalendarService(
                     ExceptionId = movedIn.Id,
                     EformId = arp.AreaRule?.EformId,
                     ItemPlanningTagId = arp.ItemPlanningTagId,
-                    DescriptionHtml = movedPlanning.Description,
+                    DescriptionHtml = description,
+                    Translations = translations,
                     Attachments = MapAttachments(arp)
                 };
 
@@ -890,6 +909,13 @@ public class BackendConfigurationCalendarService(
                         .FirstOrDefault() ?? title;
                 }
 
+                // Per-language title+description so the edit modal can prefill a
+                // compliance-backed (past) task's multi-language fields.
+                var complianceTranslations = arp?.AreaRule?.AreaRuleTranslations?
+                    .Where(t => t.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(t => new CommonTranslationsModel { Id = t.Id, LanguageId = t.LanguageId, Name = t.Name, Description = t.Description })
+                    .ToList() ?? [];
+
                 var tags = arp != null
                     ? complianceArpTags
                         .Where(x => x.AreaRulePlanningId == arp.Id)
@@ -978,6 +1004,7 @@ public class BackendConfigurationCalendarService(
                     DescriptionHtml = compliancePlanningsDict.TryGetValue(compliance.PlanningId, out var cp)
                         ? cp.Description
                         : null,
+                    Translations = complianceTranslations,
                     Attachments = MapAttachments(arp),
                     ExceptionId = complianceException?.Id,
                 };

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationPropertiesService/BackendConfigurationPropertiesService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationPropertiesService/BackendConfigurationPropertiesService.cs
@@ -698,7 +698,7 @@ public class BackendConfigurationPropertiesService(
         }
     }
 
-    public async Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedSites(int? propertyId, bool compliance)
+    public async Task<OperationDataResult<List<SiteLanguageDictionaryModel>>> GetLinkedSites(int? propertyId, bool compliance)
     {
         try
         {
@@ -730,22 +730,23 @@ public class BackendConfigurationPropertiesService(
             var sites = await sdkDbContext.Sites
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                 .Where(x => siteIds.Contains(x.Id))
-                .Select(x => new CommonDictionaryModel
+                .Select(x => new SiteLanguageDictionaryModel
                 {
                     Name = x.Name,
-                    Id = x.Id
+                    Id = x.Id,
+                    LanguageId = x.LanguageId
                 })
                 .OrderBy(x => x.Name)
                 .ToListAsync();
 
-            return new OperationDataResult<List<CommonDictionaryModel>>(true, sites);
+            return new OperationDataResult<List<SiteLanguageDictionaryModel>>(true, sites);
         }
         catch (Exception e)
         {
             SentrySdk.CaptureException(e);
             logger.LogError(e.Message);
             logger.LogTrace(e.StackTrace);
-            return new OperationDataResult<List<CommonDictionaryModel>>(false, e.Message);
+            return new OperationDataResult<List<SiteLanguageDictionaryModel>>(false, e.Message);
         }
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationPropertiesService/IBackendConfigurationPropertiesService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationPropertiesService/IBackendConfigurationPropertiesService.cs
@@ -49,6 +49,6 @@ public interface IBackendConfigurationPropertiesService
     Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedFoldersList(List<int> propertyIds);
     Task<OperationDataResult<List<PropertyFolderModel>>> GetLinkedFolderDtos(int propertyId);
     Task<OperationDataResult<List<PropertyFolderModel>>> GetLinkedFolderDtos(List<int> propertyIds);
-    Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedSites(int? propertyId, bool compliance);
+    Task<OperationDataResult<List<SiteLanguageDictionaryModel>>> GetLinkedSites(int? propertyId, bool compliance);
     Task<OperationDataResult<List<CommonDictionaryModel>>> GetLinkedSites(List<int>? propertyId);
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskWizardService/BackendConfigurationTaskWizardService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskWizardService/BackendConfigurationTaskWizardService.cs
@@ -301,7 +301,7 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                     PropertyId = x.PropertyId,
                     Translations = x.AreaRule.AreaRuleTranslations
                         .Select(y => new CommonTranslationsModel()
-                            { Id = y.Id, LanguageId = y.LanguageId, Name = y.Name })
+                            { Id = y.Id, LanguageId = y.LanguageId, Name = y.Name, Description = y.Description })
                         .ToList(),
                     RepeatEvery = (int)x.RepeatEvery,
                     StartDate = (DateTime)x.StartDate,
@@ -522,6 +522,7 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                     .Select(t => new AreaRuleTranslation
                     {
                         Name = t.Name,
+                        Description = t.Description,
                         LanguageId = t.LanguageId,
                         UpdatedByUserId = _userService.UserId,
                         CreatedByUserId = _userService.UserId
@@ -833,9 +834,10 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                         && nt.WorkflowState != Constants.WorkflowStates.Removed);
                 if (existing != null)
                 {
-                    if (existing.Name != t.Name)
+                    if (existing.Name != t.Name || existing.Description != t.Description)
                     {
                         existing.Name = t.Name;
+                        existing.Description = t.Description;
                         existing.UpdatedByUserId = _userService.UserId;
                         await existing.Update(_backendConfigurationPnDbContext);
                     }
@@ -845,6 +847,7 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                     await new AreaRuleTranslation
                     {
                         Name = t.Name,
+                        Description = t.Description,
                         LanguageId = t.LanguageId,
                         AreaRuleId = areaRulePlanning.AreaRuleId,
                         CreatedByUserId = _userService.UserId,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -422,6 +422,7 @@ export const enUS= {
   'year': 'year',
   // Modal labels
   'Title': 'Title',
+  'Translate': 'Translate',
   'Set tags...': 'Set tags...',
   'Assign to...': 'Assign to...',
   'Add description': 'Add description',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
@@ -22,6 +22,9 @@ export interface CalendarTaskModel {
   boardId: number;
   color: string;
   descriptionHtml: string;
+  // Per-language Title + Description for edit-mode prefill of the multi-language
+  // fields (mirrors the backend CalendarTaskResponseModel.Translations).
+  translations?: { languageId: number; name: string; description: string }[];
   repeatRule: CalendarRepeatRule;
   repeatMeta?: CalendarRepeatMeta;
   taskDate: string;          // ISO "YYYY-MM-DD"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
@@ -11,10 +11,34 @@
     <div class="gcal-row">
       <mat-icon class="gcal-icon gcal-icon--hidden">schedule</mat-icon>
       <div class="gcal-row-content">
-        <mat-form-field class="w-100">
+        <mat-form-field class="w-100 gcal-translatable-field">
           <mat-label>{{ 'Title' | translate }}</mat-label>
           <input matInput id="calendarEventTitle" [formControl]="titleControl" autocomplete="off">
+          <button mat-icon-button matIconSuffix type="button"
+                  *ngIf="showTranslate"
+                  id="calendarEventTitleTranslate"
+                  class="gcal-translate-btn"
+                  [matTooltip]="'Translate' | translate"
+                  (click)="toggleTitleTranslate(); $event.stopPropagation()">
+            <mat-icon>translate</mat-icon>
+          </button>
         </mat-form-field>
+
+        <!-- Per-language Title fields (Danish above is the source) -->
+        <div class="gcal-translate-fields" *ngIf="showTranslate && titleTranslateExpanded">
+          <mat-form-field class="w-100 gcal-translatable-field" *ngFor="let lang of targetLanguages">
+            <mat-label>{{ 'Title' | translate }} ({{ lang.name }})</mat-label>
+            <input matInput autocomplete="off"
+                   [ngModel]="titleByLang[lang.id]"
+                   (ngModelChange)="titleByLang[lang.id] = $event">
+            <button mat-icon-button matIconSuffix type="button"
+                    class="gcal-translate-btn"
+                    [matTooltip]="'Translate' | translate"
+                    (click)="retranslateField('title', lang.id); $event.stopPropagation()">
+              <mat-icon>autorenew</mat-icon>
+            </button>
+          </mat-form-field>
+        </div>
       </div>
     </div>
 
@@ -234,12 +258,36 @@
     <div class="gcal-row">
       <mat-icon class="gcal-icon">notes</mat-icon>
       <div class="gcal-row-content">
-        <mat-form-field class="w-100 gcal-description-field">
+        <mat-form-field class="w-100 gcal-description-field gcal-translatable-field">
           <mat-label>{{ 'Add description' | translate }}</mat-label>
           <textarea #descriptionTextarea id="calendarEventDescription" class="gcal-description-textarea" matInput
                     [formControl]="descriptionControl" rows="2"
                     (input)="autoGrowTextarea($event)"></textarea>
+          <button mat-icon-button matIconSuffix type="button"
+                  *ngIf="showTranslate"
+                  id="calendarEventDescriptionTranslate"
+                  class="gcal-translate-btn"
+                  [matTooltip]="'Translate' | translate"
+                  (click)="toggleDescTranslate(); $event.stopPropagation()">
+            <mat-icon>translate</mat-icon>
+          </button>
         </mat-form-field>
+
+        <!-- Per-language Description fields (Danish above is the source) -->
+        <div class="gcal-translate-fields" *ngIf="showTranslate && descTranslateExpanded">
+          <mat-form-field class="w-100 gcal-description-field gcal-translatable-field" *ngFor="let lang of targetLanguages">
+            <mat-label>{{ 'Description' | translate }} ({{ lang.name }})</mat-label>
+            <textarea matInput rows="2"
+                      [ngModel]="descByLang[lang.id]"
+                      (ngModelChange)="descByLang[lang.id] = $event"></textarea>
+            <button mat-icon-button matIconSuffix type="button"
+                    class="gcal-translate-btn"
+                    [matTooltip]="'Translate' | translate"
+                    (click)="retranslateField('desc', lang.id); $event.stopPropagation()">
+              <mat-icon>autorenew</mat-icon>
+            </button>
+          </mat-form-field>
+        </div>
       </div>
     </div>
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
@@ -419,3 +419,35 @@ mat-form-field.w-100.mat-mdc-form-field-type-mtx-select {
   font-style: italic;
   padding: 4px 0;
 }
+
+// ---- Per-language Title & Description translate UI -----------------------
+
+// The translate / re-translate icon button sits as a suffix inside the field.
+// Keep it compact and visually muted so it reads as a secondary action.
+.gcal-translate-btn {
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  color: rgba(0, 0, 0, 0.54);
+
+  .mat-icon {
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+  }
+
+  &:hover {
+    color: rgba(0, 0, 0, 0.78);
+  }
+}
+
+// Stacked per-language fields rendered below the Danish source field. A small
+// left inset visually nests them under the source as "translations of it".
+.gcal-translate-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 2px;
+  padding-left: 12px;
+  border-left: 2px solid rgba(0, 0, 0, 0.08);
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -11,12 +11,16 @@ import {EformVisualEditorService} from 'src/app/common/services';
 import {EformFieldTypesEnum} from 'src/app/common/const/eform-field-types';
 import {Store} from '@ngrx/store';
 import {selectCurrentUserLanguageId} from 'src/app/state/auth/auth.selector';
+import {selectLanguages} from 'src/app/state/application-settings/application-settings.selector';
+import {LanguagesModel} from 'src/app/common/models';
+import {TranslationService, TranslationRequestModel} from 'src/app/common/services/translation.service';
 import {
   BackendConfigurationPnCalendarFilesService,
   BackendConfigurationPnCalendarService,
   BackendConfigurationPnGoogleDriveService,
   BackendConfigurationPnPropertiesService,
 } from '../../../../services';
+import {LinkedSiteModel} from '../../../../services/backend-configuration-pn-properties.service';
 import {ItemsPlanningPnTagsService} from 'src/app/plugins/modules/items-planning-pn/services/items-planning-pn-tags.service';
 import {
   CALENDAR_COLORS,
@@ -83,7 +87,24 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
   isLoadingTemplate = false;
   showEformDetails = false;
   showMiniPicker = false;
-  filteredEmployees: CommonDictionaryModel[] = [];
+  filteredEmployees: LinkedSiteModel[] = [];
+
+  // ---- Per-language Title & Description state ----
+  // Active languages from the app-settings store (filtered to isActive).
+  private activeLanguages: { id: number; code: string; name: string }[] = [];
+  // Distinct non-Danish languages spoken by the currently-selected assignees,
+  // resolved to {id, code, name}. Drives the translate button + per-lang fields.
+  targetLanguages: { id: number; code: string; name: string }[] = [];
+  // Per-language Title/Description values, keyed by languageId. Danish (1) lives
+  // in titleControl/descriptionControl; these hold the non-Danish targets.
+  titleByLang: Record<number, string> = {};
+  descByLang: Record<number, string> = {};
+  // Whether the stacked per-language fields are revealed for each group.
+  titleTranslateExpanded = false;
+  descTranslateExpanded = false;
+  /** Cached result of TranslationService.translationPossible() (Google config). */
+  private translationConfigured = false;
+
   private customRepeatMeta: CalendarRepeatMeta | null = null;
   // Last concrete repeat selection before 'custom' was picked, so cancelling
   // the Tilpasset… dialog can restore the prior preset instead of 'none' (#922).
@@ -143,6 +164,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
     private tagsService: ItemsPlanningPnTagsService,
     private filesService: BackendConfigurationPnCalendarFilesService,
     private googleDriveService: BackendConfigurationPnGoogleDriveService,
+    private translationService: TranslationService,
   ) {}
 
   addPlanningTag = (name: string): Promise<{id: number; name: string}> => {
@@ -223,6 +245,21 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       this.currentLanguageId = langId ?? 1;
     });
 
+    // Load the active languages list (id/code/name) from the app-settings store.
+    // Used to resolve each assignee's languageId to a translatable target.
+    this.store.select(selectLanguages).pipe(take(1)).subscribe((model: LanguagesModel) => {
+      this.activeLanguages = (model?.languages ?? [])
+        .filter(l => l.isActive)
+        .map(l => ({id: l.id, code: l.languageCode, name: l.name}));
+      this.recomputeTargetLanguages();
+    });
+
+    // Cache whether Google Translate is configured so the translate action can
+    // decide between auto-fill and just revealing empty editable fields.
+    this.translationService.translationPossible().pipe(take(1)).subscribe(res => {
+      this.translationConfigured = !!(res && res.success && res.model);
+    });
+
     this.isEditMode = !!this.data.task;
     this.timeSlots = this.generateTimeSlots();
     this.filteredBoards = this.data.boards;
@@ -267,6 +304,11 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       this.assigneeControl.setValue(task.assigneeIds ?? []);
       this.tagsControl.setValue(task.tags ?? []);
       this.descriptionControl.setValue(task.descriptionHtml ?? '');
+      // Prefill the per-language Title/Description fields from the saved
+      // translations. Danish (1) seeds the source controls (fall back to the
+      // single title/descriptionHtml); non-Danish entries seed the maps and
+      // auto-expand so the saved translations are visible.
+      this.prefillTranslations(task);
       this.driveLinkControl.setValue(task.driveLink ?? '');
       this.showDriveInput = !!task.driveLink;
       this.boardControl.setValue(task.boardId ?? null);
@@ -399,6 +441,10 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       this.assigneeControl.setValue([]);
     });
 
+    // Recompute the per-language target set whenever the assignee selection
+    // changes — adding/removing a worker can add/remove a language field.
+    this.assigneeControl.valueChanges.subscribe(() => this.recomputeTargetLanguages());
+
     // Load eForm template details when selection changes
     // Use switchMap so rapid eForm switches cancel any in-flight getSingle()
     // and we never overwrite the current selection with a stale response.
@@ -469,6 +515,121 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
     this.propertiesService.getLinkedSites(propertyId, false).subscribe(res => {
       if (res && res.success && res.model) {
         this.filteredEmployees = res.model;
+        // Sites (and their languages) are now known — re-resolve the target set
+        // so a pre-seeded (edit/copy mode) assignee selection lights up.
+        this.recomputeTargetLanguages();
+      }
+    });
+  }
+
+  // ---- Per-language Title & Description -----------------------------------
+
+  /** True when at least one non-Danish target language is in play. */
+  get showTranslate(): boolean {
+    return this.targetLanguages.length > 0;
+  }
+
+  /**
+   * Resolve the distinct languages of the currently-selected assignees
+   * (site ids → filteredEmployees[].languageId), drop Danish (id 1), and map
+   * each to the active-languages {id, code, name}. Languages not present in the
+   * active-languages list (or with no code) are skipped. Preserves any text
+   * already typed for a still-present language; collapses the expanded fields
+   * if the target set becomes empty.
+   */
+  private recomputeTargetLanguages(): void {
+    const selectedIds = this.assigneeControl.value ?? [];
+    const langIds = new Set<number>();
+    for (const id of selectedIds) {
+      const site = this.filteredEmployees.find(e => e.id === id);
+      if (site && site.languageId && site.languageId !== 1) {
+        langIds.add(site.languageId);
+      }
+    }
+    const resolved: { id: number; code: string; name: string }[] = [];
+    for (const langId of langIds) {
+      const lang = this.activeLanguages.find(l => l.id === langId);
+      if (lang && lang.code) {
+        resolved.push(lang);
+      }
+    }
+    this.targetLanguages = resolved;
+    if (this.targetLanguages.length === 0) {
+      this.titleTranslateExpanded = false;
+      this.descTranslateExpanded = false;
+    }
+  }
+
+  /** Seed the per-language maps + source controls from saved task.translations. */
+  private prefillTranslations(task: CalendarTaskModel): void {
+    const translations = task.translations ?? [];
+    if (translations.length === 0) return;
+    const danish = translations.find(t => t.languageId === 1);
+    if (danish) {
+      this.titleControl.setValue(danish.name ?? task.title ?? '');
+      this.descriptionControl.setValue(danish.description ?? task.descriptionHtml ?? '');
+    }
+    let hasTitleTarget = false;
+    let hasDescTarget = false;
+    for (const t of translations) {
+      if (t.languageId === 1) continue;
+      this.titleByLang[t.languageId] = t.name ?? '';
+      this.descByLang[t.languageId] = t.description ?? '';
+      if (t.name) hasTitleTarget = true;
+      if (t.description) hasDescTarget = true;
+    }
+    if (hasTitleTarget) this.titleTranslateExpanded = true;
+    if (hasDescTarget) this.descTranslateExpanded = true;
+  }
+
+  /** Reveal the per-language Title fields and (re-)translate every target. */
+  toggleTitleTranslate(): void {
+    this.titleTranslateExpanded = true;
+    this.translateAll('title');
+  }
+
+  /** Reveal the per-language Description fields and (re-)translate every target. */
+  toggleDescTranslate(): void {
+    this.descTranslateExpanded = true;
+    this.translateAll('desc');
+  }
+
+  /**
+   * Translate the Danish source of the given field into every target language.
+   * No-op auto-fill when translation isn't configured (fields stay editable but
+   * empty) or when the Danish source is empty.
+   */
+  private translateAll(kind: 'title' | 'desc'): void {
+    for (const lang of this.targetLanguages) {
+      this.translateField(kind, lang);
+    }
+  }
+
+  /** Re-translate a single field for a single language (the per-field ↻). */
+  retranslateField(kind: 'title' | 'desc', languageId: number): void {
+    const lang = this.targetLanguages.find(l => l.id === languageId);
+    if (lang) {
+      this.translateField(kind, lang);
+    }
+  }
+
+  private translateField(kind: 'title' | 'desc', lang: { id: number; code: string; name: string }): void {
+    if (!this.translationConfigured) return;
+    const source = kind === 'title'
+      ? (this.titleControl.value ?? '')
+      : (this.descriptionControl.value ?? '');
+    if (!source.trim()) return;
+    this.translationService.getTranslation(new TranslationRequestModel({
+      sourceText: source,
+      sourceLanguageCode: 'da',
+      targetLanguageCode: lang.code,
+    })).subscribe(res => {
+      if (res && res.success) {
+        if (kind === 'title') {
+          this.titleByLang[lang.id] = res.model ?? '';
+        } else {
+          this.descByLang[lang.id] = res.model ?? '';
+        }
       }
     });
   }
@@ -730,9 +891,25 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       }
     }
 
+    // Build the per-language Translates array: Danish source (languageId 1)
+    // always included, plus one entry per target language that has a non-empty
+    // title OR description. Empty targets are dropped (not persisted).
+    const danishName = this.titleControl.value ?? '';
+    const danishDescription = this.descriptionControl.value ?? '';
+    const translates: { name: string; description: string; languageId: number }[] = [
+      {name: danishName, description: danishDescription, languageId: 1},
+    ];
+    for (const lang of this.targetLanguages) {
+      const name = this.titleByLang[lang.id] ?? '';
+      const description = this.descByLang[lang.id] ?? '';
+      if (name || description) {
+        translates.push({name, description, languageId: lang.id});
+      }
+    }
+
     const payload: any = {
       // Backend CalendarTaskCreateRequestModel fields
-      translates: [{name: this.titleControl.value, languageId: 1}],
+      translates,
       // Send the date-only string (local Y-M-D), NOT the raw Date — a raw Date
       // is JSON-serialised via toISOString(), which shifts a local-midnight pick
       // by the browser's UTC offset (UTC+2 "Fri 3 Jul" → 2026-07-02T22:00Z) and

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-properties.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-properties.service.ts
@@ -18,6 +18,15 @@ import {
 } from '../models';
 import { ApiBaseService } from 'src/app/common/services';
 
+// Linked-site dictionary entry, extended with the site's language so the
+// calendar modal can derive per-worker target languages. Mirrors the backend
+// SiteLanguageDictionaryModel { Id, Name, LanguageId }. Extends
+// CommonDictionaryModel so existing getLinkedSites consumers that expect a
+// CommonDictionaryModel[] keep type-checking; calendar uses `languageId`.
+export interface LinkedSiteModel extends CommonDictionaryModel {
+  languageId: number;
+}
+
 export let BackendConfigurationPnPropertiesMethods = {
   Properties: 'api/backend-configuration-pn/properties',
   PropertyAreas: 'api/backend-configuration-pn/property-areas',
@@ -220,7 +229,7 @@ export class BackendConfigurationPnPropertiesService {
     );
   }
 
-  getLinkedSites(id: number, compliance: boolean): Observable<OperationDataResult<CommonDictionaryModel[]>> {
+  getLinkedSites(id: number, compliance: boolean): Observable<OperationDataResult<LinkedSiteModel[]>> {
     return this.apiBaseService.get(
       BackendConfigurationPnPropertiesMethods.GetLinkedSites,
       { propertyId: id, compliance: compliance}


### PR DESCRIPTION
## Summary

When the assigned property-workers speak more than one language, the calendar task create/edit modal (`/plugins/backend-configuration-pn/calendar`) shows a **translate button** next to **Title** and **Description**. Pressing it reveals one field per non-Danish worker language, **auto-filled from the Danish source via the existing Google Translate integration**, and persists a title + description **per language** so each worker sees the task in their own language.

Danish is always the source. The button appears only when the selected assignees include a non-Danish language. Each target field is editable, with a per-field re-translate.

## Requires base 10.0.42

Depends on **`Microting.EformBackendConfigurationBase` 10.0.42** (microting/eform-backendconfiguration-base#861), which adds the nullable `AreaRuleTranslation.Description` column. **Greenfield — no data backfill, no legacy fallback** (per product decision).

## Backend

- **TaskWizardService** writes `Description` per language alongside `Name` in the `AreaRuleTranslation` create/update loops; `GetTaskById` returns it too.
- **GetTasksForWeek** returns a per-language `Translations` list (`Name`+`Description`) on every task build site — recurrence, orphan, moved-in, **and compliance** — plus the caller-language description, for edit-mode prefill. `WorkerNames` untouched.
- **GetLinkedSites(int?,bool)** now returns `SiteLanguageDictionaryModel` (a `CommonDictionaryModel` subclass carrying `LanguageId`) so the modal can derive worker languages; the other overload is unchanged.

## Frontend

- Translate buttons on Title/Description, stacked per-language fields, **live** target-language derivation from the assignee selection, Google Translate calls (`sourceLanguageCode: 'da'`), per-field re-translate, edit-mode prefill from `task.translations`, multi-entry `translates` payload.
- New `Translate` key in `enUS.ts` (auto-translation pipeline propagates to other locales).

## Testing

- New Testcontainers integration test asserts the calendar read returns the **caller-language** title+description and the **full `Translations` list** (Name+Description per language). Existing calendar read-path tests (`CalendarThisAndFollowingMoveBackReproTests`) stay green.
- Source plugin builds clean (0 errors).

Spec/mockup: `docs/superpowers/specs/2026-06-08-…` (workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)