### PR TITLE
fix(seed): remap seed LanguageId to real SDK ids for AreaRuleTranslations

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/AreaRuleLanguageHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/AreaRuleLanguageHelper.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microting.eForm.Infrastructure;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+namespace BackendConfiguration.Pn.Infrastructure.Helpers;
+
+/// <summary>
+/// Seed data hardcodes AreaRuleTranslation.LanguageId as 1=da, 2=en-US, 3=de-DE, but the
+/// SDK Languages table uses environment-specific auto-increment ids. These helpers resolve the
+/// real SDK language id by code so area-rule name translations point at languages that actually
+/// exist (mirrors the AreaTranslation remap added in PR #982 for SeedEForms).
+/// </summary>
+public static class AreaRuleLanguageHelper
+{
+    private static async Task<Dictionary<int, int>> BuildSeedLanguageIdToSdkIdAsync(
+        MicrotingDbContext sdkDbContext)
+    {
+        var sdkLanguages = await sdkDbContext.Languages.ToListAsync().ConfigureAwait(false);
+        var seedLanguageIdToCode = new Dictionary<int, string> { { 1, "da" }, { 2, "en-US" }, { 3, "de-DE" } };
+        var seedLanguageIdToSdkId = new Dictionary<int, int>();
+        foreach (var (seedLanguageId, code) in seedLanguageIdToCode)
+        {
+            var lang = sdkLanguages.FirstOrDefault(x => x.LanguageCode == code);
+            if (lang != null)
+            {
+                seedLanguageIdToSdkId[seedLanguageId] = lang.Id;
+            }
+        }
+
+        return seedLanguageIdToSdkId;
+    }
+
+    /// <summary>
+    /// Remaps the hardcoded seed LanguageId (1/2/3) on each area rule's translations to the real
+    /// SDK language id resolved by LanguageCode. In-place mutation is safe: each translation is
+    /// visited once and remapped from its original seed id via the static {1->da,2->en-US,3->de-DE} map.
+    /// </summary>
+    public static async Task RemapSeedLanguageIdsAsync(
+        IEnumerable<AreaRule> areaRules,
+        MicrotingDbContext sdkDbContext)
+    {
+        var seedLanguageIdToSdkId = await BuildSeedLanguageIdToSdkIdAsync(sdkDbContext).ConfigureAwait(false);
+        foreach (var areaRule in areaRules)
+        {
+            RemapTranslations(areaRule.AreaRuleTranslations, seedLanguageIdToSdkId);
+        }
+    }
+
+    /// <summary>
+    /// Single-area-rule overload of <see cref="RemapSeedLanguageIdsAsync(IEnumerable{AreaRule}, MicrotingDbContext)"/>.
+    /// </summary>
+    public static async Task RemapSeedLanguageIdsAsync(
+        AreaRule areaRule,
+        MicrotingDbContext sdkDbContext)
+    {
+        var seedLanguageIdToSdkId = await BuildSeedLanguageIdToSdkIdAsync(sdkDbContext).ConfigureAwait(false);
+        RemapTranslations(areaRule.AreaRuleTranslations, seedLanguageIdToSdkId);
+    }
+
+    /// <summary>
+    /// Remaps the hardcoded seed LanguageId (1/2/3) on a freshly built list of translations to the
+    /// real SDK language id resolved by LanguageCode (used by the Type7/Type8 build path).
+    /// </summary>
+    public static async Task RemapSeedLanguageIdsAsync(
+        IEnumerable<AreaRuleTranslation> translations,
+        MicrotingDbContext sdkDbContext)
+    {
+        var seedLanguageIdToSdkId = await BuildSeedLanguageIdToSdkIdAsync(sdkDbContext).ConfigureAwait(false);
+        RemapTranslations(translations, seedLanguageIdToSdkId);
+    }
+
+    private static void RemapTranslations(
+        IEnumerable<AreaRuleTranslation> translations,
+        IReadOnlyDictionary<int, int> seedLanguageIdToSdkId)
+    {
+        if (translations == null)
+        {
+            return;
+        }
+
+        foreach (var translation in translations)
+        {
+            if (seedLanguageIdToSdkId.TryGetValue(translation.LanguageId, out var sdkId))
+            {
+                translation.LanguageId = sdkId;
+            }
+        }
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAreaRulesServiceHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAreaRulesServiceHelper.cs
@@ -204,6 +204,8 @@ public static class BackendConfigurationAreaRulesServiceHelper
                             CreatedByUserId = userId,
                             UpdatedByUserId = userId
                         }).ToList();
+                    await AreaRuleLanguageHelper
+                        .RemapSeedLanguageIdsAsync(translations, sdkDbContext).ConfigureAwait(false);
                 }
 
                 if (areaProperty.Area.Type is AreaTypesEnum.Type8)
@@ -217,6 +219,8 @@ public static class BackendConfigurationAreaRulesServiceHelper
                             CreatedByUserId = userId,
                             UpdatedByUserId = userId
                         }).ToList();
+                    await AreaRuleLanguageHelper
+                        .RemapSeedLanguageIdsAsync(translations, sdkDbContext).ConfigureAwait(false);
                 }
 
                 // if (areaProperty.Area.Type is AreaTypesEnum.Type10)

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationPropertyAreasServiceHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationPropertyAreasServiceHelper.cs
@@ -393,6 +393,8 @@ public static class BackendConfigurationPropertyAreasServiceHelper
                                 areaRule.EformId = eformId;
                             }
 
