### PR TITLE
fix(calendar): completed events always use white text

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.html
@@ -11,7 +11,7 @@
   [style.width]="widthStyle"
   [style.z-index]="zIndexStyle"
   [style.background-color]="task.color"
-  [style.color]="task.status === false ? null : boardTextColor(task.color)"
+  [style.color]="(task.status === false || task.completed) ? null : boardTextColor(task.color)"
   cdkDrag
   [cdkDragData]="task"
   [cdkDragDisabled]="task.completed || resizing"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-task-block/calendar-task-block.component.scss
@@ -31,6 +31,13 @@
   // below), NO strike-through, full opacity. The !important overrides the inline
   // board-colour background, mirroring .gcal-task--inactive. Kept fully opaque so
   // a stacked active tile can't bleed through.
+  //
+  // Text stays white on the green tile and must NOT follow the board-colour
+  // contrast rule (boardTextColor), which picks dark text on the four light
+  // boards. The template emits a null inline [style.color] when completed, so the
+  // .task-block base `color: white` (which .task-time inherits) applies — no
+  // explicit colour needed here (unlike .gcal-task--inactive.completed, which has
+  // to re-assert white over the inactive grey).
   &.completed {
     background-color: #5c7829 !important;
   }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-week-grid/calendar-week-grid.component.html
@@ -7,7 +7,7 @@
            *ngFor="let task of getAllDayTasksForColumn(i)"
            [class.completed]="task.completed"
            [style.background-color]="task.color"
-           [style.color]="boardTextColor(task.color)"
+           [style.color]="task.completed ? null : boardTextColor(task.color)"
            (click)="onAllDayTaskClicked($event, task, i)">
         <span *ngIf="isAdmin" class="task-id">{{ task.id }}</span> {{ task.title }}
       </div>


### PR DESCRIPTION
## Summary

Completed calendar events get a green (`#5c7829`) background (`.completed` class), but their **text colour** still followed the board-colour contrast rule `boardTextColor(task.color)`. That rule returns dark `#1a1a1a` for the four "light" boards (`#fff286` / `#e6cfff` / `#ff88cf` / `#bfd8ff`), producing **unreadable dark text on the green tile**. Completed events should always be white.

## Fix (Option B — emit null inline colour, let base CSS win)

- `calendar-task-block.component.html` — timed tiles: `[style.color]` now emits `null` when `task.completed` (in addition to the existing inactive guard), so the base `.task-block { color: white }` (which `.task-time` inherits) applies.
- `calendar-week-grid.component.html` — all-day chips: same `task.completed ? null : …` guard; base `.all-day-chip { color: #fff }` applies.
- `calendar-task-block.component.scss` — comment only (no rule change): documents why no explicit colour is needed on `.completed` (base is already white), unlike `.gcal-task--inactive.completed` which must re-assert white over the inactive grey.

The text colour is now **board-colour-independent** for completed events; non-completed events keep the contrast rule unchanged. Mirrors the existing inactive-tile null-emit mechanism.

## Verification

Live on `/plugins/backend-configuration-pn/calendar`: a completed tile has the inline colour removed and computes `rgb(255,255,255)` white on the green background; simulating the old path (`#1a1a1a` inline) reproduced the dark-on-green bug. Reviewed by code-reviewer + code-simplifier (no issues; confirmed no regression for the inactive+completed combination, drag-ghost, or schedule view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)