### PR TITLE
fix(calendar): blank task titles from invalid translation LanguageId

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarTranslationLanguageIdRemapTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarTranslationLanguageIdRemapTests.cs
@@ -1,0 +1,157 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction.
+*/
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+using BackendConfiguration.Pn.Infrastructure.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.eForm.Infrastructure.Models;
+
+/// <summary>
+/// Part A regression coverage for the calendar translation LanguageId bug. The
+/// create/edit modal hardcodes the Danish source title's LanguageId to the
+/// frontend app-locale id 1, while target languages already carry the real SDK
+/// Languages.Id from GET /settings/languages. The SDK Languages table is
+/// customer-specific (Danish is NOT guaranteed to be id 1), so a verbatim persist
+/// stores the Danish title under a language no reader queries, producing a blank
+/// event title.
+///
+/// <see cref="AreaRuleLanguageHelper.RemapCommonTranslationLanguageIdsAsync"/> must
+/// remap the hardcoded app-locale ids to the SDK Languages.Id that actually carries
+/// the intended LanguageCode, while leaving true SDK target ids untouched and never
+/// dropping an unresolvable translate.
+///
+/// The SDK pre-seeds default languages as da=1, en-US=2, de-DE=3, so the harness
+/// must first force Danish onto a NON-1 id to reproduce the real-tenant condition.
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarTranslationLanguageIdRemapTests : TestBaseSetup
+{
+    /// <summary>
+    /// Forces the SDK Danish row onto a non-1 auto-increment id (reproducing the
+    /// real customer 420 condition where da=2), and returns (daId, enUsId). The SDK
+    /// default-seeds da=1/en-US=2/de-DE=3; we remove the Danish row and re-insert it
+    /// after a filler so it lands well above 1.
+    /// </summary>
+    private async Task<(int DaId, int EnUsId)> ForceDanishOntoNonOneSdkId()
+    {
+        var existingDa = await MicrotingDbContext!.Languages
+            .FirstOrDefaultAsync(x => x.LanguageCode == "da");
+        if (existingDa != null)
+        {
+            MicrotingDbContext.Languages.Remove(existingDa);
+            await MicrotingDbContext.SaveChangesAsync();
+        }
+
+        // Bump the auto-increment so the re-inserted Danish row is not id 1.
+        await MicrotingDbContext.Languages.AddAsync(
+            new Language { Name = "Filler", LanguageCode = "zz-filler", IsActive = false });
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var da = new Language { Name = "Dansk", LanguageCode = "da", IsActive = true };
+        await MicrotingDbContext.Languages.AddAsync(da);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var enUs = await MicrotingDbContext.Languages.FirstAsync(x => x.LanguageCode == "en-US");
+        return (da.Id, enUs.Id);
+    }
+
+    [Test]
+    public async Task Remap_HardcodedDanishAppLocaleId1_IsRemappedToRealSdkDanishId()
+    {
+        var (daId, _) = await ForceDanishOntoNonOneSdkId();
+        Assert.That(daId, Is.Not.EqualTo(1),
+            "Test precondition: SDK Danish id must differ from app-locale id 1 to reproduce the bug");
+
+        var translates = new List<CommonTranslationsModel>
+        {
+            // Danish source: the frontend hardcodes app-locale id 1.
+            new() { LanguageId = 1, Name = "Tank 4 inspektion", Description = "Kontrollér ventiler." },
+        };
+
+        await AreaRuleLanguageHelper.RemapCommonTranslationLanguageIdsAsync(
+            translates, MicrotingDbContext!, NullLogger.Instance);
+
+        Assert.That(translates[0].LanguageId, Is.EqualTo(daId),
+            "Danish translate must be remapped from app-locale id 1 to the real SDK Danish Languages.Id");
+        Assert.That(translates[0].Name, Is.EqualTo("Tank 4 inspektion"),
+            "Remap must not mutate the translation text");
+    }
+
+    [Test]
+    public async Task Remap_ValidSdkTargetLanguageId_IsLeftUntouched()
+    {
+        var (daId, enUsId) = await ForceDanishOntoNonOneSdkId();
+
+        var translates = new List<CommonTranslationsModel>
+        {
+            // Danish source still arrives as the hardcoded app-locale id 1.
+            new() { LanguageId = 1, Name = "Dansk titel" },
+            // A target language already carries its real SDK id (from getLanguages()).
+            new() { LanguageId = enUsId, Name = "English title" },
+        };
+
+        await AreaRuleLanguageHelper.RemapCommonTranslationLanguageIdsAsync(
+            translates, MicrotingDbContext!, NullLogger.Instance);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translates[0].LanguageId, Is.EqualTo(daId),
+                "Hardcoded Danish app-locale id 1 must be remapped to the SDK Danish id");
+            Assert.That(translates[1].LanguageId, Is.EqualTo(enUsId),
+                "A translate that already carries a valid SDK id must be left untouched");
+        });
+    }
+
+    [Test]
+    public async Task Remap_DefaultSeededTenant_DanishAlreadyAtId1_IsCorrectNoOp()
+    {
+        // Default SDK seed leaves Danish at id 1, so the hardcoded app-locale id 1 is
+        // already correct: the remap must be a no-op (not corrupt it).
+        var existingDa = await MicrotingDbContext!.Languages.FirstAsync(x => x.LanguageCode == "da");
+        Assert.That(existingDa.Id, Is.EqualTo(1),
+            "Test precondition: default-seeded SDK Danish id is 1");
+
+        var translates = new List<CommonTranslationsModel>
+        {
+            new() { LanguageId = 1, Name = "Dansk titel" },
+        };
+
+        await AreaRuleLanguageHelper.RemapCommonTranslationLanguageIdsAsync(
+            translates, MicrotingDbContext, NullLogger.Instance);
+
+        Assert.That(translates[0].LanguageId, Is.EqualTo(1),
+            "When SDK Danish already is id 1, app-locale id 1 must be left unchanged");
+    }
+
+    [Test]
+    public async Task Remap_UnresolvableLanguageId_IsLeftUnchanged_AndTranslationNotDropped()
+    {
+        // 9999 is neither a known app-locale id nor a valid SDK id.
+        var translates = new List<CommonTranslationsModel>
+        {
+            new() { LanguageId = 9999, Name = "Untouched" },
+        };
+
+        await AreaRuleLanguageHelper.RemapCommonTranslationLanguageIdsAsync(
+            translates, MicrotingDbContext!, NullLogger.Instance);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(translates, Has.Count.EqualTo(1),
+                "An unresolvable translate must never be dropped");
+            Assert.That(translates[0].LanguageId, Is.EqualTo(9999),
+                "An unresolvable translate's LanguageId must be left unchanged");
+        });
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarTranslationLanguageIdRemapTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarTranslationLanguageIdRemapTests.cs
@@ -18,42 +18,48 @@ using Microting.eForm.Infrastructure.Models;
 
 /// <summary>
 /// Part A regression coverage for the calendar translation LanguageId bug. The
