### PR TITLE
feat(calendar): 25% taller timeslots + equal-strip overlap layout

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/calendar-ui-enhancements.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/calendar-ui-enhancements.page.ts
@@ -40,7 +40,8 @@ export class CalendarUiEnhancementsPage {
     const dayCell = this.page.locator(`.day-cell-content[data-day="${dayOffset}"]`);
     const box = await dayCell.boundingBox();
     if (!box) throw new Error(`Day cell ${dayOffset} not found`);
-    const hourHeight = 52;
+    // Must match HOUR_HEIGHT in calendar-task-block.component.ts.
+    const hourHeight = 65;
     const y = box.y + hour * hourHeight + 5;
     const x = box.x + box.width / 2;
     await this.page.mouse.click(x, y);
@@ -685,7 +686,8 @@ export class CalendarUiEnhancementsPage {
     const targetCell = this.page.locator(`.day-cell-content[data-day="${targetDayOffset}"]`);
     const targetBox = await targetCell.boundingBox();
     if (!targetBox) throw new Error(`Target day cell ${targetDayOffset} not found`);
-    const hourHeight = 52;
+    // Must match HOUR_HEIGHT in calendar-task-block.component.ts.
+    const hourHeight = 65;
     const targetX = targetBox.x + targetBox.width / 2;
     // 5 px into the hour band — same convention as clickEmptyTimeSlot
     // so we land cleanly on H:00 (the grid snaps to 30-min boundaries).

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/l/calendar.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/l/calendar.page.ts
@@ -24,7 +24,8 @@ export class CalendarPage {
     const dayCell = this.page.locator(`.day-cell-content[data-day="${dayOffset}"]`);
     const box = await dayCell.boundingBox();
     if (!box) throw new Error(`Day cell ${dayOffset} not found`);
-    const hourHeight = 52;
+    // Must match HOUR_HEIGHT in calendar-task-block.component.ts.
+    const hourHeight = 65;
     const y = box.y + hour * hourHeight + hourHeight / 2;
     const x = box.x + box.width / 2;
     await this.page.mouse.click(x, y);
@@ -106,7 +107,8 @@ export class CalendarPage {
     const targetBox = await targetCell.boundingBox();
     if (!targetBox) throw new Error(`Target day ${targetDayOffset} not found`);
 
-    const hourHeight = 52;
+    // Must match HOUR_HEIGHT in calendar-task-block.component.ts.
+    const hourHeight = 65;
     const targetY = targetBox.y + targetHour * hourHeight + hourHeight / 2;
     const targetX = targetBox.x + targetBox.width / 2;
 

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/m/calendar-translation.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/m/calendar-translation.spec.ts
@@ -178,7 +178,7 @@ test.describe.serial('Calendar task-modal translation', () => {
 
   // Open the create modal at (dayOffset, hour), scrolling the week grid to the
   // top first. clickEmptyTimeSlot clicks a raw (x,y) computed from the day
-  // column's box + hour*52px; if the grid is auto-scrolled to the current time
+  // column's box + hour*65px; if the grid is auto-scrolled to the current time
   // (e.g. afternoon), an early hour lands off-grid and no modal opens. Scrolling
   // to 00:00 makes the coordinate deterministic regardless of wall-clock time.
   async function openCreateAt(

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-resize-scope.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-resize-scope.spec.ts
@@ -63,10 +63,11 @@ const worker: PropertyWorker = {
 
 let seeded = false;
 
-// HOUR_HEIGHT = 52 px; resize snaps to 15-min (≈13 px) increments. Matches
+// HOUR_HEIGHT = 65 px; resize snaps to 15-min (≈16.25 px) increments. Matches
 // the value used in calendar-resize.spec.ts and `hourHeight` in the page
 // object's clickEmptyTimeSlot / dragEventToSlot.
-const HOUR_PX = 52;
+// Must match HOUR_HEIGHT in calendar-task-block.component.ts.
+const HOUR_PX = 65;
 
 test.describe.serial('Calendar resize scope (#889)', () => {
   test.beforeEach(async ({ page }) => {
@@ -374,7 +375,7 @@ test.describe.serial('Calendar resize scope (#889)', () => {
       await calendarPage.dragResizeHandle(title, 'bottom', -HOUR_PX);
 
       // Height heuristic: at 0.25 h the block is ~1/4 of a 1-h block (HOUR_PX
-      // ≈ 52 px, so ≈13 px minus a few px of card padding). .task-time does
+      // ≈ 65 px, so ≈16.25 px minus a few px of card padding). .task-time does
       // NOT render below 0.5 h, so we assert via boundingBox height like
       // D2/D4 do. We require:
       //   (a) height > 0            — it did NOT collapse to zero/negative;

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-event-card-layout.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-event-card-layout.spec.ts
@@ -124,7 +124,7 @@ test.describe.serial('Calendar event card — adaptive layout', () => {
     const title = `L1-${generateRandmString(5)}`;
 
     // Open the modal at Monday 08:00. Default duration is 1h; shrink the end
-    // to 08:30 so we get a 30-min event (~22px tall at HOUR_HEIGHT=52 → compact).
+    // to 08:30 so we get a 30-min event (~28.5px tall at HOUR_HEIGHT=65 → compact).
     await calendarPage.openCreateModalAtSlot(0, 8);
     await calendarPage.fillAndSaveEvent(title, { endTime: '08:30' });
 

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-resize.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-resize.spec.ts
@@ -39,8 +39,9 @@ const worker: PropertyWorker = {
 
 let seeded = false;
 
-// HOUR_HEIGHT = 52 px; resize snaps to 15-min (13 px) increments.
-const HOUR_PX = 52;
+// HOUR_HEIGHT = 65 px; resize snaps to 15-min (16.25 px) increments.
+// Must match HOUR_HEIGHT in calendar-task-block.component.ts.
+const HOUR_PX = 65;
 
 test.describe.serial('Calendar event resize', () => {
   test.beforeEach(async ({ page }) => {
@@ -190,7 +191,7 @@ test.describe.serial('Calendar event resize', () => {
         const block = calendarPage.findEventBlock(title);
         const box = await block.boundingBox();
         expect(box).not.toBeNull();
-        // 30 min = 26 px (half of HOUR_PX); -4 padding = 22 px height.
+        // 30 min = 32.5 px (half of HOUR_PX); -4 padding = 28.5 px height.
         expect(box!.height).toBeLessThan(40);
       }
     });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
@@ -113,6 +113,10 @@ export interface CalendarTaskLayoutModel extends CalendarTaskModel {
   _left: number;    // left edge in % of day-column usable width
   _width: number;   // width in % of day-column usable width
   _zIndex: number;  // default stacking order within the conflict group
+  // True when this card belongs to a multi-card overlap group. Drives the
+  // click-to-raise behaviour (isInCascade) — geometry alone can't tell, since
+  // the leftmost card in a group has _width === 100 just like a solo card.
+  _inGroup?: boolean;
 }
 
 // Result returned by `PUT /calendar/tasks/{id}/complete`. Three shapes the

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.ts
@@ -72,7 +72,8 @@ export class CalendarTaskBlockComponent {
   }
 
   get widthStyle(): string {
-    if (this.raised) return `${100 - this.task._left}%`;
+    // _width already equals 100 - _left (cards extend to the right edge), so a
+    // raised card needs no width change — raising is driven purely by z-index.
     return `${this.task._width}%`;
   }
 
@@ -82,7 +83,7 @@ export class CalendarTaskBlockComponent {
   }
 
   get isInCascade(): boolean {
-    return this.task._width < 100;
+    return !!this.task._inGroup;
   }
 
   // Click on the card body: always open the detail. For cascaded cards

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.ts
@@ -2,7 +2,7 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {CdkDragEnd, CdkDragMove} from '@angular/cdk/drag-drop';
 import {boardTextColor, CalendarTaskLayoutModel} from '../../../../models/calendar';
 
-export const HOUR_HEIGHT = 52; // px per hour
+export const HOUR_HEIGHT = 65; // px per hour
 
 export interface TaskResizePayload {
   task: CalendarTaskLayoutModel;
@@ -53,14 +53,14 @@ export class CalendarTaskBlockComponent {
     return Math.max(dur * this.hourHeight - 4, 20);
   }
 
-  // Cards shorter than 40 px can't fit the two-row stack without clipping
+  // Cards shorter than 50 px can't fit the two-row stack without clipping
   // the title or wrapping the time. Below the threshold, the template
   // switches to a single inline row (title + time on the same baseline)
-  // and shrinks the type and the completion disc to match. 40 px lands
-  // between a 45-min slot (~35 px) and a 60-min slot (~48 px) at the
+  // and shrinks the type and the completion disc to match. 50 px lands
+  // between a 45-min slot (~45 px) and a 60-min slot (~61 px) at the
   // default HOUR_HEIGHT, so it's a natural break.
   get isCompact(): boolean {
-    return this.heightPx < 40;
+    return this.heightPx < 50;
   }
 
   // Google-Calendar-style cascade-with-overlap. When raised, the card jumps

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-layout.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-layout.service.spec.ts
@@ -21,8 +21,6 @@ function makeTask(id: number, startHour: number, dur: number): CalendarTaskModel
   } as CalendarTaskModel;
 }
 
-const OVERLAP_FACTOR = 1.8;
-
 describe('CalendarLayoutService', () => {
   let service: CalendarLayoutService;
 
@@ -53,27 +51,30 @@ describe('CalendarLayoutService', () => {
     expect(result.every(t => t._left === 0)).toBe(true);
   });
 
-  it('two overlapping tasks: equal-divide-with-overlap geometry', () => {
+  it('two overlapping tasks: extend-right cascade geometry', () => {
     const result = service.computeLayout([makeTask(1, 9, 1), makeTask(2, 9, 1)]);
-    const expectedWidth = 100 * OVERLAP_FACTOR / 2; // 90
-    const expectedStep = (100 - expectedWidth) / (2 - 1); // 10
-    expect(result.every(t => t._width === expectedWidth)).toBe(true);
+    // left = i * 100/2; width = 100 - left, so each card extends to the right edge.
     expect(result[0]._left).toBe(0);
-    expect(result[1]._left).toBe(expectedStep);
+    expect(result[1]._left).toBe(50);
+    expect(result[0]._width).toBe(100);
+    expect(result[1]._width).toBe(50);
     expect(result[0]._zIndex).toBe(10);
     expect(result[1]._zIndex).toBe(11);
   });
 
-  it('three mutually overlapping tasks: evenly distributed left offsets', () => {
+  it('three mutually overlapping tasks: extend-right cascade geometry', () => {
     const result = service.computeLayout([
       makeTask(1, 9, 2),
       makeTask(2, 9, 2),
       makeTask(3, 9, 2),
     ]);
-    const expectedWidth = 100 * OVERLAP_FACTOR / 3; // 60
-    const expectedStep = (100 - expectedWidth) / (3 - 1); // 20
-    expect(result.every(t => t._width === expectedWidth)).toBe(true);
-    expect(result.map(t => t._left)).toEqual([0, expectedStep, expectedStep * 2]);
+    // left = i * 100/3; width = 100 - left.
+    expect(result[0]._left).toBeCloseTo(0, 10);
+    expect(result[1]._left).toBeCloseTo(100 / 3, 10);
+    expect(result[2]._left).toBeCloseTo(200 / 3, 10);
+    expect(result[0]._width).toBe(100);
+    expect(result[1]._width).toBeCloseTo(100 - 100 / 3, 10); // 200/3 ≈ 66.667
+    expect(result[2]._width).toBeCloseTo(100 - 200 / 3, 10); // 100/3 ≈ 33.333
     expect(result.map(t => t._zIndex)).toEqual([10, 11, 12]);
   });
 
@@ -87,9 +88,10 @@ describe('CalendarLayoutService', () => {
     const standalone = result.find(t => t.id === 3)!;
     expect(standalone._width).toBe(100);
     expect(standalone._left).toBe(0);
-    const overlapping = result.filter(t => t.id !== 3);
-    const expectedWidth = 100 * OVERLAP_FACTOR / 2;
-    expect(overlapping.every(t => t._width === expectedWidth)).toBe(true);
+    // Overlapping pair: lefts 0/50, widths extend to the right edge → 100/50.
+    const overlapping = result.filter(t => t.id !== 3).sort((a, b) => a._left - b._left);
+    expect(overlapping.map(t => t._left)).toEqual([0, 50]);
+    expect(overlapping.map(t => t._width)).toEqual([100, 50]);
   });
 
   it('output is sorted by startHour ascending', () => {
@@ -128,5 +130,9 @@ describe('CalendarLayoutService', () => {
     const zIndexes = result.map(t => t._zIndex);
     // Default stacking: later index (in sort order) → higher z-index.
     expect(zIndexes).toEqual([10, 11, 12, 13]);
+    // Lefts step by 100/4 (0, 25, 50, 75); widths extend to the right edge
+    // (100 - left) → 100, 75, 50, 25.
+    expect(result.map(t => t._left)).toEqual([0, 25, 50, 75]);
+    expect(result.map(t => t._width)).toEqual([100, 75, 50, 25]);
   });
 });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-layout.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-layout.service.spec.ts
@@ -43,6 +43,7 @@ describe('CalendarLayoutService', () => {
     expect(result[0]._left).toBe(0);
     expect(result[0]._width).toBe(100);
     expect(result[0]._zIndex).toBe(10);
+    expect(result[0]._inGroup).toBe(false);
   });
 
   it('two non-overlapping tasks each get full width', () => {
@@ -60,6 +61,10 @@ describe('CalendarLayoutService', () => {
     expect(result[1]._width).toBe(50);
     expect(result[0]._zIndex).toBe(10);
     expect(result[1]._zIndex).toBe(11);
+    // Both cards — including the leftmost (_width === 100) — are flagged as in a
+    // multi-card overlap group so click-to-raise works for either.
+    expect(result[0]._inGroup).toBe(true);
+    expect(result[1]._inGroup).toBe(true);
   });
 
   it('three mutually overlapping tasks: extend-right cascade geometry', () => {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-layout.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-layout.service.ts
@@ -1,12 +1,6 @@
 import {Injectable} from '@angular/core';
 import {CalendarTaskLayoutModel, CalendarTaskModel} from '../../../models/calendar';
 
-// Overlap factor for the equal-divide-with-overlap layout. Each card in a
-// conflict group of N gets width = colW * OVERLAP_FACTOR / N, so adjacent
-// cards overlap their neighbours. 1.8 matches Google Calendar's density —
-// measured from screenshots in 2026-05-24 design spec.
-const OVERLAP_FACTOR = 1.8;
-
 @Injectable({providedIn: 'root'})
 export class CalendarLayoutService {
 
@@ -42,17 +36,17 @@ export class CalendarLayoutService {
 
     groups.forEach(group => {
       const n = group.length;
-      if (n === 1) {
-        group[0]._left = 0;
-        group[0]._width = 100;
-        group[0]._zIndex = 10;
-        return;
-      }
-      const cardWidthPct = 100 * OVERLAP_FACTOR / n;
-      const stepPct = (100 - cardWidthPct) / (n - 1);
+      // Cascade-with-overlap: each card in a conflict group of N starts at an
+      // equal 100/N step (left = i * 100/N) but extends all the way to the
+      // right edge (width = 100 - left), so cards behind run underneath the
+      // ones in front. The rightmost card (highest i) sits on top and shows
+      // fully; each earlier card reveals a 100/N strip before the next one
+      // overlaps it. For N === 1 this collapses to a single full-width card
+      // at left 0.
+      const cardWidthPct = 100 / n;
       group.forEach((ev, i) => {
-        ev._left = i * stepPct;
-        ev._width = cardWidthPct;
+        ev._left = i * cardWidthPct;
+        ev._width = 100 - ev._left; // extend to the right edge, behind the cards in front
         ev._zIndex = 10 + i;
       });
     });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-layout.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-layout.service.ts
@@ -14,7 +14,7 @@ export class CalendarLayoutService {
     const events: CalendarTaskLayoutModel[] = tasks
       .slice()
       .sort((a, b) => a.startHour - b.startHour)
-      .map(t => ({...t, _left: 0, _width: 100, _zIndex: 10}));
+      .map(t => ({...t, _left: 0, _width: 100, _zIndex: 10, _inGroup: false}));
 
     // Build conflict groups: any pair that overlaps in time joins the same group.
     const groups: CalendarTaskLayoutModel[][] = [];
@@ -48,6 +48,9 @@ export class CalendarLayoutService {
         ev._left = i * cardWidthPct;
         ev._width = 100 - ev._left; // extend to the right edge, behind the cards in front
         ev._zIndex = 10 + i;
+        // Flag multi-card overlap groups so click-to-raise works even for the
+        // leftmost card (whose _width === 100 is indistinguishable from solo).
+        ev._inGroup = n > 1;
       });
     });
 


### PR DESCRIPTION
## Summary
Two calendar week-view changes from user feedback:

1. **Timeslots 25% taller** — `HOUR_HEIGHT 52 → 65` (one constant; all 19 dependents — grid height, hour labels, now-line, tile top/height, drag/resize snap — scale automatically). Compact-card threshold bumped `40 → 50px` so short tasks keep the single-row layout at the taller scale.

2. **Overlapping tasks → equal text strips, extending right** — each card shows **100/N of text** on its left (1/2/3/4 → 100/50/33/25%), with the card body **extending to the right edge behind the cards in front**; the **rightmost card sits on top**. Formula in `calendar-layout.service.ts`: `left = i·(100/N)`, `width = 100 − left`, `zIndex = 10 + i`. Replaces the old `OVERLAP_FACTOR 1.8` cascade. Continues naturally for 5+ overlaps.

## Notes
- Added `_inGroup` flag to the layout model so click-to-raise still works for the leftmost overlapping card (its `width === 100` is otherwise indistinguishable from a solo card).
- `widthStyle` simplified (the raised branch was redundant once `width === 100 − left`; raise still works via z-index).
- Layout spec (`calendar-layout.service.spec.ts`) updated to the new geometry + `_inGroup` coverage.

Frontend-only. Before/after was reviewed via mockup prior to implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)