+                            await AreaRuleLanguageHelper
+                                .RemapSeedLanguageIdsAsync(areaRule, sdkDbContext).ConfigureAwait(false);
                             await areaRule.Create(backendConfigurationPnDbContext).ConfigureAwait(false);
                         }
 
@@ -432,6 +434,8 @@ public static class BackendConfigurationPropertyAreasServiceHelper
                                 areaRule.EformId = eformId;
                             }
 
+                            await AreaRuleLanguageHelper
+                                .RemapSeedLanguageIdsAsync(areaRule, sdkDbContext).ConfigureAwait(false);
                             await areaRule.Create(backendConfigurationPnDbContext).ConfigureAwait(false);
                         }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAreaRulesService/BackendConfigurationAreaRulesService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAreaRulesService/BackendConfigurationAreaRulesService.cs
@@ -267,24 +267,30 @@ public class BackendConfigurationAreaRulesService : IBackendConfigurationAreaRul
 					areaRule.FolderName = "00. Morgenrundtur";
 
 					await areaRule.Create(_backendConfigurationPnDbContext).ConfigureAwait(false);
-					var areaRuleTranslation = new AreaRuleTranslation
+					var areaRuleTranslations = new List<AreaRuleTranslation>
 					{
-						AreaRuleId = areaRule.Id,
-						LanguageId = 1,
-						Name = "Morgenrundtur",
-						CreatedByUserId = _userService.UserId,
-						UpdatedByUserId = _userService.UserId
+						new()
+						{
+							AreaRuleId = areaRule.Id,
+							LanguageId = 1, // da
+							Name = "Morgenrundtur",
+							CreatedByUserId = _userService.UserId,
+							UpdatedByUserId = _userService.UserId
+						},
+						new()
+						{
+							AreaRuleId = areaRule.Id,
+							LanguageId = 2, // en-US
+							Name = "Morning tour",
+							CreatedByUserId = _userService.UserId,
+							UpdatedByUserId = _userService.UserId
+						}
 					};
-					await areaRuleTranslation.Create(_backendConfigurationPnDbContext);
-					areaRuleTranslation = new AreaRuleTranslation
+					await AreaRuleLanguageHelper.RemapSeedLanguageIdsAsync(areaRuleTranslations, sdkDbContext).ConfigureAwait(false);
+					foreach (var areaRuleTranslation in areaRuleTranslations)
 					{
-						AreaRuleId = areaRule.Id,
-						LanguageId = 2,
-						Name = "Morning tour",
-						CreatedByUserId = _userService.UserId,
-						UpdatedByUserId = _userService.UserId
-					};
-					await areaRuleTranslation.Create(_backendConfigurationPnDbContext);
+						await areaRuleTranslation.Create(_backendConfigurationPnDbContext).ConfigureAwait(false);
+					}
 				}
 			}
 
@@ -336,6 +342,8 @@ public class BackendConfigurationAreaRulesService : IBackendConfigurationAreaRul
 						areaRule.ComplianceModifiable = true;
 						areaRule.NotificationsModifiable = true;
 						areaRule.EformId = eformId;
+						await AreaRuleLanguageHelper
+							.RemapSeedLanguageIdsAsync(areaRule, sdkDbContext).ConfigureAwait(false);
 						await areaRule.Create(_backendConfigurationPnDbContext).ConfigureAwait(false);
 					}
 				}


### PR DESCRIPTION
## Problem
Calendar event titles (`taskText`) come from `AreaRuleTranslations` (copied verbatim into `PlanningNameTranslation`). Those rows are seeded from `BackendConfigurationSeedAreas.AreaRules` / `AreaRulesForType7/8` (and a Type10 "Morgenrundtur" path), which **hardcode `LanguageId = 1/2/3`**. But each tenant's SDK `Languages` table uses environment-specific auto-increment ids (e.g. da=2, en-US=5, de-DE=8 — id 1 may not exist). 

Commit #983 made the gRPC title lookup strict by the worker's real Site language id, so placeholder-keyed rows stop matching → **empty event titles** in the mobile app (observed on tenant 1124).

PR #982 fixed this exact pattern for `AreaTranslations` in `SeedEForms`, but **left `AreaRuleTranslations` un-remapped** — this PR closes that gap.

## Fix
New `AreaRuleLanguageHelper.RemapSeedLanguageIdsAsync(...)` resolves the real SDK id by `LanguageCode` (map `{1→da, 2→en-US, 3→de-DE}`) and in-place re-keys translations before persist. Applied at every area-rule creation site that used raw seed ids:
- `BackendConfigurationPropertyAreasServiceHelper` (×2 seeded-default loops)
- `BackendConfigurationAreaRulesService` (area-1 re-seed + Type10 Morgenrundtur)
- `BackendConfigurationAreaRulesServiceHelper` (Type7/Type8 translation lists)

Frontend-sourced paths (already real SDK ids) are left untouched. `PlanningNameTranslation` inherits the fix automatically (it copies `AreaRuleTranslation.LanguageId` verbatim).

**Safe for all tenants:** the map keys are *seed* ids; values resolve *by language code*, so even tenants whose real ids happen to be 1/2/3 (e.g. 1116) get an identity write — no corruption. Existing broken data is repaired separately (data fix, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)