-/// create/edit modal hardcodes the Danish source title's LanguageId to the
-/// frontend app-locale id 1, while target languages already carry the real SDK
-/// Languages.Id from GET /settings/languages. The SDK Languages table is
-/// customer-specific (Danish is NOT guaranteed to be id 1), so a verbatim persist
-/// stores the Danish title under a language no reader queries, producing a blank
-/// event title.
+/// create/edit modal hardcoded the Danish source title's LanguageId to the frontend
+/// app-locale id 1, while target languages already carry the real SDK Languages.Id
+/// from GET /settings/languages. The SDK Languages table is customer-specific
+/// (Danish is NOT guaranteed to be id 1, and the ids are NOT guaranteed to be the
+/// contiguous set {1,2,3}), so a verbatim persist stores the Danish title under a
+/// language no reader queries, producing a blank event title.
 ///
 /// <see cref="AreaRuleLanguageHelper.RemapCommonTranslationLanguageIdsAsync"/> must
-/// remap the hardcoded app-locale ids to the SDK Languages.Id that actually carries
-/// the intended LanguageCode, while leaving true SDK target ids untouched and never
-/// dropping an unresolvable translate.
+/// be EXISTENCE-based: only an id that is ABSENT from the SDK Languages table is
+/// remapped (via the static app-locale map) to the SDK Languages.Id that carries the
+/// intended LanguageCode. Any id that EXISTS in SDK Languages is a real target id and
+/// must be left untouched — even when it is 2, 3 or 4 — and unresolvable translates
+/// are never dropped.
 ///
-/// The SDK pre-seeds default languages as da=1, en-US=2, de-DE=3, so the harness
-/// must first force Danish onto a NON-1 id to reproduce the real-tenant condition.
+/// These tests reproduce a SHIFTED-ID tenant (da=2, en-US=3, de-DE=4, NO id 1) to
+/// prove the safety property: a valid target id such as en-US=3 must NOT be reinterpreted
+/// via the static map (which historically mis-keyed it to de-DE), which was the corruption
+/// bug this change fixes.
 /// </summary>
 [Parallelizable(ParallelScope.Fixtures)]
 [TestFixture]
 public class CalendarTranslationLanguageIdRemapTests : TestBaseSetup
 {
     /// <summary>
-    /// Forces the SDK Danish row onto a non-1 auto-increment id (reproducing the
-    /// real customer 420 condition where da=2), and returns (daId, enUsId). The SDK
-    /// default-seeds da=1/en-US=2/de-DE=3; we remove the Danish row and re-insert it
-    /// after a filler so it lands well above 1.
+    /// Reproduces a shifted-id tenant: removes the default-seeded da/en-US/de-DE rows,
+    /// consumes id 1 with a filler so it is ABSENT for the language codes, then re-inserts
+    /// da, en-US and de-DE so they land on ascending ids &gt; 1 (typically 2, 3, 4). Returns
+    /// the resolved (daId, enUsId, deDeId). Guarantees no SDK Languages row has id 1.
     /// </summary>
-    private async Task<(int DaId, int EnUsId)> ForceDanishOntoNonOneSdkId()
+    private async Task<(int DaId, int EnUsId, int DeDeId)> ForceShiftedIdTenant()
     {
-        var existingDa = await MicrotingDbContext!.Languages
-            .FirstOrDefaultAsync(x => x.LanguageCode == "da");
-        if (existingDa != null)
+        var codes = new[] { "da", "en-US", "de-DE" };
+        var existing = await MicrotingDbContext!.Languages
+            .Where(x => codes.Contains(x.LanguageCode))
+            .ToListAsync();
+        if (existing.Count > 0)
         {
-            MicrotingDbContext.Languages.Remove(existingDa);
+            MicrotingDbContext.Languages.RemoveRange(existing);
             await MicrotingDbContext.SaveChangesAsync();
         }
 
-        // Bump the auto-increment so the re-inserted Danish row is not id 1.
+        // Consume id 1 with a filler so that no language code resolves to id 1.
         await MicrotingDbContext.Languages.AddAsync(
             new Language { Name = "Filler", LanguageCode = "zz-filler", IsActive = false });
         await MicrotingDbContext.SaveChangesAsync();
@@ -62,20 +68,36 @@ public class CalendarTranslationLanguageIdRemapTests : TestBaseSetup
         await MicrotingDbContext.Languages.AddAsync(da);
         await MicrotingDbContext.SaveChangesAsync();
 
-        var enUs = await MicrotingDbContext.Languages.FirstAsync(x => x.LanguageCode == "en-US");
-        return (da.Id, enUs.Id);
+        var enUs = new Language { Name = "English", LanguageCode = "en-US", IsActive = true };
+        await MicrotingDbContext.Languages.AddAsync(enUs);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var deDe = new Language { Name = "Deutsch", LanguageCode = "de-DE", IsActive = true };
+        await MicrotingDbContext.Languages.AddAsync(deDe);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        // The existence-based remap keys purely off whether the incoming id is present in
+        // SDK Languages, so id 1 must be absent from the WHOLE table for app-locale id 1 to
+        // be treated as the (absent) hardcoded source. The default seed put da on id 1, which
+        // we deleted; auto-increment never reuses it, so id 1 is now free.
+        var hasIdOne = await MicrotingDbContext.Languages.AnyAsync(x => x.Id == 1);
+        Assert.That(hasIdOne, Is.False,
+            "Test precondition: no SDK Languages row may sit on id 1 (shifted-id tenant)");
+
+        return (da.Id, enUs.Id, deDe.Id);
     }
 
     [Test]
-    public async Task Remap_HardcodedDanishAppLocaleId1_IsRemappedToRealSdkDanishId()
+    public async Task Remap_AbsentAppLocaleId1_IsRemappedToRealSdkDanishId()
     {
-        var (daId, _) = await ForceDanishOntoNonOneSdkId();
+        var (daId, _, _) = await ForceShiftedIdTenant();
         Assert.That(daId, Is.Not.EqualTo(1),
             "Test precondition: SDK Danish id must differ from app-locale id 1 to reproduce the bug");
 
         var translates = new List<CommonTranslationsModel>
         {
-            // Danish source: the frontend hardcodes app-locale id 1.
+            // Danish source: the frontend formerly hardcoded app-locale id 1, which is
+            // ABSENT from this tenant's SDK Languages and must be remapped to da's real id.
             new() { LanguageId = 1, Name = "Tank 4 inspektion", Description = "Kontrollér ventiler." },
         };
 
@@ -83,22 +105,63 @@ public class CalendarTranslationLanguageIdRemapTests : TestBaseSetup
             translates, MicrotingDbContext!, NullLogger.Instance);
 
         Assert.That(translates[0].LanguageId, Is.EqualTo(daId),
-            "Danish translate must be remapped from app-locale id 1 to the real SDK Danish Languages.Id");
+            "Absent app-locale id 1 must be remapped to the real SDK Danish Languages.Id");
         Assert.That(translates[0].Name, Is.EqualTo("Tank 4 inspektion"),
             "Remap must not mutate the translation text");
     }
 
     [Test]
