### PR TITLE
fix(calendar): readable text on inactive event tiles

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.html
@@ -11,7 +11,7 @@
   [style.width]="widthStyle"
   [style.z-index]="zIndexStyle"
   [style.background-color]="task.color"
-  [style.color]="boardTextColor(task.color)"
+  [style.color]="task.status === false ? null : boardTextColor(task.color)"
   cdkDrag
   [cdkDragData]="task"
   [cdkDragDisabled]="task.completed || resizing"


### PR DESCRIPTION
## Problem
Inactive calendar event tiles (`task.status === false`) render **white text on a light-grey background → unreadable**.

Gap from #980: that PR added `[style.color]="boardTextColor(task.color)"`, which returns `white` for dark boards. The `.gcal-task--inactive` SCSS repaints the tile light-grey (`#eef0f2`) with `color: #6b7280`, but that color is **not** `!important`, so the inline white wins → white-on-light-grey.

## Fix
Make the inline color conditional so inactive tiles emit no inline color and let the SCSS grey cascade:
```
[style.color]="task.status === false ? null : boardTextColor(task.color)"
```
- Inactive → `#6b7280` grey on `#eef0f2` (readable); `.completion-btn`/`.task-title` inherit, `.task-time` keeps its muted tone.
- Active → unchanged (`boardTextColor`: white on dark boards, `#1a1a1a` on light).
- Completed-inactive edge case preserved: `.gcal-task--inactive.completed { color:#fff }` still applies (white on green).

All-day chip and drag-ghost don't have a light-grey inactive state — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)