### PR TITLE
feat(calendar): Opgaver og handlinger — calendar task list page

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarTaskListIndexTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarTaskListIndexTest.cs
@@ -1,0 +1,191 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using NSubstitute;
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+/// <summary>
+/// Focused coverage for <c>BackendConfigurationCalendarService.Index</c>, the new
+/// calendar task-list endpoint. <c>Index</c> queries <c>AreaRulePlannings</c> (one
+/// row per recurrence series) and applies the request's filtration model. This
+/// fixture exercises the <c>Filters.Status</c> filter: with two seeded series for
+/// one property (one active, one inactive), an <c>Index</c> call filtered on
+/// <c>Status = true</c> must return only the active series.
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarTaskListIndexTest : TestBaseSetup
+{
+    private IUserService _userService = null!;
+    private IBackendConfigurationTaskWizardService _taskWizardService = null!;
+    private IEventDeployService _eventDeployService = null!;
+    private BackendConfigurationCalendarService _calendarService = null!;
+
+    [SetUp]
+    public async Task SetupCalendarService()
+    {
+        // FK-safe clean of the rows this fixture writes, mirroring the
+        // pattern in BackendConfigurationCalendarServiceTaskTrackerListTest.
+        BackendConfigurationPnDbContext!.AreaRulePlannings.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRulePlannings);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRules.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRules);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.Areas.RemoveRange(
+            BackendConfigurationPnDbContext.Areas);
+        BackendConfigurationPnDbContext.Properties.RemoveRange(
+            BackendConfigurationPnDbContext.Properties);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var sdkConnectionString = MicrotingDbContext!.Database.GetConnectionString()!;
+
+        // GetCurrentUserLanguage() drives translation resolution in Index; a
+        // Language with Id = 1 is enough since the seeded series carry no
+        // AreaRuleTranslations.
+        _userService = Substitute.For<IUserService>();
+        _userService.UserId.Returns(1);
+        var mockLanguage = new Language { Id = 1, Name = "English", LanguageCode = "en-US" };
+        _userService.GetCurrentUserLanguage().Returns(Task.FromResult(mockLanguage));
+
+        _taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        _eventDeployService = Substitute.For<IEventDeployService>();
+
+        // The real EFormCoreService provides GetCore(); Index uses it only to
+        // resolve worker names from the SDK Sites set. The seeded series carry
+        // no PlanningSites, so an empty Sites set is sufficient.
+        _calendarService = new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(),
+            _userService,
+            BackendConfigurationPnDbContext!,
+            new EFormCoreService(sdkConnectionString),
+            _eventDeployService,
+            ItemsPlanningPnDbContext!,
+            _taskWizardService,
+            NullLogger<BackendConfigurationCalendarService>.Instance
+        );
+    }
+
+    /// <summary>
+    /// Seeds Property → Area → AreaRule → AreaRulePlanning using the real
+    /// entities' <c>.Create(BackendConfigurationPnDbContext!)</c>, returning the
+    /// new AreaRulePlanning's Id. The <paramref name="status"/> flag becomes the
+    /// series' <c>Status</c>, which is the column <c>Index</c>'s
+    /// <c>Filters.Status</c> filter targets.
+    /// </summary>
+    private async Task<int> SeedSeries(int propertyId, int areaId, bool status)
+    {
+        var areaRule = new AreaRule
+        {
+            AreaId = areaId,
+            PropertyId = propertyId,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await areaRule.Create(BackendConfigurationPnDbContext!);
+
+        var areaRulePlanning = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id,
+            PropertyId = propertyId,
+            AreaId = areaId,
+            StartDate = DateTime.UtcNow.Date,
+            Status = status,
+            RepeatType = 2,
+            RepeatEvery = 1,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await areaRulePlanning.Create(BackendConfigurationPnDbContext!);
+
+        return areaRulePlanning.Id;
+    }
+
+    /// <summary>
+    /// Two series for one property: one active, one inactive. An Index call
+    /// filtered on Status = true must return the active series and exclude the
+    /// inactive one; every returned row must carry Status == true.
+    /// </summary>
+    [Test]
+    public async Task Index_FiltersByStatus_ReturnsOnlyActiveSeries()
+    {
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1,
+            ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await area.Create(BackendConfigurationPnDbContext!);
+
+        var property = new Property
+        {
+            Name = $"CalendarIndexProp-{Guid.NewGuid()}",
+            ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await property.Create(BackendConfigurationPnDbContext!);
+
+        var activeArpId = await SeedSeries(property.Id, area.Id, status: true);
+        var inactiveArpId = await SeedSeries(property.Id, area.Id, status: false);
+
+        var requestModel = new CalendarTaskIndexRequestModel
+        {
+            Filters = new CalendarTaskListFiltrationModel
+            {
+                PropertyIds = [property.Id],
+                Status = true
+            }
+        };
+
+        var result = await _calendarService.Index(requestModel);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model.Select(x => x.Id), Does.Contain(activeArpId));
+        Assert.That(result.Model.Select(x => x.Id), Does.Not.Contain(inactiveArpId));
+        Assert.That(result.Model.All(x => x.Status), Is.True,
+            "Index filtered on Status = true must return only active series.");
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/CalendarController.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/CalendarController.cs
@@ -29,6 +29,14 @@ public class CalendarController : Controller
         return await _backendConfigurationCalendarService.GetTasksForWeek(requestModel);
     }
 
+    [HttpPost]
+    [Route("tasks/index")]
+    public async Task<OperationDataResult<List<CalendarTaskResponseModel>>> Index(
+        [FromBody] CalendarTaskIndexRequestModel requestModel)
+    {
+        return await _backendConfigurationCalendarService.Index(requestModel);
+    }
+
     [HttpPost("tasks")]
     public async Task<OperationDataResult<int>> CreateTask([FromBody] CalendarTaskCreateRequestModel createModel)
     {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -846,7 +846,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
                 E2EId = "backend-configuration-pn-properties",
                 Link = "/plugins/backend-configuration-pn/properties",
                 Type = MenuItemTypeEnum.Link,
-                Position = 8,
+                Position = 9,
                 MenuTemplate = new PluginMenuTemplateModel
                 {
                     Name = "Properties",
@@ -921,7 +921,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
                 E2EId = "backend-configuration-pn-property-workers",
                 Link = "/plugins/backend-configuration-pn/property-workers",
                 Type = MenuItemTypeEnum.Link,
-                Position = 7,
+                Position = 8,
                 MenuTemplate = new PluginMenuTemplateModel
                 {
                     Name = "Workers",
@@ -996,7 +996,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
                 E2EId = "backend-configuration-pn-task-management",
                 Link = "/plugins/backend-configuration-pn/task-management",
                 Type = MenuItemTypeEnum.Link,
-                Position = 4,
+                Position = 5,
                 MenuTemplate = new PluginMenuTemplateModel
                 {
                     Name = "Task management",
@@ -1146,7 +1146,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
                 E2EId = "backend-configuration-pn-documents",
                 Link = "/plugins/backend-configuration-pn/documents",
                 Type = MenuItemTypeEnum.Link,
-                Position = 6,
+                Position = 7,
                 MenuTemplate = new PluginMenuTemplateModel
                 {
                     Name = "Documents",
@@ -1221,7 +1221,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
                 E2EId = "backend-configuration-pn-files",
                 Link = "/plugins/backend-configuration-pn/files",
                 Type = MenuItemTypeEnum.Link,
-                Position = 5,
+                Position = 6,
                 MenuTemplate = new PluginMenuTemplateModel
                 {
                     Name = "PDF-archive",
@@ -1296,7 +1296,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
                 E2EId = "backend-configuration-pn-task-tracker",
                 Link = "/plugins/backend-configuration-pn/task-tracker",
                 Type = MenuItemTypeEnum.Link,
-                Position = 3,
+                Position = 4,
                 MenuTemplate = new PluginMenuTemplateModel
                 {
                     Name = "Active planned tasks",
@@ -1442,6 +1442,81 @@ public class EformBackendConfigurationPlugin : IEformPlugin
             },
             new()
             {
+                Name = "Tasks and actions",
+                E2EId = "backend-configuration-pn-calendar-task-list",
+                Link = "/plugins/backend-configuration-pn/calendar-task-list",
+                Type = MenuItemTypeEnum.Link,
+                Position = 3,
+                MenuTemplate = new PluginMenuTemplateModel
+                {
+                    Name = "Tasks and actions",
+                    E2EId = "backend-configuration-pn-calendar-task-list",
+                    DefaultLink = "/plugins/backend-configuration-pn/calendar-task-list",
+                    Permissions = [],
+                    Translations =
+                    [
+                        new()
+                        {
+                            LocaleName = LocaleNames.English,
+                            Name = "Tasks and actions",
+                            Language = LanguageNames.English
+                        },
+
+                        new()
+                        {
+                            LocaleName = LocaleNames.German,
+                            Name = "Aufgaben und Aktionen",
+                            Language = LanguageNames.German
+                        },
+
+                        new()
+                        {
+                            LocaleName = LocaleNames.Danish,
+                            Name = "Opgaver og handlinger",
+                            Language = LanguageNames.Danish
+                        },
+
+                        new()
+                        {
+                            LocaleName = LocaleNames.Ukrainian,
+                            Name = "Завдання та дії",
+                            Language = LanguageNames.Ukrainian
+                        }
+                    ]
+                },
+                Translations =
+                [
+                    new()
+                    {
+                        LocaleName = LocaleNames.English,
+                        Name = "Tasks and actions",
+                        Language = LanguageNames.English
+                    },
+
+                    new()
+                    {
+                        LocaleName = LocaleNames.German,
+                        Name = "Aufgaben und Aktionen",
+                        Language = LanguageNames.German
+                    },
+
+                    new()
+                    {
+                        LocaleName = LocaleNames.Danish,
+                        Name = "Opgaver og handlinger",
+                        Language = LanguageNames.Danish
+                    },
+
+                    new()
+                    {
+                        LocaleName = LocaleNames.Ukrainian,
+                        Name = "Завдання та дії",
+                        Language = LanguageNames.Ukrainian
+                    }
+                ]
+            },
+            new()
+            {
                 Name = "Dashboard",
                 E2EId = "backend-configuration-pn-statistics",
                 Link = "/plugins/backend-configuration-pn/statistics",
@@ -1525,7 +1600,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
                 E2EId = "backend-configuration-pn-google-drive-accounts",
                 Link = "/plugins/backend-configuration-pn/google-drive-accounts",
                 Type = MenuItemTypeEnum.Link,
-                Position = 9,
+                Position = 10,
                 MenuTemplate = new PluginMenuTemplateModel
                 {
                     Name = "Connected Google Drive accounts",
@@ -1600,7 +1675,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
                 E2EId = "backend-configuration-pn-reports",
                 Link = "/plugins/backend-configuration-pn/reports",
                 Type = MenuItemTypeEnum.Link,
-                Position = 8,
+                Position = 9,
                 MenuTemplate = new PluginMenuTemplateModel
                 {
                     Name = "Reports v1",

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskIndexRequestModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskIndexRequestModel.cs
@@ -1,0 +1,7 @@
+namespace BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+
+public class CalendarTaskIndexRequestModel
+{
+    public CalendarTaskListFiltrationModel Filters { get; set; } = new();
+    public CalendarTaskListPaginationModel Pagination { get; set; } = new();
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskListFiltrationModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskListFiltrationModel.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+
+public class CalendarTaskListFiltrationModel
+{
+    public List<int> PropertyIds { get; set; } = [];
+    public List<int> BoardIds { get; set; } = [];
+    public List<int> EformIds { get; set; } = [];
+    public List<int> AssignToIds { get; set; } = [];
+    public List<int> TagIds { get; set; } = [];
+    public bool? Status { get; set; }
+    public bool? ComplianceEnabled { get; set; }
+    public string? NameFilter { get; set; }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskListPaginationModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskListPaginationModel.cs
@@ -2,6 +2,11 @@ using Microting.eFormApi.BasePn.Infrastructure.Interfaces;
 
 namespace BackendConfiguration.Pn.Infrastructure.Models.Calendar;
 
+/// <summary>
+/// Sort + pagination request for the calendar task list. Pagination fields are accepted for
+/// parity with the task-wizard request, but the endpoint returns the full filtered+sorted list
+/// and the grid paginates client-side (server applies sort only, via QueryHelper.AddSortToQuery).
+/// </summary>
 public class CalendarTaskListPaginationModel : ICommonPagination, ICommonSort
 {
     /// <inheritdoc />

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskListPaginationModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskListPaginationModel.cs
@@ -1,0 +1,18 @@
+using Microting.eFormApi.BasePn.Infrastructure.Interfaces;
+
+namespace BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+
+public class CalendarTaskListPaginationModel : ICommonPagination, ICommonSort
+{
+    /// <inheritdoc />
+    public int PageSize { get; set; }
+
+    /// <inheritdoc />
+    public int Offset { get; set; }
+
+    /// <inheritdoc />
+    public string Sort { get; set; }
+
+    /// <inheritdoc />
+    public bool IsSortDsc { get; set; }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -1031,6 +1031,157 @@ public class BackendConfigurationCalendarService(
         }
     }
 
+    public async Task<OperationDataResult<List<CalendarTaskResponseModel>>> Index(
+        CalendarTaskIndexRequestModel requestModel)
+    {
+        try
+        {
+            var filters = requestModel.Filters;
+            var userLanguageId = (await userService.GetCurrentUserLanguage()).Id;
+
+            var query = backendConfigurationPnDbContext.AreaRulePlannings
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Include(x => x.AreaRule)
+                    .ThenInclude(x => x.AreaRuleTranslations)
+                .Include(x => x.PlanningSites)
+                .Include(x => x.AreaRulePlanningTags)
+                .AsNoTracking()
+                .AsQueryable();
+
+            if (filters.PropertyIds.Any())
+                query = query.Where(x => filters.PropertyIds.Contains(x.PropertyId));
+            if (filters.Status != null)
+                query = query.Where(x => x.Status == filters.Status.Value);
+            if (filters.ComplianceEnabled != null)
+                query = query.Where(x => x.ComplianceEnabled == filters.ComplianceEnabled.Value);
+            if (filters.EformIds.Any())
+                query = query.Where(x => x.AreaRule.EformId.HasValue && filters.EformIds.Contains(x.AreaRule.EformId.Value));
+            if (filters.AssignToIds.Any())
+                query = query.Where(x => x.PlanningSites
+                    .Where(z => z.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Any(y => filters.AssignToIds.Contains(y.SiteId)));
+            if (filters.TagIds.Any())
+            {
+                foreach (var tagId in filters.TagIds)
+                {
+                    query = query.Where(x =>
+                        x.AreaRulePlanningTags
+                            .Where(y => y.WorkflowState != Constants.WorkflowStates.Removed)
+                            .Any(y => y.ItemPlanningTagId == tagId)
+                        || (x.ItemPlanningTagId.HasValue && x.ItemPlanningTagId.Value == tagId));
+                }
+            }
+            if (filters.BoardIds.Any())
+            {
+                var boardArpIds = await backendConfigurationPnDbContext.CalendarConfigurations
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Where(x => x.BoardId.HasValue && filters.BoardIds.Contains(x.BoardId.Value))
+                    .Select(x => x.AreaRulePlanningId)
+                    .Distinct()
+                    .ToListAsync();
+                query = query.Where(x => boardArpIds.Contains(x.Id));
+            }
+
+            var areaRulePlannings = await query.ToListAsync();
+            var arpIds = areaRulePlannings.Select(x => x.Id).ToList();
+
+            var calConfigsDict = await backendConfigurationPnDbContext.CalendarConfigurations
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Where(x => arpIds.Contains(x.AreaRulePlanningId))
+                .ToDictionaryAsync(x => x.AreaRulePlanningId);
+
+            var planningTagIds = areaRulePlannings
+                .SelectMany(x => x.AreaRulePlanningTags
+                    .Where(y => y.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(y => y.ItemPlanningTagId))
+                .Concat(areaRulePlannings.Where(x => x.ItemPlanningTagId.HasValue).Select(x => x.ItemPlanningTagId.Value))
+                .Distinct().ToList();
+            var planningTagNames = await itemsPlanningPnDbContext.PlanningTags
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Where(x => planningTagIds.Contains(x.Id))
+                .ToDictionaryAsync(x => x.Id, x => x.Name);
+
+            var core = await coreHelper.GetCore().ConfigureAwait(false);
+            await using var sdkDbContext = core.DbContextHelper.GetDbContext();
+            var siteIds = areaRulePlannings
+                .SelectMany(x => x.PlanningSites
+                    .Where(y => y.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(y => (int)y.SiteId))
+                .Distinct().ToList();
+            var siteNamesById = await sdkDbContext.Sites
+                .Where(s => siteIds.Contains((int)s.Id))
+                .ToDictionaryAsync(s => (int)s.Id, s => s.Name ?? string.Empty);
+
+            var rows = areaRulePlannings.Select(arp =>
+            {
+                calConfigsDict.TryGetValue(arp.Id, out var calConfig);
+                var translations = (arp.AreaRule?.AreaRuleTranslations ?? new List<AreaRuleTranslation>())
+                    .Where(t => t.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(t => new CommonTranslationsModel { Id = t.Id, LanguageId = t.LanguageId, Name = t.Name, Description = t.Description })
+                    .ToList();
+                var title = translations.FirstOrDefault(t => t.LanguageId == userLanguageId)?.Name
+                    ?? translations.FirstOrDefault()?.Name ?? "";
+                var description = translations.FirstOrDefault(t => t.LanguageId == userLanguageId)?.Description
+                    ?? translations.FirstOrDefault()?.Description;
+                var assigneeIds = (arp.PlanningSites ?? new List<PlanningSite>())
+                    .Where(ps => ps.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(ps => (int)ps.SiteId).ToList();
+                var tags = (arp.AreaRulePlanningTags ?? new List<AreaRulePlanningTag>())
+                    .Where(t => t.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(t => planningTagNames.TryGetValue(t.ItemPlanningTagId, out var n) ? n : null)
+                    .Where(n => n != null).ToList();
+
+                return new CalendarTaskResponseModel
+                {
+                    Id = arp.Id,
+                    Title = title,
+                    StartHour = calConfig?.StartHour ?? 0,
+                    Duration = calConfig?.Duration ?? 1,
+                    TaskDate = arp.StartDate?.ToString("yyyy-MM-dd") ?? "",
+                    Tags = tags,
+                    AssigneeIds = assigneeIds,
+                    WorkerNames = assigneeIds.Select(id => siteNamesById.GetValueOrDefault(id, string.Empty)).ToList(),
+                    BoardId = calConfig?.BoardId,
+                    Color = calConfig?.Color,
+                    RepeatType = arp.RepeatType ?? 0,
+                    RepeatEvery = arp.RepeatEvery ?? 1,
+                    RepeatEndMode = arp.RepeatEndMode,
+                    RepeatOccurrences = arp.RepeatOccurrences,
+                    RepeatUntilDate = arp.RepeatUntilDate,
+                    DayOfWeek = arp.DayOfWeek,
+                    DayOfMonth = arp.DayOfMonth,
+                    RepeatOrdinalWeek = arp.RepeatOrdinalWeek,
+                    RepeatWeekdaysCsv = arp.RepeatWeekdaysCsv,
+                    Status = arp.Status,
+                    ComplianceEnabled = arp.ComplianceEnabled,
+                    PropertyId = arp.PropertyId,
+                    PlanningId = arp.ItemPlanningId,
+                    EformId = arp.AreaRule?.EformId,
+                    ItemPlanningTagId = arp.ItemPlanningTagId,
+                    DescriptionHtml = description,
+                    Translations = translations,
+                };
+            }).ToList();
+
+            if (!string.IsNullOrWhiteSpace(filters.NameFilter))
+            {
+                var needle = filters.NameFilter.Trim().ToLowerInvariant();
+                rows = rows.Where(r => (r.Title ?? "").ToLowerInvariant().Contains(needle)
+                                       || r.Id.ToString().Contains(needle)).ToList();
+            }
+
+            var sorted = QueryHelper.AddSortToQuery(rows.AsQueryable(), requestModel.Pagination).ToList();
+            return new OperationDataResult<List<CalendarTaskResponseModel>>(true, sorted);
+        }
+        catch (Exception e)
+        {
+            SentrySdk.CaptureException(e);
+            logger.LogError(e, "BackendConfigurationCalendarService.Index: {Message}", e.Message);
+            return new OperationDataResult<List<CalendarTaskResponseModel>>(false,
+                localizationService.GetString("ErrorWhileObtainingTasks"));
+        }
+    }
+
     public async Task<OperationDataResult<int>> CreateTask(CalendarTaskCreateRequestModel createModel)
     {
         try

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -1085,10 +1085,13 @@ public class BackendConfigurationCalendarService(
             var areaRulePlannings = await query.ToListAsync();
             var arpIds = areaRulePlannings.Select(x => x.Id).ToList();
 
-            var calConfigsDict = await backendConfigurationPnDbContext.CalendarConfigurations
+            var calConfigsList = await backendConfigurationPnDbContext.CalendarConfigurations
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                 .Where(x => arpIds.Contains(x.AreaRulePlanningId))
-                .ToDictionaryAsync(x => x.AreaRulePlanningId);
+                .ToListAsync();
+            var calConfigsDict = calConfigsList
+                .GroupBy(x => x.AreaRulePlanningId)
+                .ToDictionary(g => g.Key, g => g.First());
 
             var planningTagIds = areaRulePlannings
                 .SelectMany(x => x.AreaRulePlanningTags

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/IBackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/IBackendConfigurationCalendarService.cs
@@ -9,6 +9,7 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 public interface IBackendConfigurationCalendarService
 {
     Task<OperationDataResult<List<CalendarTaskResponseModel>>> GetTasksForWeek(CalendarTaskRequestModel requestModel);
+    Task<OperationDataResult<List<CalendarTaskResponseModel>>> Index(CalendarTaskIndexRequestModel requestModel);
 
     /// <summary>
     /// Returns the FULL property-scoped compliance list (no deadline window):

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/backend-configuration-pn.routing.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/backend-configuration-pn.routing.ts
@@ -155,6 +155,14 @@ export const routes: Routes = [
           ),
       },
       {
+        path: 'calendar-task-list',
+        canActivate: [AuthGuard],
+        loadChildren: () =>
+          import('./modules/calendar-task-list/calendar-task-list.module').then(
+            (m) => m.CalendarTaskListModule
+          ),
+      },
+      {
         // Google OAuth popup landing route. The backend's
         // GoogleDriveController.OAuthFinish redirects here with either
         // ?gdrive_success=true or ?gdrive_err=<reason>. The component

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -474,4 +474,9 @@ export const da = {
   'Task dimmed on board and not shown in app': 'Opgave nedtonet i tavle og vises ikke i app',
   'Overdue task shown in app': 'Overskredet opgave vises i app',
   'Overdue task not shown in app': 'Overskredet opgave vises ikke i app',
+  'Tasks and actions': 'Opgaver og handlinger',
+  Compliance: 'Compliance',
+  'Export CSV': 'Eksportér CSV',
+  Board: 'Tavle',
+  Search: 'Søg',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -494,4 +494,9 @@ export const enUS= {
   'Task dimmed on board and not shown in app': 'Task dimmed on board and not shown in app',
   'Overdue task shown in app': 'Overdue task shown in app',
   'Overdue task not shown in app': 'Overdue task not shown in app',
+  'Tasks and actions': 'Tasks and actions',
+  Compliance: 'Compliance',
+  'Export CSV': 'Export CSV',
+  Board: 'Board',
+  Search: 'Search',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
@@ -90,6 +90,29 @@ export interface CalendarTaskAttachment {
   driveRevoked?: boolean;
 }
 
+// Request models for the calendar "task list" page (POST /calendar/tasks/index).
+// Mirrors the backend CalendarTaskListRequestModel: a filter block + pagination.
+export interface CalendarTaskListFiltrationModel {
+  propertyIds: number[];
+  boardIds: number[];
+  eformIds: number[];
+  assignToIds: number[];
+  tagIds: number[];
+  status: boolean | null;
+  complianceEnabled: boolean | null;
+  nameFilter: string | null;
+}
+
+export interface CalendarTaskListPaginationModel {
+  sort: string;
+  isSortDsc: boolean;
+}
+
+export interface CalendarTaskIndexRequestModel {
+  filters: CalendarTaskListFiltrationModel;
+  pagination: CalendarTaskListPaginationModel;
+}
+
 export interface CalendarRepeatMeta {
   kind: string;
   n?: number;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
@@ -42,6 +42,13 @@ export interface CalendarTaskModel {
   isAllDay?: boolean;
   exceptionId?: number;
 
+  // Surfaced from the AreaRulePlanning by the calendar `tasks/index` endpoint so
+  // the "Opgaver og handlinger" table can resolve the eForm label and the
+  // "Overskrift" (planning-tag) name from the option lists. Both optional —
+  // the week endpoint does not populate them.
+  eformId?: number | null;
+  itemPlanningTagId?: number | null;
+
   // Persisted custom-repeat fields surfaced from AreaRulePlanning so the
   // edit-modal can reconstruct a full CalendarRepeatMeta for an existing row.
   // All optional/nullable — older backends and rows without a custom rule

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/calendar-task-list-repeat.util.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/calendar-task-list-repeat.util.ts
@@ -1,0 +1,16 @@
+import {TranslateService} from '@ngx-translate/core';
+import {CalendarRepeatService} from '../calendar/services/calendar-repeat.service';
+import {CalendarTaskModel} from '../../models/calendar';
+import {getCurrentLocale} from '../calendar/services/calendar-locale.helper';
+
+export function formatRepeatText(
+  repeatService: CalendarRepeatService,
+  translate: TranslateService,
+  task: CalendarTaskModel,
+): string {
+  if (!task.repeatRule || task.repeatRule === 'none') {
+    return translate.instant('Does not repeat');
+  }
+  const meta = repeatService.reconstructMetaFromTask(task as any);
+  return meta ? repeatService.formatCustomRepeatLabel(meta, getCurrentLocale(translate)) : task.repeatRule;
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/calendar-task-list.module.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/calendar-task-list.module.ts
@@ -1,0 +1,46 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {TranslateModule} from '@ngx-translate/core';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
+import {MatCardModule} from '@angular/material/card';
+import {MatDialogModule} from '@angular/material/dialog';
+import {MtxGridModule} from '@ng-matero/extensions/grid';
+import {MtxSelectModule} from '@ng-matero/extensions/select';
+import {EformSharedModule} from 'src/app/common/modules/eform-shared/eform-shared.module';
+import {CalendarModule} from '../calendar/calendar.module';
+import {CalendarTaskListRouting} from './calendar-task-list.routing';
+import {
+  CalendarTaskListPageComponent,
+  CalendarTaskListFiltersComponent,
+  CalendarTaskListTableComponent,
+} from './components';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    CalendarTaskListRouting,
+    EformSharedModule,
+    TranslateModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatCardModule,
+    MatDialogModule,
+    MtxGridModule,
+    MtxSelectModule,
+    CalendarModule,
+  ],
+  declarations: [
+    CalendarTaskListPageComponent,
+    CalendarTaskListFiltersComponent,
+    CalendarTaskListTableComponent,
+  ],
+})
+export class CalendarTaskListModule {}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/calendar-task-list.routing.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/calendar-task-list.routing.ts
@@ -1,0 +1,11 @@
+import {NgModule} from '@angular/core';
+import {RouterModule, Routes} from '@angular/router';
+import {CalendarTaskListPageComponent} from './components';
+
+const routes: Routes = [{path: '', component: CalendarTaskListPageComponent}];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class CalendarTaskListRouting {}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-filters/calendar-task-list-filters.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-filters/calendar-task-list-filters.component.html
@@ -42,6 +42,6 @@
   </mat-form-field>
   <mat-form-field>
     <mat-label>{{ 'Search' | translate }}</mat-label>
-    <input matInput [(ngModel)]="filters.nameFilter" (ngModelChange)="emit()">
+    <input matInput [(ngModel)]="filters.nameFilter" (ngModelChange)="onSearchChange($event)">
   </mat-form-field>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-filters/calendar-task-list-filters.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-filters/calendar-task-list-filters.component.html
@@ -1,0 +1,47 @@
+<div class="ctl-filters">
+  <mat-form-field>
+    <mat-label>{{ 'Property' | translate }}</mat-label>
+    <mtx-select [items]="properties" bindValue="id" bindLabel="name" [multiple]="true"
+                [(ngModel)]="filters.propertyIds" (ngModelChange)="onPropertyChange($event)"></mtx-select>
+  </mat-form-field>
+  <mat-form-field>
+    <mat-label>{{ 'eForm' | translate }}</mat-label>
+    <mtx-select [items]="eforms" bindValue="id" bindLabel="label" [multiple]="true"
+                [(ngModel)]="filters.eformIds" (ngModelChange)="emit()"></mtx-select>
+  </mat-form-field>
+  <mat-form-field>
+    <mat-label>{{ 'Board' | translate }}</mat-label>
+    <mtx-select [items]="boards" bindValue="id" bindLabel="name" [multiple]="true"
+                [disabled]="filters.propertyIds.length !== 1"
+                [(ngModel)]="filters.boardIds" (ngModelChange)="emit()"></mtx-select>
+  </mat-form-field>
+  <mat-form-field>
+    <mat-label>{{ 'Assigned to' | translate }}</mat-label>
+    <mtx-select [items]="workers" bindValue="id" bindLabel="name" [multiple]="true"
+                [disabled]="filters.propertyIds.length !== 1"
+                [(ngModel)]="filters.assignToIds" (ngModelChange)="emit()"></mtx-select>
+  </mat-form-field>
+  <mat-form-field>
+    <mat-label>{{ 'Active' | translate }}</mat-label>
+    <mtx-select [(ngModel)]="filters.status" (ngModelChange)="emit()" [clearable]="true">
+      <mtx-option [value]="true">{{ 'Yes' | translate }}</mtx-option>
+      <mtx-option [value]="false">{{ 'No' | translate }}</mtx-option>
+    </mtx-select>
+  </mat-form-field>
+  <mat-form-field>
+    <mat-label>{{ 'Compliance' | translate }}</mat-label>
+    <mtx-select [(ngModel)]="filters.complianceEnabled" (ngModelChange)="emit()" [clearable]="true">
+      <mtx-option [value]="true">{{ 'Yes' | translate }}</mtx-option>
+      <mtx-option [value]="false">{{ 'No' | translate }}</mtx-option>
+    </mtx-select>
+  </mat-form-field>
+  <mat-form-field>
+    <mat-label>{{ 'Tags' | translate }}</mat-label>
+    <mtx-select [items]="tags" bindValue="id" bindLabel="name" [multiple]="true"
+                [(ngModel)]="filters.tagIds" (ngModelChange)="emit()"></mtx-select>
+  </mat-form-field>
+  <mat-form-field>
+    <mat-label>{{ 'Search' | translate }}</mat-label>
+    <input matInput [(ngModel)]="filters.nameFilter" (ngModelChange)="emit()">
+  </mat-form-field>
+</div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-filters/calendar-task-list-filters.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-filters/calendar-task-list-filters.component.scss
@@ -1,0 +1,16 @@
+.ctl-filters {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px 16px;
+  margin-bottom: 16px;
+
+  mat-form-field {
+    width: 100%;
+  }
+}
+
+@media (max-width: 1100px) {
+  .ctl-filters {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-filters/calendar-task-list-filters.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-filters/calendar-task-list-filters.component.ts
@@ -1,0 +1,40 @@
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {CommonDictionaryModel, SharedTagModel} from 'src/app/common/models';
+import {CalendarBoardModel, CalendarTaskListFiltrationModel} from '../../../../models/calendar';
+
+@Component({
+  selector: 'app-calendar-task-list-filters',
+  templateUrl: './calendar-task-list-filters.component.html',
+  styleUrls: ['./calendar-task-list-filters.component.scss'],
+  standalone: false,
+})
+export class CalendarTaskListFiltersComponent {
+  @Input() properties: CommonDictionaryModel[] = [];
+  @Input() boards: CalendarBoardModel[] = [];
+  @Input() eforms: {id: number; label: string}[] = [];
+  @Input() workers: CommonDictionaryModel[] = [];
+  @Input() tags: SharedTagModel[] = [];
+  @Output() filtersChanged = new EventEmitter<CalendarTaskListFiltrationModel>();
+  @Output() propertyChanged = new EventEmitter<number | null>();
+
+  filters: CalendarTaskListFiltrationModel = {
+    propertyIds: [], boardIds: [], eformIds: [], assignToIds: [],
+    tagIds: [], status: null, complianceEnabled: null, nameFilter: null,
+  };
+
+  emit() {
+    this.filtersChanged.emit({...this.filters});
+  }
+
+  onPropertyChange(ids: number[]) {
+    this.filters.propertyIds = ids ?? [];
+    // Board/worker option-lists depend on a single chosen property; clear the
+    // selections that no longer apply when the property set changes.
+    if (this.filters.propertyIds.length !== 1) {
+      this.filters.boardIds = [];
+      this.filters.assignToIds = [];
+    }
+    this.propertyChanged.emit(this.filters.propertyIds.length === 1 ? this.filters.propertyIds[0] : null);
+    this.emit();
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-filters/calendar-task-list-filters.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-filters/calendar-task-list-filters.component.ts
@@ -1,4 +1,6 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
+import {Subject} from 'rxjs';
+import {debounceTime, takeUntil} from 'rxjs/operators';
 import {CommonDictionaryModel, SharedTagModel} from 'src/app/common/models';
 import {CalendarBoardModel, CalendarTaskListFiltrationModel} from '../../../../models/calendar';
 
@@ -8,7 +10,7 @@ import {CalendarBoardModel, CalendarTaskListFiltrationModel} from '../../../../m
   styleUrls: ['./calendar-task-list-filters.component.scss'],
   standalone: false,
 })
-export class CalendarTaskListFiltersComponent {
+export class CalendarTaskListFiltersComponent implements OnInit, OnDestroy {
   @Input() properties: CommonDictionaryModel[] = [];
   @Input() boards: CalendarBoardModel[] = [];
   @Input() eforms: {id: number; label: string}[] = [];
@@ -22,8 +24,25 @@ export class CalendarTaskListFiltersComponent {
     tagIds: [], status: null, complianceEnabled: null, nameFilter: null,
   };
 
+  private searchChanged = new Subject<string>();
+  private destroy$ = new Subject<void>();
+
+  ngOnInit() {
+    this.searchChanged.pipe(debounceTime(300), takeUntil(this.destroy$)).subscribe(() => this.emit());
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
   emit() {
     this.filtersChanged.emit({...this.filters});
+  }
+
+  onSearchChange(value: string) {
+    this.filters.nameFilter = value;
+    this.searchChanged.next(value);
   }
 
   onPropertyChange(ids: number[]) {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.html
@@ -1,0 +1,21 @@
+<mat-card>
+  <mat-card-content>
+    <div class="ctl-header">
+      <h1>{{ 'Tasks and actions' | translate }}</h1>
+      <button mat-raised-button color="primary" (click)="exportCsv()">
+        <mat-icon>file_download</mat-icon> {{ 'Export CSV' | translate }}
+      </button>
+    </div>
+    <app-calendar-task-list-filters
+      [properties]="properties" [boards]="boards" [eforms]="eforms"
+      [workers]="workers" [tags]="tags"
+      (filtersChanged)="onFiltersChanged($event)"
+      (propertyChanged)="onPropertyChanged($event)">
+    </app-calendar-task-list-filters>
+    <app-calendar-task-list-table
+      [tasks]="tasks" [properties]="properties" [boards]="boards"
+      [eforms]="eforms" [planningTags]="tags"
+      (editTask)="onEditTask($event)">
+    </app-calendar-task-list-table>
+  </mat-card-content>
+</mat-card>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.scss
@@ -1,0 +1,12 @@
+.ctl-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+
+  h1 {
+    font-size: 28px;
+    font-weight: 700;
+    margin: 0;
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.spec.ts
@@ -1,0 +1,122 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {MatDialog} from '@angular/material/dialog';
+import {Overlay} from '@angular/cdk/overlay';
+import {TranslateModule} from '@ngx-translate/core';
+import {of} from 'rxjs';
+import {EFormService} from 'src/app/common/services';
+import {ItemsPlanningPnTagsService} from 'src/app/plugins/modules/items-planning-pn/services';
+import {
+  BackendConfigurationPnCalendarService,
+  BackendConfigurationPnPropertiesService,
+} from '../../../../services';
+import {CalendarRepeatService} from '../../../calendar/services/calendar-repeat.service';
+import {CalendarTaskListPageComponent} from './calendar-task-list-page.component';
+import {CalendarTaskListFiltrationModel, CalendarTaskModel} from '../../../../models/calendar';
+
+describe('CalendarTaskListPageComponent', () => {
+  let component: CalendarTaskListPageComponent;
+  let fixture: ComponentFixture<CalendarTaskListPageComponent>;
+
+  let calendarServiceStub: any;
+  let propertiesServiceStub: any;
+  let tagsServiceStub: any;
+  let eformServiceStub: any;
+  let dialogStub: any;
+  let afterClosed$: any;
+
+  beforeEach(async () => {
+    calendarServiceStub = {
+      getTasksIndex: jest.fn().mockReturnValue(of({success: true, model: []})),
+      getBoards: jest.fn().mockReturnValue(of({success: true, model: []})),
+    };
+    propertiesServiceStub = {
+      getAllPropertiesDictionary: jest.fn().mockReturnValue(of({success: true, model: []})),
+      getDeviceUsersFiltered: jest.fn().mockReturnValue(of({success: true, model: []})),
+    };
+    tagsServiceStub = {
+      getPlanningsTags: jest.fn().mockReturnValue(of({success: true, model: []})),
+    };
+    eformServiceStub = {
+      getAll: jest.fn().mockReturnValue(of({success: true, model: {templates: []}})),
+    };
+    afterClosed$ = of(false);
+    dialogStub = {
+      open: jest.fn().mockReturnValue({afterClosed: () => afterClosed$}),
+    };
+
+    await TestBed.configureTestingModule({
+      declarations: [CalendarTaskListPageComponent],
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        {provide: MatDialog, useValue: dialogStub},
+        {
+          provide: Overlay,
+          // dialogConfigHelper reads overlay.scrollStrategies.reposition().
+          useValue: {scrollStrategies: {reposition: () => ({})}},
+        },
+        {provide: BackendConfigurationPnCalendarService, useValue: calendarServiceStub},
+        {provide: BackendConfigurationPnPropertiesService, useValue: propertiesServiceStub},
+        {provide: ItemsPlanningPnTagsService, useValue: tagsServiceStub},
+        {provide: EFormService, useValue: eformServiceStub},
+        {provide: CalendarRepeatService, useValue: {}},
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CalendarTaskListPageComponent);
+    component = fixture.componentInstance;
+    // Trigger ngOnInit; every dependency is stubbed to return of(...) so it
+    // completes synchronously without throwing.
+    fixture.detectChanges();
+  });
+
+  it('should create and load on init', () => {
+    expect(component).toBeTruthy();
+    expect(propertiesServiceStub.getAllPropertiesDictionary).toHaveBeenCalled();
+    expect(tagsServiceStub.getPlanningsTags).toHaveBeenCalled();
+    expect(eformServiceStub.getAll).toHaveBeenCalled();
+    expect(calendarServiceStub.getTasksIndex).toHaveBeenCalled();
+  });
+
+  describe('onFiltersChanged', () => {
+    it('reloads tasks through getTasksIndex with the new filters', () => {
+      calendarServiceStub.getTasksIndex.mockClear();
+      const filters: CalendarTaskListFiltrationModel = {
+        propertyIds: [1],
+        boardIds: [10],
+        eformIds: [],
+        assignToIds: [],
+        tagIds: [],
+        status: true,
+        complianceEnabled: null,
+        nameFilter: 'abc',
+      };
+
+      component.onFiltersChanged(filters);
+
+      expect(calendarServiceStub.getTasksIndex).toHaveBeenCalledTimes(1);
+      const calls = calendarServiceStub.getTasksIndex.mock.calls;
+      const arg = calls[calls.length - 1][0];
+      expect(arg.filters).toEqual(filters);
+    });
+  });
+
+  describe('onEditTask', () => {
+    it('opens the edit modal via dialog.open', () => {
+      const task = {
+        id: 7,
+        boardId: 10,
+        propertyId: 1,
+        taskDate: '2026-06-09',
+        startHour: 9,
+        workerNames: [],
+        tags: [],
+      } as unknown as CalendarTaskModel;
+
+      component.onEditTask(task);
+
+      expect(dialogStub.open).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.ts
@@ -1,0 +1,210 @@
+import {Component, OnInit} from '@angular/core';
+import {MatDialog} from '@angular/material/dialog';
+import {Overlay} from '@angular/cdk/overlay';
+import {TranslateService} from '@ngx-translate/core';
+import {of} from 'rxjs';
+import {dialogConfigHelper} from 'src/app/common/helpers';
+import {CommonDictionaryModel, SharedTagModel, TemplateRequestModel} from 'src/app/common/models';
+import {EFormService} from 'src/app/common/services';
+import {
+  CalendarBoardModel,
+  CalendarTaskListFiltrationModel,
+  CalendarTaskModel,
+} from '../../../../models/calendar';
+import {
+  BackendConfigurationPnCalendarService,
+  BackendConfigurationPnPropertiesService,
+} from '../../../../services';
+import {ItemsPlanningPnTagsService} from 'src/app/plugins/modules/items-planning-pn/services';
+import {CalendarRepeatService} from '../../../calendar/services/calendar-repeat.service';
+import {getCurrentLocale} from '../../../calendar/services/calendar-locale.helper';
+import {mapResponseToCalendarTask} from '../../../calendar/services/calendar-task.mapper';
+import {
+  TaskCreateEditModalComponent,
+  TaskCreateEditModalData,
+} from '../../../calendar/modals/task-create-edit-modal/task-create-edit-modal.component';
+
+@Component({
+  selector: 'app-calendar-task-list-page',
+  templateUrl: './calendar-task-list-page.component.html',
+  styleUrls: ['./calendar-task-list-page.component.scss'],
+  standalone: false,
+})
+export class CalendarTaskListPageComponent implements OnInit {
+  properties: CommonDictionaryModel[] = [];
+  boards: CalendarBoardModel[] = [];
+  workers: CommonDictionaryModel[] = [];
+  eforms: {id: number; label: string}[] = [];
+  tags: SharedTagModel[] = [];
+  tasks: CalendarTaskModel[] = [];
+
+  private currentFilters: CalendarTaskListFiltrationModel = {
+    propertyIds: [], boardIds: [], eformIds: [], assignToIds: [],
+    tagIds: [], status: null, complianceEnabled: null, nameFilter: null,
+  };
+
+  constructor(
+    private dialog: MatDialog,
+    private overlay: Overlay,
+    private translate: TranslateService,
+    private calendarService: BackendConfigurationPnCalendarService,
+    private propertiesService: BackendConfigurationPnPropertiesService,
+    private tagsService: ItemsPlanningPnTagsService,
+    private eformService: EFormService,
+    private repeatService: CalendarRepeatService,
+  ) {}
+
+  ngOnInit() {
+    this.loadProperties();
+    this.loadTags();
+    this.loadEforms();
+    this.loadTasks();
+  }
+
+  loadProperties() {
+    this.propertiesService.getAllPropertiesDictionary().subscribe(res => {
+      if (res && res.success) {
+        this.properties = res.model;
+      }
+    });
+  }
+
+  loadTags() {
+    this.tagsService.getPlanningsTags().subscribe(res => {
+      if (res && res.success) {
+        this.tags = res.model;
+      }
+    });
+  }
+
+  loadEforms() {
+    const req = new TemplateRequestModel();
+    req.sort = 'Id';
+    req.isSortDsc = false;
+    req.pageSize = 1000;
+    this.eformService.getAll(req).subscribe(res => {
+      if (res && res.success && res.model) {
+        this.eforms = res.model.templates.map(t => ({id: t.id, label: t.label}));
+      }
+    });
+  }
+
+  loadBoards(propertyId: number) {
+    this.calendarService.getBoards(propertyId).subscribe(res => {
+      if (res && res.success) {
+        this.boards = res.model;
+      }
+    });
+  }
+
+  loadWorkers(propertyId: number) {
+    this.propertiesService.getDeviceUsersFiltered({
+      propertyIds: [propertyId],
+      nameFilter: '',
+      sort: 'Name',
+      isSortDsc: false,
+      showResigned: false,
+      tagIds: [],
+    }).subscribe(res => {
+      if (res && res.success) {
+        this.workers = res.model.map(u => ({
+          id: u.siteId,
+          name: u.fullName || `${u.userFirstName} ${u.userLastName}`.trim() || u.siteName,
+          description: '',
+        } as CommonDictionaryModel));
+      }
+    });
+  }
+
+  onFiltersChanged(filters: CalendarTaskListFiltrationModel) {
+    this.currentFilters = filters;
+    this.loadTasks();
+  }
+
+  onPropertyChanged(propertyId: number | null) {
+    this.boards = [];
+    this.workers = [];
+    if (propertyId != null) {
+      this.loadBoards(propertyId);
+      this.loadWorkers(propertyId);
+    }
+  }
+
+  loadTasks() {
+    this.calendarService.getTasksIndex({
+      filters: this.currentFilters,
+      pagination: {sort: 'Id', isSortDsc: false},
+    }).subscribe(res => {
+      if (res && res.success) {
+        // The index endpoint returns the raw AreaRulePlanning projection (repeat
+        // integers, no `repeatRule`). Map each row exactly as the calendar week
+        // grid does so the humanized Gentagelse + modal `data.task` are identical.
+        this.tasks = (res.model ?? []).map(mapResponseToCalendarTask);
+      }
+    });
+  }
+
+  onEditTask(task: CalendarTaskModel) {
+    const data: TaskCreateEditModalData = {
+      task,
+      date: task.taskDate,
+      startHour: task.startHour,
+      boards: this.boards,
+      selectedBoardId: task.boardId ?? undefined,
+      employees: this.workers,
+      tags: this.tags.map(t => t.name),
+      propertyId: task.propertyId,
+      properties: this.properties,
+      eforms: of(this.eforms),
+      folderId: null,
+      planningTags: this.tags.map(t => ({id: t.id, name: t.name})),
+    };
+    const ref = this.dialog.open(TaskCreateEditModalComponent, {
+      ...dialogConfigHelper(this.overlay, data),
+      minWidth: 1024,
+    });
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.loadTasks();
+      }
+    });
+  }
+
+  exportCsv() {
+    const headers = ['Id', 'Property', 'Board', 'Report headline', 'Task name', 'eForm',
+      'Assigned to', 'Tags', 'Repeat', 'Active', 'Compliance']
+      .map(h => this.translate.instant(h));
+    const rows = this.tasks.map(t => [
+      t.id,
+      this.properties.find(p => p.id === t.propertyId)?.name ?? '',
+      this.boards.find(b => b.id === t.boardId)?.name ?? '',
+      this.tags.find(x => x.id === t.itemPlanningTagId)?.name ?? '',
+      t.title ?? '',
+      this.eforms.find(e => e.id === t.eformId)?.label ?? '',
+      (t.workerNames ?? []).join(', '),
+      (t.tags ?? []).join(', '),
+      this.repeatTextForCsv(t),
+      this.translate.instant(t.status ? 'Yes' : 'No'),
+      this.translate.instant(t.complianceEnabled ? 'Yes' : 'No'),
+    ]);
+    const esc = (v: unknown) => {
+      const s = String(v ?? '');
+      return /[";\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+    };
+    const csv = headers.join(';') + '\n' + rows.map(r => r.map(esc).join(';')).join('\n');
+    const blob = new Blob([new Uint8Array([0xEF, 0xBB, 0xBF]), csv], {type: 'text/csv;charset=utf-8;'});
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'opgaver-og-handlinger.csv';
+    link.click();
+    URL.revokeObjectURL(link.href);
+  }
+
+  private repeatTextForCsv(t: CalendarTaskModel): string {
+    if (!t.repeatRule || t.repeatRule === 'none') {
+      return this.translate.instant('Does not repeat');
+    }
+    const meta = this.repeatService.reconstructMetaFromTask(t);
+    return meta ? this.repeatService.formatCustomRepeatLabel(meta, getCurrentLocale(this.translate)) : t.repeatRule;
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.ts
@@ -121,6 +121,8 @@ export class CalendarTaskListPageComponent implements OnInit {
     this.loadTasks();
   }
 
+  // Board names/colors are resolved from the property-scoped board list, so they only appear
+  // when a single property is selected (table swatch falls back to task.color).
   onPropertyChanged(propertyId: number | null) {
     this.boards = [];
     this.workers = [];
@@ -177,6 +179,7 @@ export class CalendarTaskListPageComponent implements OnInit {
     const rows = this.tasks.map(t => [
       t.id,
       this.properties.find(p => p.id === t.propertyId)?.name ?? '',
+      // Board names only resolve when a single property is selected (boards is property-scoped).
       this.boards.find(b => b.id === t.boardId)?.name ?? '',
       this.tags.find(x => x.id === t.itemPlanningTagId)?.name ?? '',
       t.title ?? '',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.ts
@@ -17,8 +17,8 @@ import {
 } from '../../../../services';
 import {ItemsPlanningPnTagsService} from 'src/app/plugins/modules/items-planning-pn/services';
 import {CalendarRepeatService} from '../../../calendar/services/calendar-repeat.service';
-import {getCurrentLocale} from '../../../calendar/services/calendar-locale.helper';
 import {mapResponseToCalendarTask} from '../../../calendar/services/calendar-task.mapper';
+import {formatRepeatText} from '../../calendar-task-list-repeat.util';
 import {
   TaskCreateEditModalComponent,
   TaskCreateEditModalData,
@@ -201,10 +201,6 @@ export class CalendarTaskListPageComponent implements OnInit {
   }
 
   private repeatTextForCsv(t: CalendarTaskModel): string {
-    if (!t.repeatRule || t.repeatRule === 'none') {
-      return this.translate.instant('Does not repeat');
-    }
-    const meta = this.repeatService.reconstructMetaFromTask(t);
-    return meta ? this.repeatService.formatCustomRepeatLabel(meta, getCurrentLocale(this.translate)) : t.repeatRule;
+    return formatRepeatText(this.repeatService, this.translate, t);
   }
 }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.html
@@ -1,0 +1,33 @@
+<mtx-grid
+  [data]="tasks"
+  [columns]="columns"
+  [cellTemplate]="{board: boardTpl, title: titleTpl, status: statusTpl, compliance: complianceTpl}"
+  [pageOnFront]="true"
+  [showPaginator]="true"
+  [pageSizeOptions]="[5, 10, 25, 50]"
+  [pageSize]="10"
+  [sortOnFront]="true"
+  [rowStriped]="true"
+  noResultText="{{ 'No tasks found' | translate }}">
+</mtx-grid>
+
+<ng-template #boardTpl let-row>
+  <span class="swatch" [style.background]="boardColor(row)"></span>
+  <span>{{ board(row.boardId)?.name ?? '' }}</span>
+</ng-template>
+
+<ng-template #titleTpl let-row>
+  <a class="ctl-link" (click)="onEdit(row)">{{ row.title }}</a>
+</ng-template>
+
+<ng-template #statusTpl let-row>
+  <span class="badge" [ngClass]="row.status ? 'ja' : 'nej'">
+    {{ (row.status ? 'Yes' : 'No') | translate }}
+  </span>
+</ng-template>
+
+<ng-template #complianceTpl let-row>
+  <span class="badge" [ngClass]="row.complianceEnabled ? 'ja' : 'nej'">
+    {{ (row.complianceEnabled ? 'Yes' : 'No') | translate }}
+  </span>
+</ng-template>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.scss
@@ -1,0 +1,40 @@
+:host ::ng-deep {
+  .swatch {
+    display: inline-block;
+    width: 11px;
+    height: 11px;
+    border-radius: 3px;
+    margin-right: 8px;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+    vertical-align: middle;
+  }
+
+  .ctl-link {
+    color: #1d4ed8;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .ctl-link:hover {
+    text-decoration: underline;
+  }
+
+  .badge {
+    display: inline-block;
+    min-width: 42px;
+    text-align: center;
+    border-radius: 6px;
+    padding: 4px 12px;
+    font-weight: 700;
+    color: #fff;
+  }
+
+  .badge.ja {
+    background: #1f8a4c;
+  }
+
+  .badge.nej {
+    background: #c62828;
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.spec.ts
@@ -1,0 +1,135 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {TranslateModule} from '@ngx-translate/core';
+import {CalendarTaskListTableComponent} from './calendar-task-list-table.component';
+import {CalendarRepeatService} from '../../../calendar/services/calendar-repeat.service';
+import {CalendarBoardModel, CalendarTaskModel} from '../../../../models/calendar';
+import {CommonDictionaryModel, SharedTagModel} from 'src/app/common/models';
+
+describe('CalendarTaskListTableComponent', () => {
+  let component: CalendarTaskListTableComponent;
+  let fixture: ComponentFixture<CalendarTaskListTableComponent>;
+  let repeatServiceStub: {
+    reconstructMetaFromTask: jest.Mock;
+    formatCustomRepeatLabel: jest.Mock;
+  };
+
+  const properties: CommonDictionaryModel[] = [
+    {id: 1, name: 'Property One', description: ''},
+    {id: 2, name: 'Property Two', description: ''},
+  ];
+  const boards: CalendarBoardModel[] = [
+    {id: 10, name: 'Board Ten', color: '#d04d4d', propertyId: 1},
+    {id: 20, name: 'Board Twenty', color: '#5ba8ff', propertyId: 2},
+  ];
+  const planningTags: SharedTagModel[] = [{id: 5, name: 'Tag Five'} as SharedTagModel];
+
+  function makeTask(overrides: Partial<CalendarTaskModel> = {}): CalendarTaskModel {
+    return {
+      id: 1,
+      title: 'Task',
+      startHour: 9,
+      duration: 1,
+      startText: '09:00',
+      endText: '10:00',
+      tags: [],
+      assigneeIds: [],
+      workerNames: [],
+      boardId: 10,
+      color: '',
+      descriptionHtml: '',
+      repeatRule: 'none',
+      taskDate: '2026-06-09',
+      completed: false,
+      status: true,
+      complianceEnabled: false,
+      propertyId: 1,
+      ...overrides,
+    } as CalendarTaskModel;
+  }
+
+  beforeEach(async () => {
+    repeatServiceStub = {
+      reconstructMetaFromTask: jest.fn(),
+      // Ignore the locale arg so getCurrentLocale(translate) can't affect output.
+      formatCustomRepeatLabel: jest.fn().mockReturnValue('Ugentligt hver mandag'),
+    };
+
+    await TestBed.configureTestingModule({
+      declarations: [CalendarTaskListTableComponent],
+      imports: [TranslateModule.forRoot()],
+      providers: [{provide: CalendarRepeatService, useValue: repeatServiceStub}],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CalendarTaskListTableComponent);
+    component = fixture.componentInstance;
+    component.properties = properties;
+    component.boards = boards;
+    component.planningTags = planningTags;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('propertyName', () => {
+    it('resolves a name from the @Input properties list', () => {
+      expect(component.propertyName(1)).toBe('Property One');
+      expect(component.propertyName(2)).toBe('Property Two');
+    });
+
+    it('returns empty string for unknown or nullish ids', () => {
+      expect(component.propertyName(999)).toBe('');
+      expect(component.propertyName(null)).toBe('');
+      expect(component.propertyName(undefined)).toBe('');
+    });
+  });
+
+  describe('board', () => {
+    it('resolves a board from the @Input boards list', () => {
+      expect(component.board(10)).toEqual(boards[0]);
+      expect(component.board(20)).toEqual(boards[1]);
+    });
+
+    it('returns undefined for unknown or nullish ids', () => {
+      expect(component.board(999)).toBeUndefined();
+      expect(component.board(null)).toBeUndefined();
+      expect(component.board(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('repeatText', () => {
+    it('returns the stubbed humanized label for a repeating task', () => {
+      const meta = {kind: 'weeklyOne', weekday: 1, endMode: 'never'};
+      repeatServiceStub.reconstructMetaFromTask.mockReturnValue(meta);
+      const task = makeTask({repeatRule: 'custom'});
+
+      const result = component.repeatText(task);
+
+      expect(repeatServiceStub.reconstructMetaFromTask).toHaveBeenCalled();
+      expect(repeatServiceStub.formatCustomRepeatLabel).toHaveBeenCalled();
+      expect(result).toBe('Ugentligt hver mandag');
+    });
+
+    it("returns the 'Does not repeat' key for repeatRule 'none'", () => {
+      // TranslateModule.forRoot() echoes the key when no translation is loaded.
+      const result = component.repeatText(makeTask({repeatRule: 'none'}));
+      expect(result).toBe('Does not repeat');
+      expect(repeatServiceStub.reconstructMetaFromTask).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onEdit', () => {
+    it('emits editTask on row click', () => {
+      const task = makeTask({id: 42});
+      const emitted: CalendarTaskModel[] = [];
+      component.editTask.subscribe((t: CalendarTaskModel) => emitted.push(t));
+
+      component.onEdit(task);
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].id).toBe(42);
+    });
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.ts
@@ -4,7 +4,7 @@ import {MtxGridColumn} from '@ng-matero/extensions/grid';
 import {CommonDictionaryModel, SharedTagModel} from 'src/app/common/models';
 import {CalendarBoardModel, CalendarTaskModel} from '../../../../models/calendar';
 import {CalendarRepeatService} from '../../../calendar/services/calendar-repeat.service';
-import {getCurrentLocale} from '../../../calendar/services/calendar-locale.helper';
+import {formatRepeatText} from '../../calendar-task-list-repeat.util';
 
 @Component({
   selector: 'app-calendar-task-list-table',
@@ -39,14 +39,7 @@ export class CalendarTaskListTableComponent {
   }
 
   repeatText(task: CalendarTaskModel): string {
-    if (!task.repeatRule || task.repeatRule === 'none') {
-      return this.translate.instant('Does not repeat');
-    }
-    const meta = this.repeatService.reconstructMetaFromTask(task);
-    if (!meta) {
-      return task.repeatRule;
-    }
-    return this.repeatService.formatCustomRepeatLabel(meta, getCurrentLocale(this.translate));
+    return formatRepeatText(this.repeatService, this.translate, task);
   }
 
   columns: MtxGridColumn[] = [

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.ts
@@ -1,0 +1,91 @@
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {TranslateService} from '@ngx-translate/core';
+import {MtxGridColumn} from '@ng-matero/extensions/grid';
+import {CommonDictionaryModel, SharedTagModel} from 'src/app/common/models';
+import {CalendarBoardModel, CalendarTaskModel} from '../../../../models/calendar';
+import {CalendarRepeatService} from '../../../calendar/services/calendar-repeat.service';
+import {getCurrentLocale} from '../../../calendar/services/calendar-locale.helper';
+
+@Component({
+  selector: 'app-calendar-task-list-table',
+  templateUrl: './calendar-task-list-table.component.html',
+  styleUrls: ['./calendar-task-list-table.component.scss'],
+  standalone: false,
+})
+export class CalendarTaskListTableComponent {
+  @Input() tasks: CalendarTaskModel[] = [];
+  @Input() properties: CommonDictionaryModel[] = [];
+  @Input() boards: CalendarBoardModel[] = [];
+  @Input() eforms: {id: number; label: string}[] = [];
+  @Input() planningTags: SharedTagModel[] = [];
+  @Output() editTask = new EventEmitter<CalendarTaskModel>();
+
+  constructor(
+    private translate: TranslateService,
+    private repeatService: CalendarRepeatService,
+  ) {}
+
+  propertyName = (id: number | null | undefined): string =>
+    id == null ? '' : (this.properties.find(p => p.id === id)?.name ?? '');
+  board = (id: number | null | undefined): CalendarBoardModel | undefined =>
+    id == null ? undefined : this.boards.find(b => b.id === id);
+  eformLabel = (id: number | null | undefined): string =>
+    id == null ? '' : (this.eforms.find(e => e.id === id)?.label ?? '');
+  planningTagName = (id: number | null | undefined): string =>
+    id == null ? '' : (this.planningTags.find(t => t.id === id)?.name ?? '');
+
+  boardColor(task: CalendarTaskModel): string {
+    return task.color || this.board(task.boardId)?.color || 'transparent';
+  }
+
+  repeatText(task: CalendarTaskModel): string {
+    if (!task.repeatRule || task.repeatRule === 'none') {
+      return this.translate.instant('Does not repeat');
+    }
+    const meta = this.repeatService.reconstructMetaFromTask(task);
+    if (!meta) {
+      return task.repeatRule;
+    }
+    return this.repeatService.formatCustomRepeatLabel(meta, getCurrentLocale(this.translate));
+  }
+
+  columns: MtxGridColumn[] = [
+    {
+      field: 'id', header: this.translate.stream('Id'), sortable: true, sortProp: {id: 'Id'},
+      formatter: (t: CalendarTaskModel) =>
+        `${t.id} <small class="microting-uid">(${t.planningId ?? ''})</small>`,
+    },
+    {
+      field: 'property', header: this.translate.stream('Property'),
+      formatter: (t: CalendarTaskModel) => this.propertyName(t.propertyId),
+    },
+    {field: 'board', header: this.translate.stream('Board')},
+    {
+      field: 'overskrift', header: this.translate.stream('Report headline'),
+      formatter: (t: CalendarTaskModel) => this.planningTagName(t.itemPlanningTagId),
+    },
+    {field: 'title', header: this.translate.stream('Task name'), sortable: true, sortProp: {id: 'Title'}},
+    {
+      field: 'eform', header: this.translate.stream('eForm'),
+      formatter: (t: CalendarTaskModel) => this.eformLabel(t.eformId),
+    },
+    {
+      field: 'assignedTo', header: this.translate.stream('Assigned to'),
+      formatter: (t: CalendarTaskModel) => (t.workerNames ?? []).join('<br/>'),
+    },
+    {
+      field: 'tags', header: this.translate.stream('Tags'),
+      formatter: (t: CalendarTaskModel) => (t.tags ?? []).join(', '),
+    },
+    {
+      field: 'repeat', header: this.translate.stream('Repeat'),
+      formatter: (t: CalendarTaskModel) => this.repeatText(t),
+    },
+    {field: 'status', header: this.translate.stream('Active'), sortable: true, sortProp: {id: 'Status'}},
+    {field: 'compliance', header: this.translate.stream('Compliance')},
+  ];
+
+  onEdit(task: CalendarTaskModel) {
+    this.editTask.emit(task);
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/index.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/index.ts
@@ -1,0 +1,3 @@
+export * from './calendar-task-list-page/calendar-task-list-page.component';
+export * from './calendar-task-list-filters/calendar-task-list-filters.component';
+export * from './calendar-task-list-table/calendar-task-list-table.component';

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/calendar.module.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/calendar.module.ts
@@ -133,6 +133,11 @@ export {
     MtxSelectModule,
     MtxGridModule,
   ],
+  exports: [
+    // Re-export the create/edit modal so a sibling module (the calendar
+    // task-list page) can open it without re-declaring it.
+    TaskCreateEditModalComponent,
+  ],
   providers: [
     // Override MAT_DATE_FORMATS only inside this module so the event-modal
     // date input renders the long Danish form ("Mandag, 21. april") while

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -12,7 +12,6 @@ import {
 } from '../../../../services';
 import {
   CalendarBoardModel,
-  CalendarRepeatRule,
   CalendarTaskLayoutModel,
   CalendarTaskModel,
   CalendarToggleCompleteResult,
@@ -20,6 +19,7 @@ import {
 import {CommonDictionaryModel, SharedTagModel, TemplateRequestModel} from 'src/app/common/models';
 import {EFormService} from 'src/app/common/services';
 import {CalendarLayoutService} from '../../services/calendar-layout.service';
+import {mapResponseToCalendarTask} from '../../services/calendar-task.mapper';
 import {CalendarStateService} from '../store';
 import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {TaskCreateEditModalComponent, TaskCreateEditModalData} from '../../modals/task-create-edit-modal/task-create-edit-modal.component';
@@ -279,10 +279,7 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       )
       .subscribe(res => {
         if (res && res.success) {
-          this.tasks = (res.model || []).map((t: any) => ({
-            ...t,
-            repeatRule: this.mapRepeatType(t.repeatType ?? 0, t.repeatEvery ?? 1),
-          }));
+          this.tasks = (res.model || []).map((t: any) => mapResponseToCalendarTask(t));
           this.rebuildLayout(monday);
         }
       });
@@ -930,17 +927,6 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
     const modalWidth = 500;
     const spaceRight = window.innerWidth - cellRight;
     return spaceRight >= modalWidth + 16 ? cellRight : cellLeft;
-  }
-
-  private mapRepeatType(repeatType: number, repeatEvery: number): CalendarRepeatRule {
-    if (!repeatType || repeatType === 0) return 'none';
-    switch (repeatType) {
-      case 1: return repeatEvery === 1 ? 'daily' : 'custom';
-      case 2: return repeatEvery === 1 ? 'weeklyOne' : 'custom';
-      case 3: return repeatEvery === 1 ? 'monthlyDom' : 'custom';
-      case 4: return repeatEvery === 1 ? 'yearlyOne' : 'custom';
-      default: return 'custom';
-    }
   }
 
   private toLocalDateString(d: Date): string {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-task.mapper.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-task.mapper.ts
@@ -1,0 +1,31 @@
+import {CalendarRepeatRule, CalendarTaskModel} from '../../../models/calendar';
+
+/**
+ * Maps the backend AreaRulePlanning repeat-type/-every integers onto the
+ * frontend's `CalendarRepeatRule` union. Extracted verbatim from
+ * CalendarContainerComponent so both the week-grid and the task-list page
+ * derive the repeat rule identically.
+ */
+export function mapRepeatType(repeatType: number, repeatEvery: number): CalendarRepeatRule {
+  if (!repeatType || repeatType === 0) return 'none';
+  switch (repeatType) {
+    case 1: return repeatEvery === 1 ? 'daily' : 'custom';
+    case 2: return repeatEvery === 1 ? 'weeklyOne' : 'custom';
+    case 3: return repeatEvery === 1 ? 'monthlyDom' : 'custom';
+    case 4: return repeatEvery === 1 ? 'yearlyOne' : 'custom';
+    default: return 'custom';
+  }
+}
+
+/**
+ * Converts a raw `tasks/week` (or `tasks/index`) response item into the
+ * `CalendarTaskModel` that the calendar UI — and the create/edit modal
+ * (`data.task`) — consumes. The DTO already matches the model shape; the only
+ * derived field is `repeatRule`, computed from the persisted repeat integers.
+ */
+export function mapResponseToCalendarTask(dto: any): CalendarTaskModel {
+  return {
+    ...dto,
+    repeatRule: mapRepeatType(dto.repeatType ?? 0, dto.repeatEvery ?? 1),
+  };
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-calendar.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-calendar.service.ts
@@ -5,6 +5,7 @@ import {OperationDataResult, OperationResult} from 'src/app/common/models';
 import {
   CalendarBoardModel,
   CalendarTaskCreateModel,
+  CalendarTaskIndexRequestModel,
   CalendarTaskModel,
   CalendarTaskUpdateModel,
   CalendarToggleCompleteResult,
@@ -14,6 +15,7 @@ import {
 
 export let BackendConfigurationPnCalendarMethods = {
   TasksWeek: 'api/backend-configuration-pn/calendar/tasks/week',
+  Index: 'api/backend-configuration-pn/calendar/tasks/index',
   Tasks: 'api/backend-configuration-pn/calendar/tasks',
   MoveTask: 'api/backend-configuration-pn/calendar/tasks/move',
   ResizeTask: 'api/backend-configuration-pn/calendar/tasks/resize',
@@ -40,6 +42,10 @@ export class BackendConfigurationPnCalendarService {
       tagNames,
       siteIds,
     });
+  }
+
+  getTasksIndex(model: CalendarTaskIndexRequestModel): Observable<OperationDataResult<CalendarTaskModel[]>> {
+    return this.apiBaseService.post(BackendConfigurationPnCalendarMethods.Index, model);
   }
 
   createTask(model: CalendarTaskCreateModel): Observable<OperationDataResult<number>> {


### PR DESCRIPTION
## Summary

Adds a new **"Opgaver og handlinger"** page to the BackendConfiguration plugin — the tabular counterpart to the calendar (`/plugins/backend-configuration-pn/calendar`). It lists calendar tasks (one row per series) with a filter bar, sortable columns, client-side pagination, and CSV export, and **reuses the calendar's existing `TaskCreateEditModalComponent`** for editing (row-click → edit modal). It is distinct from the legacy task-wizard (which is built on the old item-planning system); this is backed by the calendar's task model.

Route: `/plugins/backend-configuration-pn/calendar-task-list`. New endpoint: `POST api/backend-configuration-pn/calendar/tasks/index`.

Design spec & implementation plan: `docs/superpowers/specs/2026-06-09-calendar-task-list-design.md` and `docs/superpowers/plans/2026-06-09-calendar-task-list.md` (in the flutter-eform repo).

## Backend
- New `Index` on `BackendConfigurationCalendarService` (+ interface) querying `AreaRulePlanning` (one row per series, **no occurrence expansion**), mirroring the task-wizard Index pattern. Returns the existing `CalendarTaskResponseModel`.
- Filters: property, board (via `CalendarConfiguration`), eForm, assignee, tags, active, compliance, free-text. Sort via `QueryHelper.AddSortToQuery`; pagination is client-side (documented on the model, matching the task-wizard reference).
- New request/filter/pagination models; `POST calendar/tasks/index` controller action.
- New menu entry in `GetNavigationMenu` (EN "Tasks and actions" / DA "Opgaver og handlinger").
- Integration test (passes against MariaDB Testcontainer) verifying the status filter.

## Frontend
- New lazy module `modules/calendar-task-list/` (filters + table + page components).
- **Gentagelse** column shows the full humanized recurrence via the calendar's existing `CalendarRepeatService` (`reconstructMetaFromTask` + `formatCustomRepeatLabel`) — identical wording to the recurrence picker (e.g. "Ugentligt hver mandag", "Månedligt på den 2. torsdag", "Gentages ikke").
- **Tavle** column shows the board color swatch + name (board metadata is property-scoped, so name/swatch resolve when a single property is filtered; the swatch falls back to the task color).
- Ja/Nej badges for Aktiv/Compliance; clickable Opgavenavn opens the calendar edit modal; CSV built client-side (BOM + `;`, humanized Gentagelse).
- Reuses the calendar modal, `mapResponseToCalendarTask`, and option-list services; extracted a shared `formatRepeatText` helper.
- Jest specs for the table + page (11 tests, pass).

## Verification
- `dotnet build` green; integration test passes (real MariaDB).
- Frontend production build green; 11 Jest tests pass.
- **Live smoke** against the local stack (real 420 data): page + table render, Gentagelse full descriptions, Ja/Nej badges, Tavle swatch (single-property), Aktiv filter changes the row set, edit modal opens populated, CSV downloads correctly.

## ⚠️ Deployment note — menu re-seed
The host syncs plugin menu items into `MenuItems` only on plugin **install/enable**, not on every startup. On an already-seeded DB, the new "Opgaver og handlinger" entry will **not appear in the left nav until the plugin is re-enabled / the menu is re-seeded**. The page is reachable by route in the meantime. The menu code itself follows the exact task-wizard entry pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)