-    public async Task Remap_ValidSdkTargetLanguageId_IsLeftUntouched()
+    public async Task Remap_ValidEnUsSdkId_IsLeftUnchanged_NoCorruption()
     {
-        var (daId, enUsId) = await ForceDanishOntoNonOneSdkId();
+        // Regression guard for the corruption bug: a valid en-US SDK id collides with
+        // the static app-locale map's en-US slot (2) only by accident; the OLD value-based
+        // guard remapped any present id 1/2/3 whose SDK code mismatched the static code,
+        // corrupting good targets. The existence-based guard must leave any present id alone.
+        var (_, enUsId, deDeId) = await ForceShiftedIdTenant();
 
         var translates = new List<CommonTranslationsModel>
         {
-            // Danish source still arrives as the hardcoded app-locale id 1.
-            new() { LanguageId = 1, Name = "Dansk titel" },
-            // A target language already carries its real SDK id (from getLanguages()).
             new() { LanguageId = enUsId, Name = "English title" },
+        };
+
+        await AreaRuleLanguageHelper.RemapCommonTranslationLanguageIdsAsync(
+            translates, MicrotingDbContext!, NullLogger.Instance);
+
+        Assert.That(translates[0].LanguageId, Is.EqualTo(enUsId),
+            "A valid SDK en-US id must be left unchanged — never reinterpreted via the static map");
+        Assert.That(translates[0].LanguageId, Is.Not.EqualTo(deDeId),
+            "The corruption bug remapped a valid en-US id onto de-DE; this must not happen");
+    }
+
+    [Test]
+    public async Task Remap_ValidDeDeSdkId_IsLeftUnchanged()
+    {
+        var (_, _, deDeId) = await ForceShiftedIdTenant();
+
+        var translates = new List<CommonTranslationsModel>
+        {
+            new() { LanguageId = deDeId, Name = "Deutscher Titel" },
+        };
+
+        await AreaRuleLanguageHelper.RemapCommonTranslationLanguageIdsAsync(
+            translates, MicrotingDbContext!, NullLogger.Instance);
+
+        Assert.That(translates[0].LanguageId, Is.EqualTo(deDeId),
+            "A valid SDK de-DE id must be left unchanged");
+    }
+
+    [Test]
+    public async Task Remap_MixedSourceAndTargets_OnShiftedTenant_OnlyAbsentIdRemapped()
+    {
+        var (daId, enUsId, deDeId) = await ForceShiftedIdTenant();
+
+        var translates = new List<CommonTranslationsModel>
+        {
+            // Danish source still arrives as the absent app-locale id 1.
+            new() { LanguageId = 1, Name = "Dansk titel" },
+            // Targets already carry their true SDK ids (from getLanguages()).
+            new() { LanguageId = enUsId, Name = "English title" },
+            new() { LanguageId = deDeId, Name = "Deutscher Titel" },
         };
 
         await AreaRuleLanguageHelper.RemapCommonTranslationLanguageIdsAsync(
@@ -107,36 +170,19 @@ public class CalendarTranslationLanguageIdRemapTests : TestBaseSetup
         Assert.Multiple(() =>
         {
             Assert.That(translates[0].LanguageId, Is.EqualTo(daId),
-                "Hardcoded Danish app-locale id 1 must be remapped to the SDK Danish id");
+                "Absent Danish app-locale id 1 must be remapped to the SDK Danish id");
             Assert.That(translates[1].LanguageId, Is.EqualTo(enUsId),
-                "A translate that already carries a valid SDK id must be left untouched");
+                "A translate that already carries a valid SDK en-US id must be left untouched");
+            Assert.That(translates[2].LanguageId, Is.EqualTo(deDeId),
+                "A translate that already carries a valid SDK de-DE id must be left untouched");
         });
     }
 
     [Test]
