### PR TITLE
feat(calendar): add Start date column to task list

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.ts
@@ -174,7 +174,7 @@ export class CalendarTaskListPageComponent implements OnInit {
 
   exportCsv() {
     const headers = ['Id', 'Property', 'Board', 'Report headline', 'Task name', 'eForm',
-      'Assigned to', 'Tags', 'Repeat', 'Active', 'Compliance']
+      'Assigned to', 'Tags', 'Start date', 'Repeat', 'Active', 'Compliance']
       .map(h => this.translate.instant(h));
     const rows = this.tasks.map(t => [
       t.id,
@@ -186,6 +186,7 @@ export class CalendarTaskListPageComponent implements OnInit {
       this.eforms.find(e => e.id === t.eformId)?.label ?? '',
       (t.workerNames ?? []).join(', '),
       (t.tags ?? []).join(', '),
+      this.formatStartDate(t.taskDate),
       this.repeatTextForCsv(t),
       this.translate.instant(t.status ? 'Yes' : 'No'),
       this.translate.instant(t.complianceEnabled ? 'Yes' : 'No'),
@@ -205,5 +206,14 @@ export class CalendarTaskListPageComponent implements OnInit {
 
   private repeatTextForCsv(t: CalendarTaskModel): string {
     return formatRepeatText(this.repeatService, this.translate, t);
+  }
+
+  // "yyyy-MM-dd" -> "dd-MM-yyyy" (split-and-reorder; no timezone-sensitive Date parsing).
+  private formatStartDate(value: string): string {
+    if (!value) {
+      return '';
+    }
+    const [y, m, d] = value.split('-');
+    return d && m && y ? `${d}-${m}-${y}` : '';
   }
 }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.spec.ts
@@ -120,6 +120,17 @@ describe('CalendarTaskListTableComponent', () => {
     });
   });
 
+  describe('formatStartDate', () => {
+    it('reorders "yyyy-MM-dd" to "dd-MM-yyyy"', () => {
+      expect(component.formatStartDate('2026-06-09')).toBe('09-06-2026');
+    });
+
+    it('returns empty string for empty or malformed input', () => {
+      expect(component.formatStartDate('')).toBe('');
+      expect(component.formatStartDate(undefined as unknown as string)).toBe('');
+    });
+  });
+
   describe('onEdit', () => {
     it('emits editTask on row click', () => {
       const task = makeTask({id: 42});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-table/calendar-task-list-table.component.ts
@@ -42,6 +42,16 @@ export class CalendarTaskListTableComponent {
     return formatRepeatText(this.repeatService, this.translate, task);
   }
 
+  // Converts the row's `taskDate` ("yyyy-MM-dd") to "dd-MM-yyyy" by splitting
+  // and reordering (no `new Date()` parsing, which could shift across timezones).
+  formatStartDate(value: string): string {
+    if (!value) {
+      return '';
+    }
+    const [y, m, d] = value.split('-');
+    return d && m && y ? `${d}-${m}-${y}` : '';
+  }
+
   columns: MtxGridColumn[] = [
     {
       field: 'id', header: this.translate.stream('Id'), sortable: true, sortProp: {id: 'Id'},
@@ -69,6 +79,10 @@ export class CalendarTaskListTableComponent {
     {
       field: 'tags', header: this.translate.stream('Tags'),
       formatter: (t: CalendarTaskModel) => (t.tags ?? []).join(', '),
+    },
+    {
+      field: 'taskDate', header: this.translate.stream('Start date'), sortable: true,
+      formatter: (t: CalendarTaskModel) => this.formatStartDate(t.taskDate),
     },
     {
       field: 'repeat', header: this.translate.stream('Repeat'),


### PR DESCRIPTION
## Summary
Adds a **Start date** ("Startdato") column to the "Opgaver og handlinger" calendar task list and to its CSV export. The data was already on each row (`CalendarTaskResponseModel.TaskDate`), so this is a frontend-only change — no backend/endpoint change.

## Details
- New sortable column in the table, placed before Gentagelse (mirrors the task-wizard ordering), displaying each row's `taskDate` as `dd-MM-yyyy`.
- Column is bound to the raw `taskDate` (`yyyy-MM-dd`) so client-side sort is chronological; display is formatted via a small `formatStartDate` helper that splits/reorders the string (no `new Date()`, so no timezone shift) and returns '' for empty/invalid.
- CSV export gains a matching "Start date" column in the same position (header + value indices verified aligned).
- Reuses the existing `'Start date'` i18n key (`da: 'Start dato'`) — no duplication.

## Verification
- Frontend production build green.
- Jest: 13 tests pass (incl. 2 new `formatStartDate` cases: `2026-06-09` → `09-06-2026`, empty/undefined → '').
- Code-reviewed (spec + quality): no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)