### PR TITLE
ci: set ALLOW_FAKE_TRANSLATE=true for translation e2e

### DIFF
--- a/.github/workflows/dotnet-core-master.yml
+++ b/.github/workflows/dotnet-core-master.yml
@@ -94,7 +94,7 @@ jobs:
       run: sleep 15
     - name: Start the newly build Docker container
       id: docker-run
-      run: docker run --name my-container -p 4200:5000 --network data microtingas/work-items-planning-container:latest "/ConnectionString=host=mariadbtest;Database=420_Angular;user=root;password=secretpassword;port=3306;Convert Zero Datetime = true;SslMode=none;" "/api-key=FAKE_TRANSLATE_E2E" > docker_run_log 2>&1 &
+      run: docker run --name my-container -p 4200:5000 --network data -e ALLOW_FAKE_TRANSLATE=true microtingas/work-items-planning-container:latest "/ConnectionString=host=mariadbtest;Database=420_Angular;user=root;password=secretpassword;port=3306;Convert Zero Datetime = true;SslMode=none;" "/api-key=FAKE_TRANSLATE_E2E" > docker_run_log 2>&1 &
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -93,7 +93,7 @@ jobs:
       run: sleep 15
     - name: Start the newly build Docker container
       id: docker-run
-      run: docker run --name my-container -p 4200:5000 --network data microtingas/work-items-planning-container:latest "/ConnectionString=host=mariadbtest;Database=420_Angular;user=root;password=secretpassword;port=3306;Convert Zero Datetime = true;SslMode=none;" "/api-key=FAKE_TRANSLATE_E2E" > docker_run_log 2>&1 &
+      run: docker run --name my-container -p 4200:5000 --network data -e ALLOW_FAKE_TRANSLATE=true microtingas/work-items-planning-container:latest "/ConnectionString=host=mariadbtest;Database=420_Angular;user=root;password=secretpassword;port=3306;Convert Zero Datetime = true;SslMode=none;" "/api-key=FAKE_TRANSLATE_E2E" > docker_run_log 2>&1 &
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
Adds the `ALLOW_FAKE_TRANSLATE=true` opt-in env to the backend-pn playwright `docker run` (both pr + master workflows), ahead of gating the `FAKE_TRANSLATE_E2E` sentinel in `TranslationService`.

**No-op until the backend code change lands** — the env is currently ignored. This must merge **before** the `eform-angular-frontend` code change so shard `m` keeps passing once the sentinel requires the flag.

See spec `2026-06-11-translation-real-apikey-prod-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)