-    public async Task Remap_DefaultSeededTenant_DanishAlreadyAtId1_IsCorrectNoOp()
+    public async Task Remap_AbsentIdNotInStaticMap_IsLeftUnchanged_AndTranslationNotDropped()
     {
-        // Default SDK seed leaves Danish at id 1, so the hardcoded app-locale id 1 is
-        // already correct: the remap must be a no-op (not corrupt it).
-        var existingDa = await MicrotingDbContext!.Languages.FirstAsync(x => x.LanguageCode == "da");
-        Assert.That(existingDa.Id, Is.EqualTo(1),
-            "Test precondition: default-seeded SDK Danish id is 1");
+        await ForceShiftedIdTenant();
 
-        var translates = new List<CommonTranslationsModel>
-        {
-            new() { LanguageId = 1, Name = "Dansk titel" },
-        };
-
-        await AreaRuleLanguageHelper.RemapCommonTranslationLanguageIdsAsync(
-            translates, MicrotingDbContext, NullLogger.Instance);
-
-        Assert.That(translates[0].LanguageId, Is.EqualTo(1),
-            "When SDK Danish already is id 1, app-locale id 1 must be left unchanged");
-    }
-
-    [Test]
-    public async Task Remap_UnresolvableLanguageId_IsLeftUnchanged_AndTranslationNotDropped()
-    {
         // 9999 is neither a known app-locale id nor a valid SDK id.
         var translates = new List<CommonTranslationsModel>
         {
@@ -151,7 +197,7 @@ public class CalendarTranslationLanguageIdRemapTests : TestBaseSetup
             Assert.That(translates, Has.Count.EqualTo(1),
                 "An unresolvable translate must never be dropped");
             Assert.That(translates[0].LanguageId, Is.EqualTo(9999),
-                "An unresolvable translate's LanguageId must be left unchanged");
+                "An absent id with no static-map entry must be left unchanged");
         });
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/Services/ResolveTaskTitleTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/Services/ResolveTaskTitleTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using NUnit.Framework;
+
+namespace BackendConfiguration.Pn.Test.Services;
+
+[TestFixture]
+public class ResolveTaskTitleTests
+{
+    private static AreaRuleTranslation T(int languageId, string name) =>
+        new() { LanguageId = languageId, Name = name };
+
+    [Test]
+    public void UserLanguageNonEmpty_Wins()
+    {
+        var translations = new List<AreaRuleTranslation>
+        {
+            T(1, "English"),
+            T(2, "Dansk")
+        };
+
+        var title = BackendConfigurationCalendarService.ResolveTaskTitle(translations, 2, null);
+
+        Assert.That(title, Is.EqualTo("Dansk"));
+    }
+
+    [Test]
+    public void UserLanguageEmptyString_FallsBackToOtherLanguage()
+    {
+        // Reproduces the original `??`-only bug: an empty-string name in the
+        // user's language must NOT win; we must fall through to another row.
+        var translations = new List<AreaRuleTranslation>
+        {
+            T(1, "English"),
+            T(2, "")
+        };
+
+        var title = BackendConfigurationCalendarService.ResolveTaskTitle(translations, 2, null);
+
+        Assert.That(title, Is.EqualTo("English"));
+    }
+
+    [Test]
+    public void UserLanguageWhitespace_FallsBackToOtherLanguage()
+    {
+        var translations = new List<AreaRuleTranslation>
+        {
+            T(1, "English"),
+            T(2, "   ")
+        };
+
+        var title = BackendConfigurationCalendarService.ResolveTaskTitle(translations, 2, null);
+
+        Assert.That(title, Is.EqualTo("English"));
+    }
+
+    [Test]
+    public void NoTranslations_UsesFinalFallback()
+    {
+        var title = BackendConfigurationCalendarService.ResolveTaskTitle(
+            new List<AreaRuleTranslation>(), 2, "Compliance Item");
+
+        Assert.That(title, Is.EqualTo("Compliance Item"));
+    }
+
+    [Test]
+    public void NullTranslations_UsesFinalFallback()
+    {
+        var title = BackendConfigurationCalendarService.ResolveTaskTitle(null, 2, "Compliance Item");
+
+        Assert.That(title, Is.EqualTo("Compliance Item"));
+    }
+
+    [Test]
+    public void AllEmptyTranslations_FallsBackToFinalFallback()
+    {
+        var translations = new List<AreaRuleTranslation>
+        {
+            T(1, ""),
+            T(2, "   ")
+        };
+
+        var title = BackendConfigurationCalendarService.ResolveTaskTitle(translations, 2, "Compliance Item");
+
+        Assert.That(title, Is.EqualTo("Compliance Item"));
+    }
+
+    [Test]
+    public void AllEmpty_AndNullFallback_ReturnsEmptyString()
+    {
+        var translations = new List<AreaRuleTranslation>
+        {
+            T(1, ""),
+            T(2, null)
+        };
+
+        var title = BackendConfigurationCalendarService.ResolveTaskTitle(translations, 2, null);
+
+        Assert.That(title, Is.EqualTo(""));
+    }
+
+    [Test]
+    public void AllEmpty_AndWhitespaceFallback_ReturnsEmptyString()
+    {
+        var title = BackendConfigurationCalendarService.ResolveTaskTitle(
+            new List<AreaRuleTranslation>(), 2, "   ");
+
+        Assert.That(title, Is.EqualTo(""));
+    }
+
+    [Test]
+    public void UserLanguageMissing_CrossLanguageFallback_WinsOverFinalFallback()
+    {
+        // Event 113 scenario: translation exists but keyed to a language the
+        // reader didn't query — must degrade to the available title, not the
+        // (often null) compliance fallback.
+        var translations = new List<AreaRuleTranslation>
+        {
+            T(1, "Available Title")
+        };
+
+        var title = BackendConfigurationCalendarService.ResolveTaskTitle(translations, 2, null);
+
+        Assert.That(title, Is.EqualTo("Available Title"));
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -18,6 +18,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <InternalsVisibleTo Include="BackendConfiguration.Pn.Test" />
+    </ItemGroup>
+
+    <ItemGroup>
       <None Remove="Resources\eForms\01. Miljøledelse_skabelon.xml" />
       <None Remove="Resources\eForms\01. Vandforbrug.xml" />
       <None Remove="Resources\eForms\02. Brandudstyr.xml" />

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/AreaRuleLanguageHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/AreaRuleLanguageHelper.cs
@@ -2,7 +2,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microting.eForm.Infrastructure;
+using Microting.eForm.Infrastructure.Models;
 using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
 
 namespace BackendConfiguration.Pn.Infrastructure.Helpers;
@@ -87,6 +89,84 @@ public static class AreaRuleLanguageHelper
             {
                 translation.LanguageId = sdkId;
             }
+        }
+    }
+
+    /// <summary>
+    /// The calendar create/edit modal hardcodes the Danish source title's LanguageId to the
+    /// frontend app-locale id 1 (see task-create-edit-modal.component.ts), while target-language
+    /// translates already carry the real SDK Languages.Id returned by GET /settings/languages.
+    /// Persisting the verbatim id stores the Danish title under LanguageId=1, which no reader ever
+    /// queries (readers match against the user's SDK Languages.Id resolved by LanguageCode), so the
+    /// event title renders blank.
+    ///
+    /// The SDK Languages table is customer-specific (auto-increment ids; Danish is NOT guaranteed to
+    /// be id 1), so the hardcoded app-locale id 1 only happens to be correct when the tenant's
+    /// Danish row landed on id 1. This remaps each incoming translate's LanguageId IN PLACE to the
+    /// SDK Languages.Id that ACTUALLY carries the intended language code, but only when the incoming
+    /// id is one of the frontend's static app-locale ids {1->da, 2->en-US, 3->de-DE} AND the SDK row
+    /// currently at that id is NOT already the matching language. Concretely:
+    ///   * Danish source comes in as app-locale id 1. If SDK id 1 is the Danish row, it is left as-is
+    ///     (correct no-op). If SDK id 1 is some other language (or missing), it is remapped to the
+    ///     SDK id whose LanguageCode == "da".
+    ///   * Target languages already carry their true SDK id whose LanguageCode matches, so they are
+    ///     left untouched (never corrupted), even when that id is 2 or 3.
+    /// Resolution mirrors the #985 seed remap and #982 (resolve by LanguageCode). A translate whose
+    /// app-locale code cannot be resolved to any SDK language is left unchanged (never dropped) and
+    /// logged.
+    /// </summary>
+    public static async Task RemapCommonTranslationLanguageIdsAsync(
+        IEnumerable<CommonTranslationsModel> translations,
+        MicrotingDbContext sdkDbContext,
+        ILogger logger = null)
+    {
+        if (translations == null)
+        {
+            return;
+        }
+
+        var translationList = translations.ToList();
+        if (translationList.Count == 0)
+        {
+            return;
+        }
+
+        var sdkLanguages = await sdkDbContext.Languages.ToListAsync().ConfigureAwait(false);
+        var sdkLanguageById = sdkLanguages.ToDictionary(x => x.Id);
+        // Mirror of the frontend applicationLanguages app-locale ids (1=da, 2=en-US, 3=de-DE).
+        var appLocaleIdToCode = new Dictionary<int, string> { { 1, "da" }, { 2, "en-US" }, { 3, "de-DE" } };
+
+        foreach (var translation in translationList)
+        {
+            // Only the static app-locale ids carry the buggy hardcoded convention; any other id is
+            // a true SDK Languages.Id sent by the modal's target languages -> leave it untouched.
+            if (!appLocaleIdToCode.TryGetValue(translation.LanguageId, out var code))
+            {
+                continue;
+            }
+
+            // The SDK row currently at this id already IS the intended language -> correct no-op
+            // (e.g. a default-seeded tenant where da=1). Avoids corrupting a target that legitimately
+            // carries SDK id 2 or 3.
+            if (sdkLanguageById.TryGetValue(translation.LanguageId, out var sdkAtSameId)
+                && sdkAtSameId.LanguageCode == code)
+            {
+                continue;
+            }
+
+            // The id points at the wrong (or no) language: resolve the intended language by code.
+            var sdkLanguage = sdkLanguages.FirstOrDefault(x => x.LanguageCode == code);
+            if (sdkLanguage != null)
+            {
+                translation.LanguageId = sdkLanguage.Id;
+                continue;
+            }
+
+            // Could not resolve the intended language to a real SDK row: keep the original id (never
+            // drop the translation) and warn so the mis-keyed row is at least traceable.
+            logger?.LogWarning(
+                "RemapCommonTranslationLanguageIdsAsync: could not resolve translate LanguageId {LanguageId} (code {Code}) to a valid SDK Languages.Id; leaving unchanged",
+                translation.LanguageId, code);
         }
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/AreaRuleLanguageHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/AreaRuleLanguageHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,7 +26,7 @@ public static class AreaRuleLanguageHelper
         var seedLanguageIdToSdkId = new Dictionary<int, int>();
         foreach (var (seedLanguageId, code) in seedLanguageIdToCode)
         {
-            var lang = sdkLanguages.FirstOrDefault(x => x.LanguageCode == code);
+            var lang = sdkLanguages.FirstOrDefault(x => string.Equals(x.LanguageCode, code, StringComparison.OrdinalIgnoreCase));
             if (lang != null)
             {
                 seedLanguageIdToSdkId[seedLanguageId] = lang.Id;
@@ -158,7 +159,7 @@ public static class AreaRuleLanguageHelper
             }
 
             // Resolve the intended language by code to its real SDK id.
-            var sdkLanguage = sdkLanguages.FirstOrDefault(x => x.LanguageCode == code);
+            var sdkLanguage = sdkLanguages.FirstOrDefault(x => string.Equals(x.LanguageCode, code, StringComparison.OrdinalIgnoreCase));
             if (sdkLanguage != null)
             {
                 translation.LanguageId = sdkLanguage.Id;

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/AreaRuleLanguageHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/AreaRuleLanguageHelper.cs
@@ -101,19 +101,20 @@ public static class AreaRuleLanguageHelper
     /// event title renders blank.
     ///
     /// The SDK Languages table is customer-specific (auto-increment ids; Danish is NOT guaranteed to
-    /// be id 1), so the hardcoded app-locale id 1 only happens to be correct when the tenant's
-    /// Danish row landed on id 1. This remaps each incoming translate's LanguageId IN PLACE to the
-    /// SDK Languages.Id that ACTUALLY carries the intended language code, but only when the incoming
-    /// id is one of the frontend's static app-locale ids {1->da, 2->en-US, 3->de-DE} AND the SDK row
-    /// currently at that id is NOT already the matching language. Concretely:
-    ///   * Danish source comes in as app-locale id 1. If SDK id 1 is the Danish row, it is left as-is
-    ///     (correct no-op). If SDK id 1 is some other language (or missing), it is remapped to the
-    ///     SDK id whose LanguageCode == "da".
-    ///   * Target languages already carry their true SDK id whose LanguageCode matches, so they are
-    ///     left untouched (never corrupted), even when that id is 2 or 3.
-    /// Resolution mirrors the #985 seed remap and #982 (resolve by LanguageCode). A translate whose
-    /// app-locale code cannot be resolved to any SDK language is left unchanged (never dropped) and
-    /// logged.
+    /// be id 1, and ids are NOT guaranteed to be the contiguous set {1,2,3}). This remaps each
+    /// incoming translate's LanguageId IN PLACE — but the guard is purely EXISTENCE-based, never
+    /// value-based:
+    ///   * If the incoming id EXISTS in the SDK Languages table, it is a real SDK Languages.Id
+    ///     (sent by the modal's target languages, resolved from getLanguages()) -> leave it
+    ///     untouched. This is the critical safety property: a valid target id such as en-US=3 on a
+    ///     shifted-id tenant must NOT be reinterpreted via the static app-locale map (which would
+    ///     mis-key it to de-DE) -> no corruption of good data.
+    ///   * If the incoming id is ABSENT from the SDK Languages table, it can only be the frontend's
+    ///     hardcoded app-locale id {1->da, 2->en-US, 3->de-DE}. Resolve the intended language code
+    ///     from that static map, look up the SDK row by LanguageCode, and remap to its real id.
+    ///   * If an absent id is not in the static map, or its code has no matching SDK row, the
+    ///     translate is left unchanged (never dropped) and a warning is logged.
+    /// Resolution mirrors the #985 seed remap and #982 (resolve by LanguageCode).
     /// </summary>
     public static async Task RemapCommonTranslationLanguageIdsAsync(
         IEnumerable<CommonTranslationsModel> translations,
@@ -131,30 +132,32 @@ public static class AreaRuleLanguageHelper
             return;
         }
 
-        var sdkLanguages = await sdkDbContext.Languages.ToListAsync().ConfigureAwait(false);
-        var sdkLanguageById = sdkLanguages.ToDictionary(x => x.Id);
+        var sdkLanguages = await sdkDbContext.Languages.AsNoTracking().ToListAsync().ConfigureAwait(false);
+        var sdkIds = sdkLanguages.Select(x => x.Id).ToHashSet();
         // Mirror of the frontend applicationLanguages app-locale ids (1=da, 2=en-US, 3=de-DE).
         var appLocaleIdToCode = new Dictionary<int, string> { { 1, "da" }, { 2, "en-US" }, { 3, "de-DE" } };
 
         foreach (var translation in translationList)
         {
-            // Only the static app-locale ids carry the buggy hardcoded convention; any other id is
-            // a true SDK Languages.Id sent by the modal's target languages -> leave it untouched.
+            // EXISTENCE-based guard: a present id is a real SDK Languages.Id (a target language sent
+            // by the modal). Never touch it — reinterpreting it via the static app-locale map would
+            // corrupt valid data on shifted-id tenants (e.g. en-US=3 -> wrongly remapped to de-DE).
+            if (sdkIds.Contains(translation.LanguageId))
+            {
+                continue;
+            }
+
+            // The id is absent from SDK Languages, so it can only be the frontend's hardcoded
+            // app-locale id. Resolve the intended language code from the static map.
             if (!appLocaleIdToCode.TryGetValue(translation.LanguageId, out var code))
             {
+                logger?.LogWarning(
+                    "RemapCommonTranslationLanguageIdsAsync: translate LanguageId {LanguageId} is absent from SDK Languages and is not a known app-locale id; leaving unchanged",
+                    translation.LanguageId);
                 continue;
             }
 
-            // The SDK row currently at this id already IS the intended language -> correct no-op
-            // (e.g. a default-seeded tenant where da=1). Avoids corrupting a target that legitimately
-            // carries SDK id 2 or 3.
-            if (sdkLanguageById.TryGetValue(translation.LanguageId, out var sdkAtSameId)
-                && sdkAtSameId.LanguageCode == code)
-            {
-                continue;
-            }
-
-            // The id points at the wrong (or no) language: resolve the intended language by code.
+            // Resolve the intended language by code to its real SDK id.
             var sdkLanguage = sdkLanguages.FirstOrDefault(x => x.LanguageCode == code);
             if (sdkLanguage != null)
             {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -501,10 +501,7 @@ public class BackendConfigurationCalendarService(
                 var hasNonAlwaysRepeat = arp.RepeatType.HasValue && arp.RepeatType.Value > 0 && !isRepeatAlways;
                 var isAllDay = calConfig == null && !hasNonAlwaysRepeat;
 
-                var title = arp.AreaRule?.AreaRuleTranslations?
-                    .Where(t => t.LanguageId == userLanguageId)
-                    .Select(t => t.Name)
-                    .FirstOrDefault() ?? arp.AreaRule?.AreaRuleTranslations?.FirstOrDefault()?.Name ?? "";
+                var title = ResolveTaskTitle(arp.AreaRule?.AreaRuleTranslations, userLanguageId, null);
 
                 // Per-language title+description for edit-mode prefill, plus the
                 // caller-language description (same selection as the title above).
@@ -732,10 +729,7 @@ public class BackendConfigurationCalendarService(
                 var hasNonAlwaysRepeat = arp.RepeatType.HasValue && arp.RepeatType.Value > 0 && !isRepeatAlways;
                 var isAllDay = movedCalConfig == null && !hasNonAlwaysRepeat;
 
-                var title = arp.AreaRule?.AreaRuleTranslations?
-                    .Where(t => t.LanguageId == userLanguageId)
-                    .Select(t => t.Name)
-                    .FirstOrDefault() ?? arp.AreaRule?.AreaRuleTranslations?.FirstOrDefault()?.Name ?? "";
+                var title = ResolveTaskTitle(arp.AreaRule?.AreaRuleTranslations, userLanguageId, null);
 
                 var translations = arp.AreaRule?.AreaRuleTranslations?
                     .Where(t => t.WorkflowState != Constants.WorkflowStates.Removed)
@@ -903,14 +897,7 @@ public class BackendConfigurationCalendarService(
                 CalendarConfiguration calConfig = null;
                 complianceCalConfigs.TryGetValue(arp.Id, out calConfig);
 
-                var title = compliance.ItemName ?? "";
-                if (arp?.AreaRule?.AreaRuleTranslations != null)
-                {
-                    title = arp.AreaRule.AreaRuleTranslations
-                        .Where(t => t.LanguageId == userLanguageId)
-                        .Select(t => t.Name)
-                        .FirstOrDefault() ?? title;
-                }
+                var title = ResolveTaskTitle(arp?.AreaRule?.AreaRuleTranslations, userLanguageId, compliance.ItemName);
 
                 // Per-language title+description so the edit modal can prefill a
                 // compliance-backed (past) task's multi-language fields.
@@ -4342,14 +4329,7 @@ public class BackendConfigurationCalendarService(
                     }
                 }
 
-                var title = compliance.ItemName ?? "";
-                if (arp?.AreaRule?.AreaRuleTranslations != null)
-                {
-                    title = arp.AreaRule.AreaRuleTranslations
-                        .Where(t => t.LanguageId == userLanguageId)
-                        .Select(t => t.Name)
-                        .FirstOrDefault() ?? title;
-                }
+                var title = ResolveTaskTitle(arp?.AreaRule?.AreaRuleTranslations, userLanguageId, compliance.ItemName);
 
                 // Description in the caller/worker language (same selection as the
                 // title and as GetTasksForWeek): caller language, else first
@@ -4457,5 +4437,27 @@ public class BackendConfigurationCalendarService(
             return new OperationDataResult<List<CalendarTaskResponseModel>>(false,
                 $"{localizationService.GetString("ErrorWhileGettingCalendarTasks")}: {e.Message}");
         }
+    }
+
+    /// <summary>
+    /// Resolves a calendar task title with a robust, cross-language fallback chain:
+    /// 1) the user-language translation with a non-empty name,
+    /// 2) any translation with a non-empty name (cross-language fallback),
+    /// 3) the caller-supplied final fallback (e.g. compliance.ItemName), else "".
+    /// Uses string.IsNullOrWhiteSpace (NOT ??) so empty-string names also fall through.
+    /// </summary>
+    internal static string ResolveTaskTitle(
+        IEnumerable<AreaRuleTranslation> translations, int userLanguageId, string finalFallback)
+    {
+        var list = translations?.ToList() ?? new List<AreaRuleTranslation>();
+        // 1) user-language, non-empty name
+        var byLang = list.FirstOrDefault(t => t.LanguageId == userLanguageId
+                                              && !string.IsNullOrWhiteSpace(t.Name))?.Name;
+        if (!string.IsNullOrWhiteSpace(byLang)) return byLang!;
+        // 2) any translation with a non-empty name (cross-language fallback)
+        var any = list.FirstOrDefault(t => !string.IsNullOrWhiteSpace(t.Name))?.Name;
+        if (!string.IsNullOrWhiteSpace(any)) return any!;
+        // 3) caller-supplied fallback (e.g. compliance.ItemName), else empty
+        return string.IsNullOrWhiteSpace(finalFallback) ? "" : finalFallback!;
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskWizardService/BackendConfigurationTaskWizardService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskWizardService/BackendConfigurationTaskWizardService.cs
@@ -5,6 +5,7 @@ namespace BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService
 using BackendConfigurationLocalizationService;
 using Infrastructure;
 using Infrastructure.Enums;
+using Infrastructure.Helpers;
 using Infrastructure.Models.TaskWizard;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -382,6 +383,14 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
             var core = await _coreHelper.GetCore();
             var sdkDbContext = core.DbContextHelper.GetDbContext();
 
+            // Remap each translate's LanguageId to the real SDK Languages.Id before it is persisted
+            // into PlanningNameTranslation and AreaRuleTranslations below. The calendar modal
+            // hardcodes the Danish source title to app-locale id 1, which is not a valid SDK id and
+            // would otherwise store the title under a language no reader ever queries (blank title).
+            await AreaRuleLanguageHelper
+                .RemapCommonTranslationLanguageIdsAsync(createModel.Translates, sdkDbContext, _logger)
+                .ConfigureAwait(false);
+
             var eformName = sdkDbContext.CheckListTranslations
                 .Where(x => x.CheckListId == createModel.EformId)
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
@@ -699,6 +708,12 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
         {
             var core = await _coreHelper.GetCore();
             var sdkDbContext = core.DbContextHelper.GetDbContext();
+
+            // Remap each translate's LanguageId to the real SDK Languages.Id before it is persisted
+            // into AreaRuleTranslations and PlanningNameTranslation below (same fix as CreateTask).
+            await AreaRuleLanguageHelper
+                .RemapCommonTranslationLanguageIdsAsync(updateModel.Translates, sdkDbContext, _logger)
+                .ConfigureAwait(false);
 
             var eformName = sdkDbContext.CheckListTranslations
                 .Where(x => x.CheckListId == updateModel.EformId)

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -541,6 +541,19 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
    * already typed for a still-present language; collapses the expanded fields
    * if the target set becomes empty.
    */
+  /**
+   * Resolve the real SDK Languages.Id for the Danish source title from the
+   * loaded active-languages list (same list the targets resolve their ids from,
+   * populated from getLanguages() -> SDK Languages). The SDK Languages table is
+   * customer-specific: Danish is NOT guaranteed to be id 1 (e.g. customer 420 has
+   * da=2). Falls back to 1 only if Danish is somehow absent from the loaded list,
+   * so the backend existence-based remap can still recover it.
+   */
+  private resolveDanishLanguageId(): number {
+    const danish = this.activeLanguages.find(l => l.code === 'da');
+    return danish?.id ?? 1;
+  }
+
   private recomputeTargetLanguages(): void {
     const selectedIds = this.assigneeControl.value ?? [];
     const langIds = new Set<number>();
@@ -908,13 +921,14 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       }
     }
 
-    // Build the per-language Translates array: Danish source (languageId 1)
-    // always included, plus one entry per target language that has a non-empty
-    // title OR description. Empty targets are dropped (not persisted).
+    // Build the per-language Translates array: Danish source (real SDK
+    // Languages.Id, NOT the hardcoded app-locale id 1) always included, plus one
+    // entry per target language that has a non-empty title OR description. Empty
+    // targets are dropped (not persisted).
     const danishName = this.titleControl.value ?? '';
     const danishDescription = this.descriptionControl.value ?? '';
     const translates: { name: string; description: string; languageId: number }[] = [
-      {name: danishName, description: danishDescription, languageId: 1},
+      {name: danishName, description: danishDescription, languageId: this.resolveDanishLanguageId()},
     ];
     for (const lang of this.targetLanguages) {
       const name = this.titleByLang[lang.id] ?? '';


### PR DESCRIPTION
## Summary
Calendar/task titles were rendering blank (the tile showed only the numeric id, e.g. "113") for tasks whose Danish title translation was stored under an **invalid LanguageId**. Affected both the Angular calendar and the Flutter mobile app (both read the same `GetTasksForWeek` title resolution).

## Root cause
- The calendar create/edit modal hardcoded the Danish source title as `languageId: 1`, and the backend persisted it **verbatim** into `AreaRuleTranslations` and `PlanningNameTranslation`.
- But the SDK `Languages` table is **customer-specific** (e.g. this tenant: da=2, en-US=5, de-DE=8, **no id 1**). So the Danish title was stored under a language id no reader ever queries → blank title. Confirmed live: AreaRule 113 was created today and still got `LanguageId=1`. The earlier `#985` "remap seed LanguageId" fix only covered seed paths, not the calendar create/update path.
- Secondary: the compliance title branches had no cross-language fallback, so a mis-keyed translation degraded to blank instead of the available name.

## Fix
**Write path (stop minting bad rows):**
- Frontend: the modal now resolves Danish's **real SDK id** by language code from the loaded languages list instead of hardcoding `1`.
- Backend: `AreaRuleLanguageHelper.RemapCommonTranslationLanguageIdsAsync` defensively remaps any incoming translation `LanguageId` that is **absent from SDK Languages**, resolving via language code → SDK `Languages.Id`. Applied on Create + Update, covering both `AreaRuleTranslations` and `PlanningNameTranslation`. Existence-based guard: valid SDK ids are never touched (avoids corrupting multi-language targets on shifted-id tenants).

**Read path (graceful degrade):**
- A single `ResolveTaskTitle` helper replaces 4 inconsistent title-computation sites (recurrence, moved-in, compliance in GetTasksForWeek, compliance in GetTaskTrackerList). Order: user-language non-empty → any non-empty translation → caller fallback (e.g. compliance.ItemName) → "". Uses `IsNullOrWhiteSpace` so empty-string names also fall through (the old `??` only caught null).

## Tests
- Remap: shifted-id tenant scenario; asserts an absent app-locale id is remapped by code AND that a valid SDK target id is left untouched (anti-corruption regression test).
- `ResolveTaskTitle`: user-lang wins, empty-string fall-through, cross-language fallback, null collection, all-empty → "".
- Backend build green; remap + resolver tests pass; frontend build green.

## Note
Existing mis-keyed rows in a database (created before this fix) still carry the bad LanguageId; the read-path fallback makes them display correctly, and they can be repaired by remapping `AreaRuleTranslations`/`PlanningNameTranslation` rows whose LanguageId is absent from SDK `Languages` to the correct id by code (done for the local 420 DB during investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)