### PR TITLE
fix(calendar): stop board color-picker popover clipping the 8th swatch

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-sidebar/calendar-sidebar.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-sidebar/calendar-sidebar.component.html
@@ -30,7 +30,7 @@
         <button mat-icon-button class="board-menu-btn" [matMenuTriggerFor]="boardMenu" (click)="startEditBoard(board); $event.stopPropagation()">
           <mat-icon>more_vert</mat-icon>
         </button>
-        <mat-menu #boardMenu="matMenu">
+        <mat-menu #boardMenu="matMenu" class="board-edit-menu">
           <div class="board-edit-popover" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
             <label class="field-label">{{ 'Navn tavle' | translate }}</label>
             <mat-form-field appearance="outline" style="width: 100%;">

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-sidebar/calendar-sidebar.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-sidebar/calendar-sidebar.component.scss
@@ -289,3 +289,12 @@
     justify-content: flex-start;
   }
 }
+
+// The board edit popover renders inside a mat-menu panel in the CDK overlay
+// (outside :host), so this override must be global — NOT :host-scoped — to
+// reach the panel and lift Material's default 280px panel cap, fitting all
+// 8 colour swatches (8×32px + 7×8px gaps + padding = 352px) without clipping.
+::ng-deep .board-edit-menu.mat-mdc-menu-panel {
+  max-width: none;
+  min-width: 352px;
+}


### PR DESCRIPTION
## Problem
The board color-picker popover (sidebar ⋮ menu) still showed a horizontal scrollbar with the 8th swatch clipped, despite PR #977 setting `.board-edit-popover { min-width: 352px }`.

**Root cause:** the popover renders inside a `mat-menu`, whose panel (`.mat-mdc-menu-panel`) has Angular Material's default `max-width: 280px`. That cap clips the 352px content regardless of the inner min-width. PR #977 never touched the panel.

A second bug: the first attempt used `panelClass="board-edit-menu"`, but `panelClass` is **not** a `mat-menu` attribute — Material aliases the panel-class input as `class`. So the class was never applied to the panel and the override selector matched nothing. (Confirmed via DOM: panel classList lacked `board-edit-menu`, max-width stayed 280px.)

## Fix
- `<mat-menu class="board-edit-menu">` (correct panel-class input)
- Global (non-`:host`) `::ng-deep .board-edit-menu.mat-mdc-menu-panel { max-width: none; min-width: 352px; }` — must be global because the panel lives in the CDK overlay outside the component host.

## Verification (Playwright, live app)
Reproduced the new 8-colour palette state locally, then confirmed after the fix:
- panel `max-width: none`, panel width **384px**
- `hasHorizontalScroll: false`
- all 8 swatches in a single row, no clipping

![verified](verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)