### PR TITLE
fix(calendar): translate repeat-scope modal titles (Edit/Move/Delete repeat)

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -505,4 +505,7 @@ export const bgBG = {
   Delete: 'Изтриване',
   Edit: 'Редактиране',
   'Select date': 'Изберете дата',
+  'Edit repeat': 'Редактиране на повторение',
+  'Move repeat': 'Повторение на движението',
+  'Delete repeat': 'Изтриване на повторение',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -505,4 +505,7 @@ export const csCZ = {
   Delete: 'Vymazat',
   Edit: 'Upravit',
   'Select date': 'Vyberte datum',
+  'Edit repeat': 'Upravit opakování',
+  'Move repeat': 'Opakování pohybu',
+  'Delete repeat': 'Smazat opakování',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -506,4 +506,7 @@ export const da = {
   Delete: 'Slet',
   Edit: 'Rediger',
   'Select date': 'Vælg dato',
+  'Edit repeat': 'Rediger gentagelse',
+  'Move repeat': 'Flyt gentagelse',
+  'Delete repeat': 'Slet gentagelse',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -556,4 +556,7 @@ export const deDE = {
   Save: 'Speichern',
   Delete: 'Löschen',
   Edit: 'Bearbeiten',
+  'Edit repeat': 'Bearbeiten wiederholen',
+  'Move repeat': 'Bewegung wiederholen',
+  'Delete repeat': 'Löschen Sie die Wiederholung',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -505,4 +505,7 @@ export const elGR = {
   Delete: 'Διαγράφω',
   Edit: 'Εκδίδω',
   'Select date': 'Επιλογή ημερομηνίας',
+  'Edit repeat': 'Επεξεργασία επανάληψης',
+  'Move repeat': 'Επανάληψη κίνησης',
+  'Delete repeat': 'Διαγραφή επανάληψης',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -524,4 +524,7 @@ export const enUS= {
   Delete: 'Delete',
   Edit: 'Edit',
   'Select date': 'Select date',
+  'Edit repeat': 'Edit repeat',
+  'Move repeat': 'Move repeat',
+  'Delete repeat': 'Delete repeat',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -505,4 +505,7 @@ export const esES = {
   Delete: 'Borrar',
   Edit: 'Editar',
   'Select date': 'Seleccione la fecha',
+  'Edit repeat': 'Editar repetir',
+  'Move repeat': 'Mover repetir',
+  'Delete repeat': 'Eliminar repetir',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -505,4 +505,7 @@ export const etET = {
   Delete: 'Kustuta',
   Edit: 'Redigeeri',
   'Select date': 'Valige kuupäev',
+  'Edit repeat': 'Redigeeri kordust',
+  'Move repeat': 'Liigutuse kordus',
+  'Delete repeat': 'Kustuta kordus',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -505,4 +505,7 @@ export const fiFI = {
   Delete: 'Poistaa',
   Edit: 'Muokata',
   'Select date': 'Valitse päivämäärä',
+  'Edit repeat': 'Muokkaa toistoa',
+  'Move repeat': 'Siirrä toisto',
+  'Delete repeat': 'Poista toisto',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -504,4 +504,7 @@ export const frFR = {
   Delete: 'Supprimer',
   Edit: 'Modifier',
   'Select date': 'Sélectionnez une date',
+  'Edit repeat': 'Répéter la modification',
+  'Move repeat': 'Répéter le déplacement',
+  'Delete repeat': 'Supprimer la répétition',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -505,4 +505,7 @@ export const hrHR = {
   Delete: 'Izbrisati',
   Edit: 'Uredi',
   'Select date': 'Odaberite datum',
+  'Edit repeat': 'Uredi ponavljanje',
+  'Move repeat': 'Ponavljanje poteza',
+  'Delete repeat': 'Izbriši ponavljanje',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -505,4 +505,7 @@ export const huHU = {
   Delete: 'Töröl',
   Edit: 'Szerkesztés',
   'Select date': 'Dátum kiválasztása',
+  'Edit repeat': 'Szerkesztés ismétlése',
+  'Move repeat': 'Mozgás ismétlése',
+  'Delete repeat': 'Ismétlés törlése',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -505,4 +505,7 @@ export const isIS = {
   Delete: 'Eyða',
   Edit: 'Breyta',
   'Select date': 'Veldu dagsetningu',
+  'Edit repeat': 'Breyta endurtekningu',
+  'Move repeat': 'Færa endurtekið',
+  'Delete repeat': 'Eyða endurtekningu',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -505,4 +505,7 @@ export const itIT = {
   Delete: 'Eliminare',
   Edit: 'Modificare',
   'Select date': 'Seleziona la data',
+  'Edit repeat': 'Modifica ripeti',
+  'Move repeat': 'Muoviti ripeti',
+  'Delete repeat': 'Elimina ripeti',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -505,4 +505,7 @@ export const ltLT = {
   Delete: 'Ištrinti',
   Edit: 'Redaguoti',
   'Select date': 'Pasirinkite datą',
+  'Edit repeat': 'Redaguoti kartojimą',
+  'Move repeat': 'Judėjimo kartojimas',
+  'Delete repeat': 'Ištrinti kartojimą',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -505,4 +505,7 @@ export const lvLV = {
   Delete: 'Dzēst',
   Edit: 'Rediģēt',
   'Select date': 'Izvēlieties datumu',
+  'Edit repeat': 'Rediģēt atkārtojumu',
+  'Move repeat': 'Pārvietošanas atkārtošana',
+  'Delete repeat': 'Dzēst atkārtojumu',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -505,4 +505,7 @@ export const nlNL = {
   Delete: 'Verwijderen',
   Edit: 'Bewerking',
   'Select date': 'Selecteer datum',
+  'Edit repeat': 'Herhalen bewerken',
+  'Move repeat': 'Verplaats herhalen',
+  'Delete repeat': 'Verwijder herhaling',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -505,4 +505,7 @@ export const noNO = {
   Delete: 'Slett',
   Edit: 'Redigere',
   'Select date': 'Velg dato',
+  'Edit repeat': 'Rediger gjentakelse',
+  'Move repeat': 'Flytt gjenta',
+  'Delete repeat': 'Slett gjentakelse',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -505,4 +505,7 @@ export const plPL = {
   Delete: 'Usuwać',
   Edit: 'Redagować',
   'Select date': 'Wybierz datę',
+  'Edit repeat': 'Edytuj powtórzenie',
+  'Move repeat': 'Przesuń powtórz',
+  'Delete repeat': 'Usuń powtórzenie',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -505,4 +505,7 @@ export const ptBR = {
   Delete: 'Excluir',
   Edit: 'Editar',
   'Select date': 'Selecione a data',
+  'Edit repeat': 'Editar repetição',
+  'Move repeat': 'Repita o movimento',
+  'Delete repeat': 'Excluir repetição',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -505,4 +505,7 @@ export const ptPT = {
   Delete: 'Excluir',
   Edit: 'Editar',
   'Select date': 'Selecione a data',
+  'Edit repeat': 'Editar repetição',
+  'Move repeat': 'Repita o movimento',
+  'Delete repeat': 'Excluir repetição',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -505,4 +505,7 @@ export const roRO = {
   Delete: 'Şterge',
   Edit: 'Edita',
   'Select date': 'Selectați data',
+  'Edit repeat': 'Repetare editare',
+  'Move repeat': 'Repetare mutare',
+  'Delete repeat': 'Ștergeți repetarea',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -505,4 +505,7 @@ export const skSK = {
   Delete: 'Odstrániť',
   Edit: 'Upraviť',
   'Select date': 'Vyberte dátum',
+  'Edit repeat': 'Upraviť opakovanie',
+  'Move repeat': 'Opakovanie pohybu',
+  'Delete repeat': 'Odstrániť opakovanie',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -505,4 +505,7 @@ export const slSL = {
   Delete: 'Izbriši',
   Edit: 'Uredi',
   'Select date': 'Izberite datum',
+  'Edit repeat': 'Uredi ponovitev',
+  'Move repeat': 'Ponavljanje premikanja',
+  'Delete repeat': 'Izbriši ponovitev',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -505,4 +505,7 @@ export const svSE = {
   Delete: 'Radera',
   Edit: 'Redigera',
   'Select date': 'Välj datum',
+  'Edit repeat': 'Redigera upprepning',
+  'Move repeat': 'Flytta upprepa',
+  'Delete repeat': 'Ta bort upprepning',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -505,4 +505,7 @@ export const ukUA = {
   Delete: 'Видалити',
   Edit: 'Редагувати',
   'Select date': 'Виберіть дату',
+  'Edit repeat': 'Редагувати повторення',
+  'Move repeat': 'Повторення руху',
+  'Delete repeat': 'Видалити повторення',
 };


### PR DESCRIPTION
The recurring-series scope dialog titles `Edit repeat`/`Move repeat`/`Delete repeat` (set inline by mode in repeat-scope-modal.component.html) were missing from the i18n source and rendered raw. Adds them to enUS.ts and propagates to all 25 languages (Danish: Rediger/Flyt/Slet gentagelse). Pure additive — no template/key changes. Follow-up to #1000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)