### PR TITLE
fix(calendar): default new task to the last-activated board

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/n/calendar-default-board.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/n/calendar-default-board.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../../Page objects/Login.page';
+import { generateRandmString } from '../../../helper-functions';
+import { CalendarUiEnhancementsPage } from '../calendar-ui-enhancements.page';
+import { BackendConfigurationPropertiesPage, PropertyCreateUpdate } from '../BackendConfigurationProperties.page';
+
+// Regression for the user report: the create-task modal pre-selected the
+// lowest-id board (first created) whenever more than one board was active,
+// ignoring the board the user had just activated. PropertyCreateUpdate fields:
+// name?, chrNumber?, cvrNumber?, address?, workOrderFlow?.
+const property: PropertyCreateUpdate = {
+  name: 'cal-board-' + generateRandmString(5),
+  chrNumber: generateRandmString(5),
+  address: generateRandmString(5),
+  cvrNumber: '1111111',
+};
+
+// Board A is created first (lower id, the "Miljøtilsyn" analogue); board B is
+// created + activated last. With both active, the modal must default to B.
+const boardA = 'A-' + generateRandmString(5);
+const boardB = 'B-' + generateRandmString(5);
+
+// --- helpers --------------------------------------------------------------
+
+async function createBoard(page: import('@playwright/test').Page, name: string) {
+  await page.locator('a.sidebar-action-link', { hasText: 'Opret tavle' }).click();
+  const dialog = page.locator('mat-dialog-container');
+  await dialog.locator('input[formcontrolname="name"]').fill(name);
+  await dialog.locator('button.btn-primary', { hasText: 'Opret' }).click();
+  await dialog.waitFor({ state: 'detached', timeout: 10000 });
+  await expect(page.locator('.board-list .board-name', { hasText: name })).toBeVisible({ timeout: 10000 });
+}
+
+function boardItem(page: import('@playwright/test').Page, name: string) {
+  return page.locator('.board-item', { has: page.locator('.board-name', { hasText: name }) });
+}
+
+async function activateBoard(page: import('@playwright/test').Page, name: string) {
+  await boardItem(page, name).locator('.board-name').click();
+  await expect(boardItem(page, name).locator('.board-checkbox.active')).toBeVisible({ timeout: 5000 });
+}
+
+async function deactivateBoard(page: import('@playwright/test').Page, name: string) {
+  await boardItem(page, name).locator('.board-name').click();
+  await expect(boardItem(page, name).locator('.board-checkbox.active')).toHaveCount(0, { timeout: 5000 });
+}
+
+// The mtx-select displays the selected board's name as its value label.
+async function selectedBoardLabel(page: import('@playwright/test').Page): Promise<string> {
+  return (await page.locator('#calendarEventBoard .mtx-select__value, #calendarEventBoard .ng-value-label')
+    .first().innerText()).trim();
+}
+
+// --- tests ----------------------------------------------------------------
+
+test.describe.serial('Calendar new-task default board', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4200');
+    await new LoginPage(page).login();
+  });
+
+  test('seed: property + two boards, activate A then B', async ({ page }) => {
+    const propertiesPage = new BackendConfigurationPropertiesPage(page);
+    await propertiesPage.goToProperties();
+    await propertiesPage.createProperty(property);
+
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    await calendarPage.goToCalendar();
+    await calendarPage.selectProperty(property.name as string);
+
+    await createBoard(page, boardA);
+    await createBoard(page, boardB);
+
+    // Activate A first, then B — both stay checked, B is the last activated.
+    await activateBoard(page, boardA);
+    await activateBoard(page, boardB);
+    await expect(boardItem(page, boardA).locator('.board-checkbox.active')).toBeVisible();
+    await expect(boardItem(page, boardB).locator('.board-checkbox.active')).toBeVisible();
+  });
+
+  test('create modal defaults to the last-activated board (B), not the lowest-id board (A)', async ({ page }) => {
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    await calendarPage.goToCalendar();
+    await calendarPage.selectProperty(property.name as string);
+
+    // Re-activate A then B (a fresh page load reset the in-memory filter).
+    await activateBoard(page, boardA);
+    await activateBoard(page, boardB);
+
+    await calendarPage.clickEmptyTimeSlot(1, 9); // Tuesday 09:00 next week
+    await expect(page.locator('#calendarEventTitle')).toBeVisible({ timeout: 10000 });
+
+    expect(await selectedBoardLabel(page)).toBe(boardB);
+  });
+
+  test('falls back when the last-activated board is deactivated', async ({ page }) => {
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    await calendarPage.goToCalendar();
+    await calendarPage.selectProperty(property.name as string);
+
+    await activateBoard(page, boardA);
+    await activateBoard(page, boardB);
+    await deactivateBoard(page, boardB); // B (the last-activated) is no longer active
+
+    await calendarPage.clickEmptyTimeSlot(1, 9);
+    await expect(page.locator('#calendarEventTitle')).toBeVisible({ timeout: 10000 });
+
+    // The guard drops the no-longer-active last-activated board: the modal must
+    // NOT default to B. It falls back to the existing behavior (the lowest-id
+    // board — here the property's auto-created "Default" board, which stays
+    // active alongside A). The board select is [clearable]="false", so a real
+    // board is always shown — assert it's non-empty and specifically not B.
+    const label = await selectedBoardLabel(page);
+    expect(label.length).toBeGreaterThan(0);
+    expect(label).not.toBe(boardB);
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -72,6 +72,10 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
   currentDate: string = (() => { const d = new Date(); return `${d.getFullYear()}-${(d.getMonth()+1).toString().padStart(2,'0')}-${d.getDate().toString().padStart(2,'0')}`; })();
   viewMode: 'week' | 'day' | 'schedule' = 'week';
   activeBoardIds: number[] = [];
+  // The board the user most recently turned ON in the sidebar. Transient
+  // (in-memory only) — used to default the create-task modal to that board
+  // even when several boards stay checked. Re-seeded on board load.
+  lastActivatedBoardId: number | null = null;
   activeSiteIds: number[] = [];
   activeTeamIds: number[] = [];
   activeTagNames: string[] = [];
@@ -174,6 +178,7 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
         if (autoSelectDefault && this.boards.length > 0) {
           const defaultBoard = this.boards.reduce((min, b) => b.id < min.id ? b : min);
           this.stateService.setActiveBoardIds([defaultBoard.id]);
+          this.lastActivatedBoardId = defaultBoard.id;
         }
         this.propertiesService.getLinkedFolderDtos(propertyId).subscribe(folderRes => {
           if (folderRes && folderRes.success) {
@@ -348,7 +353,10 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       date: event.date,
       startHour: event.startHour,
       boards: this.boards,
-      selectedBoardId: this.activeBoardIds.length === 1 ? this.activeBoardIds[0] : undefined,
+      selectedBoardId:
+        (this.lastActivatedBoardId != null && this.activeBoardIds.includes(this.lastActivatedBoardId))
+          ? this.lastActivatedBoardId
+          : (this.activeBoardIds.length === 1 ? this.activeBoardIds[0] : undefined),
       employees: this.employees,
       tags: this.tags.map(t => t.name),
       propertyId: this.currentPropertyId!,
@@ -466,6 +474,12 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
   }
 
   onBoardToggled(boardId: number) {
+    // The store update is async, so activeBoardIds here still reflects the
+    // pre-toggle state: if the board is not currently active, this click is
+    // turning it ON — remember it as the default for new tasks.
+    if (!this.activeBoardIds.includes(boardId)) {
+      this.lastActivatedBoardId = boardId;
+    }
     this.stateService.toggleBoard(boardId);
     this.loadTasks();
   }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
@@ -446,6 +446,7 @@
         <mat-form-field class="w-100">
           <mat-label>{{ 'My boards' | translate }}</mat-label>
           <mtx-select
+            id="calendarEventBoard"
             [formControl]="boardControl"
             [items]="filteredBoards"
             bindValue="id"


### PR DESCRIPTION
## What

Fixes a user-reported bug: when creating a calendar task, the board ("tavle") dropdown defaulted to the first-created board ("Miljøtilsyn") instead of the board the user had just marked active.

## Root cause

There is no persistent "active/default board" concept — the sidebar checkbox toggles a transient in-memory visibility filter (`activeBoardIds`). The modal only honoured it when **exactly one** board was checked; with more than one active (the common case: the auto-selected default board stays checked when the user activates a new one), it fell back to the lowest-id board.

## Fix

Track the most-recently-activated board in memory:
- `onBoardToggled` records the board when the user turns it **on**.
- `loadBoards` seeds it to the auto-selected board on load / property switch.
- `openCreateModal` passes it to the modal while it's still active; otherwise the existing fallback is preserved.

No DB/API/migration. The modal's own `find(...) ?? fallbackBoard` already guards a stale/deleted id.

## Tests

New Playwright e2e `n/calendar-default-board.spec.ts` (3 serial tests): modal defaults to the last-activated board even when several stay checked; falls back (not the deactivated board) otherwise. All pass locally. Added `id="calendarEventBoard"` to the board select as the test hook.

Design spec: `docs/superpowers/specs/2026-06-09-calendar-new-task-default-board-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)