### PR TITLE
feat: complete events by any property worker (not just task-assigned)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/EventDeployServiceTest.cs
@@ -906,6 +906,161 @@ public class EventDeployServiceTest : TestBaseSetup
     }
 
     // ------------------------------------------------------------------
+    // 12b. EnsureComplianceForOccurrence_SiteIsActivePropertyWorkerNotInPlanningSites_Deploys
+    //
+    // Positive counterpart to the pin test above, locking in the #932/#1377
+    // guard RELAXATION. The on-demand calendar materialisation now lets a user
+    // complete a future/on-demand occurrence on behalf of ANY active worker of
+    // the event's PROPERTY (the worker pickers list every property worker, same
+    // source as GetLinkedSites). Such a worker is legitimately tied to the event
+    // even though it is NOT in the planning's PlanningSites, so the guard's
+    // second branch (PropertyWorkers probe) must accept it and DEPLOY rather
+    // than throw. Setup mirrors the pin test (target site absent from
+    // PlanningSites) but adds a real eForm template + the full BC graph so the
+    // deploy path runs to completion (ReadeForm + CaseCreateLocalOnly + the
+    // PlanningCaseSite/Compliance writes), plus the one extra row the relaxation
+    // turns on: an active PropertyWorker for (property, target site).
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task EnsureComplianceForOccurrence_SiteIsActivePropertyWorkerNotInPlanningSites_Deploys()
+    {
+        var core = await GetCore();
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        // The planning is assigned to A; the target site B is NOT in
+        // PlanningSites but IS an active worker of the planning's property.
+        var assignedSite = new Site
+        {
+            Name = "niels-site-propertyworker",
+            MicrotingUid = 63,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        var targetSite = new Site
+        {
+            Name = "soren-site-propertyworker",
+            MicrotingUid = 62,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddRangeAsync(assignedSite, targetSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        // Real eForm template so DeployForRotationAsync's ReadeForm +
+        // CaseCreateLocalOnly succeed and a real PlanningCaseSite + Compliance
+        // row are written once the guard lets the deploy through.
+        var template = await core.TemplateFromXml(CommentTemplateXml);
+        var templateId = await core.TemplateCreate(template);
+
+        // The guard's PropertyWorkers probe keys on areaRulePlanning.PropertyId,
+        // so the ARP must point at a real Property and the seeded PropertyWorker
+        // must reference that same PropertyId. Seed the minimal BC graph
+        // (Area → Property → AreaRule) the deploy path reads.
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"PropertyWorkerProp-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id, EformId = templateId,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // The relaxation: target site B is an ACTIVE PropertyWorker of the
+        // planning's property even though it is absent from PlanningSites. This
+        // single row is what flips the guard from throw to deploy.
+        await BackendConfigurationPnDbContext.PropertyWorkers.AddAsync(new PropertyWorker
+        {
+            PropertyId = property.Id,
+            WorkerId = targetSite.Id,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        });
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var deadline = DateTime.UtcNow.Date.AddDays(2);
+
+        var planning = new Microting.ItemsPlanningBase.Infrastructure.Data.Entities.Planning
+        {
+            WorkflowState = Constants.WorkflowStates.Created,
+            StartDate = deadline.AddDays(-7),
+            Enabled = true,
+            RepeatEvery = 1,
+            RepeatType = Microting.ItemsPlanningBase.Infrastructure.Enums.RepeatType.Month,
+            NextExecutionTime = deadline,
+            DayOfMonth = deadline.Day,
+            RepeatUntil = deadline.AddMonths(6),
+            RelatedEFormId = templateId,
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        // Planning is assigned ONLY to assignedSite — NOT the target site.
+        ItemsPlanningPnDbContext.PlanningSites.Add(new Microting.ItemsPlanningBase.Infrastructure.Data.Entities.PlanningSite
+        {
+            PlanningId = planning.Id,
+            SiteId = assignedSite.Id,
+            WorkflowState = Constants.WorkflowStates.Created,
+        });
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        // In-memory ARP (as in the pin test): the call only reads
+        // .ItemPlanningId and .PropertyId off it; the Planning itself is looked
+        // up from the DB. PropertyId MUST match the seeded PropertyWorker.
+        var areaRulePlanning = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id,
+            ItemPlanningId = planning.Id,
+            PropertyId = property.Id,
+            AreaId = area.Id,
+        };
+
+        var (calendar, coreHelper) = MakeMocks([], core);
+        var service = MakeService(calendar, coreHelper);
+
+        // Act — target site B (an active property worker, absent from
+        // PlanningSites) materialises the occurrence. The guard must NOT throw.
+        EnsureComplianceResult? result = null;
+        Assert.DoesNotThrowAsync(async () =>
+            result = await service.EnsureComplianceForOccurrenceAsync(
+                areaRulePlanning, deadline, targetSite.Id, CancellationToken.None));
+
+        // Assert — it DEPLOYED: a fresh Compliance with a real SDK case, and a
+        // PlanningCaseSite written for the target site (inverse of the pin test).
+        Assert.That(result, Is.Not.Null,
+            "An active property worker must get a deploy result, not a null skip.");
+        Assert.That(result!.Created, Is.True,
+            "The occurrence must be newly materialised for the property worker.");
+        Assert.That(result.ComplianceId, Is.GreaterThan(0),
+            "A valid (non-zero) ComplianceId must be returned on deploy.");
+        Assert.That(result.SdkCaseId, Is.GreaterThan(0),
+            "A real SDK case must back the deploy (MicrotingSdkCaseId > 0).");
+
+        var planningCaseSiteCount = await ItemsPlanningPnDbContext.PlanningCaseSites
+            .CountAsync(pcs => pcs.PlanningId == planning.Id
+                               && pcs.MicrotingSdkSiteId == targetSite.Id
+                               && pcs.WorkflowState != Constants.WorkflowStates.Removed);
+        Assert.That(planningCaseSiteCount, Is.EqualTo(1),
+            "A PlanningCaseSite must be written for an active property worker "
+            + "even when the site is absent from PlanningSites (#932/#1377 relaxation).");
+    }
+
+    // ------------------------------------------------------------------
     // 13. EnsureDeployedAsync_ConcurrentPassesSameRotation_CreatesExactlyOnePlanningCaseSite
     //
     // Regression for #934. The forensic snapshot showed four identical

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -2697,18 +2697,46 @@ public class BackendConfigurationCalendarService(
                         localizationService.GetString("TaskHasNoComplianceCase"));
                 }
 
-                var planningSite = workerId.HasValue
-                    ? arp.PlanningSites?.FirstOrDefault(s =>
-                        s.SiteId == workerId.Value
-                        && s.WorkflowState != Constants.WorkflowStates.Removed)
-                    : arp.PlanningSites?.FirstOrDefault(s =>
-                        s.WorkflowState != Constants.WorkflowStates.Removed);
-                if (planningSite == null)
+                // Resolve the SDK site to materialise the on-demand case for.
+                //
+                // When the caller picks a worker, allow ANY active worker of the
+                // event's PROPERTY — not just the task's assigned PlanningSites.
+                // The calendar / task-tracker worker pickers now list every
+                // property worker (same source as GetLinkedSites:
+                // PropertyWorkers WHERE PropertyId = <property> AND not removed),
+                // so a user can complete a future/on-demand occurrence on behalf
+                // of any property worker. We still reject an arbitrary site id
+                // that is NOT a property worker, so a stray id can never leak a
+                // case to an unrelated worker.
+                //
+                // When no worker is picked, keep the historical default: pick the
+                // first non-removed PlanningSite assigned to the task.
+                int targetSiteId;
+                if (workerId.HasValue)
                 {
-                    return new OperationDataResult<CalendarToggleCompleteResult>(false,
-                        workerId.HasValue
-                            ? localizationService.GetString("SelectedWorkerNotAssignedToTask")
-                            : localizationService.GetString("NoAssignedWorker"));
+                    var isActivePropertyWorker = await backendConfigurationPnDbContext.PropertyWorkers
+                        .AsNoTracking()
+                        .AnyAsync(pw =>
+                            pw.PropertyId == arp.PropertyId
+                            && pw.WorkerId == workerId.Value
+                            && pw.WorkflowState != Constants.WorkflowStates.Removed);
+                    if (!isActivePropertyWorker)
+                    {
+                        return new OperationDataResult<CalendarToggleCompleteResult>(false,
+                            localizationService.GetString("SelectedWorkerNotAssignedToTask"));
+                    }
+                    targetSiteId = workerId.Value;
+                }
+                else
+                {
+                    var planningSite = arp.PlanningSites?.FirstOrDefault(s =>
+                        s.WorkflowState != Constants.WorkflowStates.Removed);
+                    if (planningSite == null)
+                    {
+                        return new OperationDataResult<CalendarToggleCompleteResult>(false,
+                            localizationService.GetString("NoAssignedWorker"));
+                    }
+                    targetSiteId = planningSite.SiteId;
                 }
 
                 if (string.IsNullOrWhiteSpace(occurrenceDate))
@@ -2729,7 +2757,7 @@ public class BackendConfigurationCalendarService(
                 var deadline = parsedDate.Date;
 
                 var ensure = await eventDeployService
-                    .EnsureComplianceForOccurrenceAsync(arp, deadline, planningSite.SiteId)
+                    .EnsureComplianceForOccurrenceAsync(arp, deadline, targetSiteId)
                     .ConfigureAwait(false);
                 if (ensure == null || ensure.ComplianceId <= 0)
                 {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
@@ -419,24 +419,33 @@ public class EventDeployService(
         // 0. Defense-in-depth site-assignment guard (#932 / #1377). This is the
         //    single source of truth for every PlanningCaseSite write, so it is
         //    the right place to refuse a cross-worker leak. A PlanningCaseSite
-        //    must only ever be written for a site that is in the planning's own
-        //    (non-removed) PlanningSites. The two callers already uphold this:
-        //    EnsureDeployedAsync site-narrows its candidates (#935 defect A) and
-        //    the on-demand EnsureComplianceForOccurrenceAsync caller passes an
-        //    assigned site. If either invariant ever regresses, fail loud here
-        //    rather than silently deploying a case to a non-assigned worker (the
-        //    exact symptom #932 reports). In EnsureDeployedAsync this throw is
-        //    swallowed by the per-rotation try/catch and recovered on the next
-        //    sync; on the on-demand path it surfaces the bug to the caller.
+        //    must only ever be written for a site that is legitimately tied to
+        //    this event — either the task's own (non-removed) PlanningSites, OR
+        //    an active worker of the event's PROPERTY (PropertyWorkers).
         //
-        //    Cost: this re-queries PlanningSites even though EnsureDeployedAsync
-        //    already narrowed by the same predicate. We keep it unconditional
-        //    (rather than passing a "trust me" flag from the narrowed caller) so
-        //    the guard genuinely protects EVERY write site, including future
-        //    callers. The extra indexed AnyAsync is negligible here: this method
-        //    only runs for candidates that survived the idempotence guard (i.e.
-        //    actually need deploying) and is dominated by the SDK ReadeForm +
-        //    CaseCreateLocalOnly round-trips that follow.
+        //    The on-demand calendar materialisation now lets a user complete a
+        //    future/on-demand occurrence on behalf of ANY active property worker
+        //    (the worker pickers list every property worker, same source as
+        //    GetLinkedSites). Such a worker may not be in PlanningSites, so the
+        //    guard accepts the property-worker case too — while still refusing a
+        //    site that is neither, so a stray id can never leak a case to an
+        //    unrelated worker.
+        //
+        //    The two callers uphold this: EnsureDeployedAsync site-narrows its
+        //    candidates to PlanningSites (#935 defect A) and the on-demand
+        //    EnsureComplianceForOccurrenceAsync caller validates the site is an
+        //    active property worker. If either invariant ever regresses, fail
+        //    loud here rather than silently deploying a case to an unrelated
+        //    worker (the exact symptom #932 reports). In EnsureDeployedAsync this
+        //    throw is swallowed by the per-rotation try/catch and recovered on
+        //    the next sync; on the on-demand path it surfaces the bug to the
+        //    caller.
+        //
+        //    Cost: at most two indexed AnyAsync (the PropertyWorkers probe is
+        //    only evaluated when the site is not already a PlanningSite). Both
+        //    are negligible against the SDK ReadeForm + CaseCreateLocalOnly
+        //    round-trips that follow, and this method only runs for candidates
+        //    that survived the idempotence guard (i.e. actually need deploying).
         var siteIsAssignedToPlanning = await itemsPlanningPnDbContext.PlanningSites
             .AsNoTracking()
             .AnyAsync(ps =>
@@ -447,10 +456,22 @@ public class EventDeployService(
             .ConfigureAwait(false);
         if (!siteIsAssignedToPlanning)
         {
-            throw new InvalidOperationException(
-                $"EventDeployService refused to deploy planning {planning.Id} to sdkSiteId {sdkSiteId}: "
-                + "the site is not in the planning's (non-removed) PlanningSites. Deploying here would "
-                + "leak a case to a non-assigned worker (#932/#1377).");
+            var siteIsActivePropertyWorker = await dbContext.PropertyWorkers
+                .AsNoTracking()
+                .AnyAsync(pw =>
+                        pw.PropertyId == areaRulePlanning.PropertyId
+                        && pw.WorkerId == sdkSiteId
+                        && pw.WorkflowState != Constants.WorkflowStates.Removed,
+                    ct)
+                .ConfigureAwait(false);
+            if (!siteIsActivePropertyWorker)
+            {
+                throw new InvalidOperationException(
+                    $"EventDeployService refused to deploy planning {planning.Id} to sdkSiteId {sdkSiteId}: "
+                    + "the site is neither in the planning's (non-removed) PlanningSites nor an active "
+                    + $"worker of property {areaRulePlanning.PropertyId}. Deploying here would leak a case "
+                    + "to an unrelated worker (#932/#1377).");
+            }
         }
 
         // 3. Resolve / create PlanningCase.

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -606,11 +606,20 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
     let selectedWorkerId: number | undefined;
 
     if (needsWorkerSelect) {
-      const sites: CommonDictionaryModel[] = task.assigneeIds.map((id, i) => ({
-        id,
-        name: task.workerNames[i] ?? '',
-        description: '',
-      }));
+      // List ALL workers assigned to the event's PROPERTY (not just the
+      // task-assigned subset), sorted alphabetically by name. Mirrors the
+      // task-tracker change (openSelectWorkerModal). getLinkedSites(propertyId,
+      // true) returns the property's non-removed PropertyWorkers as
+      // CommonDictionaryModel ({id, name, languageId}) — the exact shape the
+      // modal's `sites` input expects. Locale-aware 'da' sort so Danish
+      // characters (æ/ø/å) order correctly; copy the array first (no in-place
+      // mutation of the service response).
+      const linked = await firstValueFrom(
+        this.propertiesService.getLinkedSites(task.propertyId, true),
+      );
+      if (!linked?.success || !linked.model) return;
+      const sites: CommonDictionaryModel[] =
+        [...linked.model].sort((a, b) => a.name.localeCompare(b.name, 'da'));
 
       const ref = this.dialog.open(CalendarSelectWorkerModalComponent, {
         minWidth: '400px',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-container/task-tracker-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-container/task-tracker-container.component.ts
@@ -311,9 +311,11 @@ export class TaskTrackerContainerComponent implements OnInit, AfterViewInit, Aft
           this.propertyService.getLinkedSites(data.model.propertyId, true)
             .subscribe((sites) => {
               if (sites && sites.success && sites.model) {
-                // only take the sites that are in the data.model.assignedTo
+                // List ALL workers assigned to the event's property (not just the
+                // task-assigned subset), sorted alphabetically by name. Locale-aware
+                // 'da' sort so Danish characters (æ/ø/å) order correctly.
                 this.selectWorkerForEditModal.componentInstance.sites =
-                  sites.model.filter(x => data.model.assignedTo.includes(x.id));
+                  [...sites.model].sort((a, b) => a.name.localeCompare(b.name, 'da'));
                 if (this.selectWorkerForEditModal.componentInstance.sites.length === 1) {
                   this.selectWorkerForEditModal.componentInstance.selectedSite = this.selectWorkerForEditModal.componentInstance.sites[0];
                 }


### PR DESCRIPTION
## Summary
When completing an event, the worker-selection list now shows **all workers assigned to the event's property**, sorted alphabetically — instead of only the task-assigned subset.

## Changes
**Frontend (worker pickers → all property workers, sorted):**
- `task-tracker-container.ts` `openSelectWorkerModal`: drop the `assignedTo` intersection; list full `getLinkedSites(propertyId, true)`, sorted `localeCompare(…, 'da')`.
- `calendar-container.ts` `onToggleCompleteRequested`: fetch property workers via `getLinkedSites` instead of the task's `assigneeIds`/`workerNames`; sorted. Single-worker pre-select preserved in both.

**Backend (allow any active property worker to complete):**
- `BackendConfigurationCalendarService.ToggleComplete`: gate changed from "workerId ∈ PlanningSites" → "workerId ∈ active PropertyWorkers for the planning's property".
- `EventDeployService.DeployForRotationAsync`: the #932/#1377 anti-leak guard widened to allow a site that is in PlanningSites **OR** is an active PropertyWorker; still throws for truly-unassigned sites (no leak).

**Test:**
- New integration test `EnsureComplianceForOccurrence_SiteIsActivePropertyWorkerNotInPlanningSites_Deploys` — asserts a property-worker-not-in-PlanningSites now deploys. The #932/#1377 pin test (truly-unassigned → throws) is unchanged and still passes. Both run green locally against the MariaDB testcontainer.

## Blast-radius note
`DeployForRotationAsync`'s other caller (automated/mobile `EnsureDeployedAsync`) pre-narrows candidates to `PlanningSites` and never reaches the new fallback branch, so the guard relaxation does not regress #932/#1377 for those flows. `PropertyWorker.WorkerId` is the SDK site id (matches `getLinkedSites` and the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)