### PR TITLE
fix(calendar): render now-line in front of task tiles

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-day-column/calendar-day-column.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-day-column/calendar-day-column.component.scss
@@ -46,7 +46,7 @@
       right: 0;
       height: 2px;
       background: var(--error, #ea4335);
-      z-index: 10;
+      z-index: 1000; // above task tiles (incl. raised at 999) so the current-time line shows in front
       pointer-events: none;
 
       &::before {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.scss
@@ -305,7 +305,7 @@
   right: 0;
   height: 2px;
   background: var(--error, #ea4335);
-  z-index: 10;
+  z-index: 1000; // above task tiles (incl. raised at 999) so the current-time line shows in front
   pointer-events: none;
 
   &::before {


### PR DESCRIPTION
## Feedback
"Vis den aktuelle tidslinje i kalender (den røde streg) foran opgaverne og ikke bagved." — show the current-time line in front of the tasks, not behind.

## Fix
The `.now-line` had `z-index: 10`, the same as task tiles (z 10–13, or 999 when raised), so tiles painted over it. Bumped `.now-line` to `z-index: 1000` (above raised tiles) in both `calendar-week-grid` and the parallel `calendar-day-column`. It already has `pointer-events: none`, so it doesn't block clicks/drag on the tiles underneath. No e2e test references the now-line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)