### PR TITLE
feat(grpc): serve worker task Title/Description + eForm in the worker's Site language

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarMultiLanguageTitleDescriptionTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarMultiLanguageTitleDescriptionTests.cs
@@ -164,6 +164,95 @@ public class CalendarMultiLanguageTitleDescriptionTests : TestBaseSetup
         Assert.That(da.Description, Is.EqualTo("Kontrollér ventiler og noter tryk."));
     }
 
+    // Seeds a monthly 1st-Saturday task with da/en/de AreaRuleTranslations
+    // (Name+Description) and returns the property id + language ids.
+    private async Task<(int PropertyId, Langs Langs)> SeedTriLingualTask()
+    {
+        var langs = await EnsureLanguages();
+
+        var area = new Area { Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property { Name = $"MlProp-{Guid.NewGuid()}", ItemPlanningTagId = 0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule { AreaId = area.Id, PropertyId = property.Id, EformId = 0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        foreach (var (langId, name, desc) in new[]
+                 {
+                     (langs.Da, "Tank 4 inspektion", "Kontrollér ventiler og noter tryk."),
+                     (langs.En, "Tank 4 inspection", "Check valves and note the pressure."),
+                     (langs.De, "Tank 4 Inspektion", "Ventile prüfen und den Druck notieren."),
+                 })
+        {
+            await BackendConfigurationPnDbContext.AreaRuleTranslations.AddAsync(new AreaRuleTranslation
+            { AreaRuleId = areaRule.Id, LanguageId = langId, Name = name, Description = desc, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 });
+        }
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var startDate = new DateTime(2026, 6, 6, 0, 0, 0, DateTimeKind.Utc);
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Month, StartDate = startDate,
+            DayOfMonth = 0, Description = "Kontrollér ventiler og noter tryk.", RelatedEFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id, ItemPlanningId = planning.Id,
+            StartDate = startDate, Status = true, RepeatType = 3, RepeatEvery = 1,
+            RepeatOrdinalWeek = 1, DayOfWeek = 6,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(new CalendarConfiguration
+        { AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0, WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 });
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        return (property.Id, langs);
+    }
+
+    // The gRPC seam: requestModel.LanguageId overrides the current-user language
+    // (the worker's Site.LanguageId), and null falls back to the current user.
+    [Test]
+    public async Task GetTasksForWeek_RequestLanguageId_OverridesCurrentUserLanguage()
+    {
+        var core = await GetCore();
+        var (propertyId, langs) = await SeedTriLingualTask();
+
+        // Current user is DANISH; the request asks for ENGLISH (the worker's site).
+        var svc = BuildService(core, langs.Da);
+        var weekStart = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        async Task<CalendarTaskResponseModel> Tile(int? languageId)
+        {
+            var res = await svc.GetTasksForWeek(new CalendarTaskRequestModel
+            {
+                PropertyId = propertyId, WeekStart = IsoUtc(weekStart),
+                WeekEnd = IsoUtc(weekStart.AddDays(6).AddHours(23).AddMinutes(59)),
+                ActionableOnly = false, BoardIds = [], TagNames = [], SiteIds = [], LanguageId = languageId
+            });
+            Assert.That(res.Success, Is.True, res.Message);
+            return res.Model!.Single(t => t.TaskDate == "2026-06-06");
+        }
+
+        var overridden = await Tile(langs.En);
+        Assert.That(overridden.Title, Is.EqualTo("Tank 4 inspection"), "LanguageId override → English title");
+        Assert.That(overridden.DescriptionHtml, Is.EqualTo("Check valves and note the pressure."), "LanguageId override → English description");
+
+        var fallback = await Tile(null);
+        Assert.That(fallback.Title, Is.EqualTo("Tank 4 inspektion"), "null LanguageId → current-user (Danish) title");
+        Assert.That(fallback.DescriptionHtml, Is.EqualTo("Kontrollér ventiler og noter tryk."), "null LanguageId → current-user (Danish) description");
+    }
+
     private BackendConfigurationCalendarService BuildService(eFormCore.Core core, int callerLanguageId)
     {
         var language = MicrotingDbContext!.Languages.First(x => x.Id == callerLanguageId);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskRequestModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskRequestModel.cs
@@ -24,4 +24,13 @@ public class CalendarTaskRequestModel
     /// and completed ones, so the admin can audit the full week.
     /// </summary>
     public bool ActionableOnly { get; set; } = false;
+
+    /// <summary>
+    /// Optional explicit language for Title/Description selection. Set by the
+    /// mobile-worker gRPC path (<c>EventsGrpcService</c>) to the worker's
+    /// SDK <c>Site.LanguageId</c> so the worker sees the task in their own
+    /// language. Null (angular admin REST / <c>CalendarGrpcService</c>) → the
+    /// current user's language, preserving existing behaviour.
+    /// </summary>
+    public int? LanguageId { get; set; }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -49,7 +49,10 @@ public class BackendConfigurationCalendarService(
             var weekEnd = DateTime.Parse(requestModel.WeekEnd, CultureInfo.InvariantCulture,
                 DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
 
-            var userLanguageId = (await userService.GetCurrentUserLanguage()).Id;
+            // gRPC mobile-worker path passes the worker's Site.LanguageId so the
+            // worker sees Title/Description in their own language; web/REST passes
+            // null and keeps the current-user language (#unchanged).
+            var userLanguageId = requestModel.LanguageId ?? (await userService.GetCurrentUserLanguage()).Id;
             var result = new List<CalendarTaskResponseModel>();
 
             // Get the default board for this property (first created board)
@@ -4005,11 +4008,13 @@ public class BackendConfigurationCalendarService(
     /// (compliance.Deadline &lt; UtcNow AND Status != 100)</c>).
     /// </remarks>
     public async Task<OperationDataResult<List<CalendarTaskResponseModel>>> GetTaskTrackerList(
-        int propertyId, int? sdkSiteIdForFilter)
+        int propertyId, int? sdkSiteIdForFilter, int? languageId = null)
     {
         try
         {
-            var userLanguageId = (await userService.GetCurrentUserLanguage()).Id;
+            // gRPC mobile-worker path passes the worker's Site.LanguageId; web
+            // passes null and keeps the current-user language.
+            var userLanguageId = languageId ?? (await userService.GetCurrentUserLanguage()).Id;
             var dateTimeNow = DateTime.UtcNow;
             var result = new List<CalendarTaskResponseModel>();
 
@@ -4164,6 +4169,20 @@ public class BackendConfigurationCalendarService(
                         .FirstOrDefault() ?? title;
                 }
 
+                // Description in the caller/worker language (same selection as the
+                // title and as GetTasksForWeek): caller language, else first
+                // translation, else the single planning description.
+                var descriptionHtml = planning.Description;
+                if (arp?.AreaRule?.AreaRuleTranslations != null)
+                {
+                    descriptionHtml = arp.AreaRule.AreaRuleTranslations
+                        .Where(t => t.LanguageId == userLanguageId)
+                        .Select(t => t.Description)
+                        .FirstOrDefault()
+                        ?? arp.AreaRule.AreaRuleTranslations.Select(t => t.Description).FirstOrDefault()
+                        ?? planning.Description;
+                }
+
                 var tags = arp != null
                     ? complianceArpTags
                         .Where(x => x.AreaRulePlanningId == arp.Id)
@@ -4239,7 +4258,7 @@ public class BackendConfigurationCalendarService(
                     EformId = arp?.AreaRule?.EformId,
                     SdkCaseId = compliance.MicrotingSdkCaseId,
                     ItemPlanningTagId = arp?.ItemPlanningTagId,
-                    DescriptionHtml = planning.Description,
+                    DescriptionHtml = descriptionHtml,
                     Attachments = MapAttachments(arp),
                     TaskIsExpired = taskIsExpired
                 };

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/IBackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/IBackendConfigurationCalendarService.cs
@@ -29,7 +29,7 @@ public interface IBackendConfigurationCalendarService
     /// disable site filtering (admin context).
     /// </summary>
     Task<OperationDataResult<List<CalendarTaskResponseModel>>> GetTaskTrackerList(
-        int propertyId, int? sdkSiteIdForFilter);
+        int propertyId, int? sdkSiteIdForFilter, int? languageId = null);
     Task<OperationDataResult<int>> CreateTask(CalendarTaskCreateRequestModel createModel);
     Task<OperationResult> UpdateTask(CalendarTaskUpdateRequestModel updateModel);
     Task<OperationResult> DeleteTask(CalendarTaskDeleteRequestModel deleteModel);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/EventsGrpcService.cs
@@ -227,7 +227,9 @@ public class EventsGrpcService(
             // itself; this read, which is what the worker actually sees, must
             // only return events assigned to their site.
             SiteIds = [sdkSiteId],
-            ActionableOnly = true
+            ActionableOnly = true,
+            // Serve Title/Description in the worker's own site language.
+            LanguageId = await siteResolver.GetSiteLanguageIdAsync(sdkSiteId)
         };
 
         var result = await calendarService.GetTasksForWeek(model);
@@ -355,7 +357,8 @@ public class EventsGrpcService(
                 "Caller has no PropertyWorker access to the requested property."));
         }
 
-        var result = await calendarService.GetTaskTrackerList(propertyId, (int)sdkSiteId)
+        var result = await calendarService
+            .GetTaskTrackerList(propertyId, (int)sdkSiteId, await siteResolver.GetSiteLanguageIdAsync((int)sdkSiteId))
             .ConfigureAwait(false);
 
         var response = new ListTaskTrackerResponse();
@@ -504,7 +507,14 @@ public class EventsGrpcService(
 
         var core = await coreHelper.GetCore().ConfigureAwait(false);
         var sdkDbContext = core.DbContextHelper.GetDbContext();
-        var language = await sdkDbContext.Languages.FirstAsync().ConfigureAwait(false);
+        // Serve the eForm template (field labels/descriptions/options) in the
+        // worker's own site language; fall back to the DB-first language when the
+        // worker has no resolvable site or no row for that language exists.
+        var siteLanguageId = await siteResolver.GetSiteLanguageIdAsync().ConfigureAwait(false);
+        var language = siteLanguageId.HasValue
+            ? await sdkDbContext.Languages.FirstOrDefaultAsync(l => l.Id == siteLanguageId.Value).ConfigureAwait(false)
+              ?? await sdkDbContext.Languages.FirstAsync().ConfigureAwait(false)
+            : await sdkDbContext.Languages.FirstAsync().ConfigureAwait(false);
 
         foreach (var (taskId, caseId) in taskIdToCaseId)
         {
@@ -1065,7 +1075,9 @@ public class EventsGrpcService(
             // #931 — the mobile stream only surfaces events assigned to the
             // caller's own site (the worker), never the whole property.
             SiteIds = [sdkSiteId],
-            ActionableOnly = true
+            ActionableOnly = true,
+            // Serve Title/Description in the worker's own site language.
+            LanguageId = await siteResolver.GetSiteLanguageIdAsync(sdkSiteId)
         };
 
         var result = await calendarService.GetTasksForWeek(model).ConfigureAwait(false);
@@ -1796,7 +1808,9 @@ public class EventsGrpcService(
             // #931 — scope the echo read to the caller's site, consistent with
             // the list/stream reads; a worker only ever sees their own events.
             SiteIds = [sdkSiteId],
-            ActionableOnly = true
+            ActionableOnly = true,
+            // Serve Title/Description in the worker's own site language.
+            LanguageId = await siteResolver.GetSiteLanguageIdAsync(sdkSiteId)
         }).ConfigureAwait(false);
 
         var refreshedTask = refreshed.Success && refreshed.Model != null
@@ -2008,7 +2022,9 @@ public class EventsGrpcService(
             // #931 — scope the echo read to the caller's site, consistent with
             // the list/stream reads; a worker only ever sees their own events.
             SiteIds = [sdkSiteId],
-            ActionableOnly = true
+            ActionableOnly = true,
+            // Serve Title/Description in the worker's own site language.
+            LanguageId = await siteResolver.GetSiteLanguageIdAsync(sdkSiteId)
         }).ConfigureAwait(false);
 
         var refreshedTask = refreshed.Success && refreshed.Model != null
@@ -2303,7 +2319,9 @@ public class EventsGrpcService(
             // #931 — scope the echo read to the caller's site, consistent with
             // the list/stream reads; a worker only ever sees their own events.
             SiteIds = [sdkSiteId],
-            ActionableOnly = true
+            ActionableOnly = true,
+            // Serve Title/Description in the worker's own site language.
+            LanguageId = await siteResolver.GetSiteLanguageIdAsync(sdkSiteId)
         }).ConfigureAwait(false);
 
         var refreshedTask = refreshed.Success && refreshed.Model != null
@@ -3225,7 +3243,9 @@ public class EventsGrpcService(
             // #931 — scope the echo read to the caller's site, consistent with
             // the list/stream reads; a worker only ever sees their own events.
             SiteIds = [sdkSiteId],
-            ActionableOnly = true
+            ActionableOnly = true,
+            // Serve Title/Description in the worker's own site language.
+            LanguageId = await siteResolver.GetSiteLanguageIdAsync(sdkSiteId)
         }).ConfigureAwait(false);
 
         var refreshedTask = refreshed.Success && refreshed.Model != null

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/GrpcSiteResolver.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/GrpcSiteResolver.cs
@@ -10,6 +10,16 @@ namespace BackendConfiguration.Pn.Services.GrpcServices;
 public interface IGrpcSiteResolver
 {
     Task<int> GetSdkSiteIdAsync();
+
+    /// <summary>
+    /// The SDK Site.LanguageId of the calling worker's resolved site, so the
+    /// gRPC path can serve Title/Description/eForm in the worker's own language.
+    /// Null when the worker has no resolvable site / no language (caller falls
+    /// back to its existing default language). Pass <paramref name="preResolvedSiteId"/>
+    /// when the caller already resolved the site via <see cref="GetSdkSiteIdAsync"/>
+    /// to avoid re-running the worker→site lookup.
+    /// </summary>
+    Task<int?> GetSiteLanguageIdAsync(int? preResolvedSiteId = null);
 }
 
 public class GrpcSiteResolver(
@@ -65,5 +75,24 @@ public class GrpcSiteResolver(
         }
 
         return siteWorker.SiteId ?? 0;
+    }
+
+    public async Task<int?> GetSiteLanguageIdAsync(int? preResolvedSiteId = null)
+    {
+        var siteId = preResolvedSiteId ?? await GetSdkSiteIdAsync().ConfigureAwait(false);
+        if (siteId == 0)
+        {
+            return null;
+        }
+
+        var core = await coreHelper.GetCore().ConfigureAwait(false);
+        var sdkDbContext = core.DbContextHelper.GetDbContext();
+        // `LanguageId > 0` guards a malformed Site (LanguageId 0): return null so
+        // the caller falls back to its default rather than querying language 0.
+        return await sdkDbContext.Sites
+            .Where(s => s.Id == siteId && s.LanguageId > 0)
+            .Select(s => (int?)s.LanguageId)
+            .FirstOrDefaultAsync()
+            .ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary

The mobile/device property-worker gRPC path (`EventsGrpcService`) served task **Title/Description** from the authenticated **account locale** and the **eForm template fields** from the **DB-first language**. Neither was the worker's own language. Both now use the worker's SDK **`Site.LanguageId`** (the per-language data already exists from #981 / `AreaRuleTranslation` + the SDK `CheckList`/`Field` translations — only the *selector* was wrong).

## Changes (backend only)

- **`GrpcSiteResolver.GetSiteLanguageIdAsync(int? preResolvedSiteId = null)`** — resolves the worker's `Site.LanguageId` (reusing an already-resolved site id to avoid an extra worker→site lookup). Returns null when there's no site / `LanguageId == 0` → callers fall back to their existing default.
- **`CalendarTaskRequestModel.LanguageId`** (optional) — `GetTasksForWeek` uses `requestModel.LanguageId ?? CurrentUserLanguage`. **Web/REST pass null → unchanged.**
- **`GetTaskTrackerList`** — gains an optional `languageId`, and now also selects **Description** per-language (it previously emitted the single `planning.Description` regardless of language).
- **`EventsGrpcService`** — passes the worker's site language into all 6 task-list request builds + `GetTaskTrackerList`, and resolves the eForm read language (`LoadFieldsByTaskIdAsync`) from the site language (falling back to the DB-first language; the SDK `CaseRead` further falls back to Danish if a template has no translation for that language). Write-path field-value canonicalization defaults are intentionally left unchanged.

## Testing

Integration test (Testcontainers): `requestModel.LanguageId` overrides the current-user language (override → English title+description; null → current-user Danish). Source plugin builds clean; existing calendar tests stay green.

## Notes
- No base migration, no `.proto` change, no frontend change. Deploy-time language is already correct (`sdkSite.LanguageId`).
- Code-reviewed; fixed a real gap (tracker Description was not language-aware) and reduced redundant site lookups on the hot/stream paths.

Spec: `docs/superpowers/specs/2026-06-08-grpc-worker-language-task-eform-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)