### PR TITLE
fix(seed): resolve AreaTranslation LanguageId from SDK languages by code

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -610,10 +610,33 @@ public class EformBackendConfigurationPlugin : IEformPlugin
             }
         }
 
+        // Seed data hardcodes AreaTranslation.LanguageId as 1=da, 2=en-US, 3=de-DE, but the
+        // SDK Languages table uses environment-specific auto-increment ids. Resolve the real
+        // SDK language id by code so translations point at languages that actually exist.
+        var sdkLanguagesForAreaSeed = await sdkDbContext.Languages.ToListAsync().ConfigureAwait(false);
+        var seedLanguageIdToCode = new Dictionary<int, string> { { 1, "da" }, { 2, "en-US" }, { 3, "de-DE" } };
+        var seedLanguageIdToSdkId = new Dictionary<int, int>();
+        foreach (var (seedLanguageId, languageCode) in seedLanguageIdToCode)
+        {
+            var sdkLanguage = sdkLanguagesForAreaSeed.FirstOrDefault(x => x.LanguageCode == languageCode);
+            if (sdkLanguage != null)
+            {
+                seedLanguageIdToSdkId[seedLanguageId] = sdkLanguage.Id;
+            }
+        }
+
         foreach (var newArea in BackendConfigurationSeedAreas.AreasSeed
                      .Where(newArea => !backendConfigurationPnDbContext.Areas.Any(x => x.Id == newArea.Id))
                      .Where(x => x.IsDisabled == false))
         {
+            foreach (var translation in newArea.AreaTranslations)
+            {
+                if (seedLanguageIdToSdkId.TryGetValue(translation.LanguageId, out var sdkLanguageId))
+                {
+                    translation.LanguageId = sdkLanguageId;
+                }
+            }
+
             await newArea.Create(backendConfigurationPnDbContext).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
## Problem
Area seed data (`BackendConfigurationSeedAreas`) hardcodes `AreaTranslation.LanguageId` as **1=da, 2=en-US, 3=de-DE**. But the SDK `Languages` table uses **environment-specific auto-increment ids** (observed: da=2, en-US=5, de-DE=8). So the seeded `LanguageId` values point at SDK languages that don't exist in that environment.

When an area (e.g. `00. Logbøger`) is activated during property creation, `Core.FolderCreate` does `Languages.FirstOrDefault(x => x.Id == translation.LanguageId)` → **null** → dereferences `language.LanguageCode` → **NullReferenceException**, surfaced as `"FolderCreate failed"` / `ErrorWhileCreatingCalendarTask`. Failed retries also left duplicate `AreaProperty` rows.

## Fix
In the area-seeding loop (`SeedEForms`), build a map from the seed's hardcoded language id → real SDK language id (resolved by `LanguageCode`) and remap each translation before `newArea.Create(...)`. Translations now point at languages that actually exist, regardless of the environment's SDK language ids.

Scope: seed-only. Existing-data repair was handled separately and is intentionally not part of this change.

## Test plan
- [ ] Fresh seed in an environment where SDK language ids ≠ 1/2/3 → AreaTranslations get correct SDK ids
- [ ] Create a property → `00. Logbøger` activates without `FolderCreate failed`
- [ ] Create a calendar task on the new property → no `ErrorWhileCreatingCalendarTask`

🤖 Generated with [Claude Code](https://claude.com/claude-code)