### PR TITLE
fix(workers): clean up orphan SDK site so deleted/failed workers don't block name reuse

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
@@ -8,6 +8,7 @@ using BackendConfiguration.Pn.Infrastructure.Models.AssignmentWorker;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using eFormCore;
 using JetBrains.Annotations;
+using Microting.eForm.Dto;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microting.eForm.Infrastructure;
@@ -864,10 +865,46 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
             int userId, TimePlanningPnDbContext timePlanningDbContext, BaseDbContext baseDbContext,
             IUserService userService, UserManager<EformUser> userManager)
         {
+            var sdkDbContext = core.DbContextHelper.GetDbContext();
+            SiteDto? siteDto = null;
+
+            // Compensating cleanup: SiteCreate already committed the SDK Site (and possibly Worker)
+            // before this failure. core.SiteDelete is not null-safe for siteworker-less orphans, so
+            // soft-delete the SDK rows directly to avoid leaving an active orphan that blocks name reuse.
+            async Task CleanupOrphanSiteAsync()
+            {
+                if (siteDto == null)
+                {
+                    return;
+                }
+
+                try
+                {
+                    var orphanSite = await sdkDbContext.Sites
+                        .FirstOrDefaultAsync(x => x.MicrotingUid == siteDto.SiteId
+                            && x.WorkflowState != Constants.WorkflowStates.Removed).ConfigureAwait(false);
+                    if (orphanSite != null)
+                    {
+                        await orphanSite.Delete(sdkDbContext).ConfigureAwait(false);
+                    }
+
+                    var orphanWorker = await sdkDbContext.Workers
+                        .FirstOrDefaultAsync(x => x.MicrotingUid == siteDto.WorkerUid
+                            && x.WorkflowState != Constants.WorkflowStates.Removed).ConfigureAwait(false);
+                    if (orphanWorker != null)
+                    {
+                        await orphanWorker.Delete(sdkDbContext).ConfigureAwait(false);
+                    }
+                }
+                catch (Exception cleanupEx)
+                {
+                    SentrySdk.CaptureException(cleanupEx);
+                    Console.WriteLine($"[CreateDeviceUser] failed to clean up orphan SDK site after a failed worker create: {cleanupEx}");
+                }
+            }
+
             try
             {
-                var sdkDbContext = core.DbContextHelper.GetDbContext();
-
                 if (sdkDbContext.Workers.AsNoTracking().Any(x =>
                         x.Email == deviceUserModel.WorkerEmail && x.WorkflowState != Constants.WorkflowStates.Removed))
                 {
@@ -889,7 +926,7 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                     return new OperationDataResult<int>(false, "TheEmployeeAlreadyExist");
                 }
 
-                var siteDto = await core.SiteCreate(siteName, deviceUserModel.UserFirstName,
+                siteDto = await core.SiteCreate(siteName, deviceUserModel.UserFirstName,
                     deviceUserModel.UserLastName,
                     deviceUserModel.WorkerEmail, deviceUserModel.LanguageCode).ConfigureAwait(false);
 
@@ -1102,7 +1139,8 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                     {
                         Console.WriteLine($"[CreateDeviceUser] EXCEPTION: {e}");
                         // _logger.LogError(e.Message);
-                        return new OperationDataResult<int>(false, "");
+                        await CleanupOrphanSiteAsync().ConfigureAwait(false);
+                        return new OperationDataResult<int>(false, "DeviceUserCouldNotBeCreated");
                     }
                 }
 
@@ -1111,6 +1149,7 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
             {
                 SentrySdk.CaptureException(ex);
                 Console.WriteLine(ex.Message);
+                await CleanupOrphanSiteAsync().ConfigureAwait(false);
                 return new OperationDataResult<int>(false, "DeviceUserCouldNotBeCreated");
             }
         }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
@@ -8,7 +8,6 @@ using BackendConfiguration.Pn.Infrastructure.Models.AssignmentWorker;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using eFormCore;
 using JetBrains.Annotations;
-using Microting.eForm.Dto;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microting.eForm.Infrastructure;
@@ -866,7 +865,6 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
             IUserService userService, UserManager<EformUser> userManager)
         {
             var sdkDbContext = core.DbContextHelper.GetDbContext();
-            SiteDto? siteDto = null;
             string siteName = null;
 
             async Task CleanupOrphanSiteAsync()
@@ -877,11 +875,9 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                 }
                 try
                 {
-                    // SiteCreate commits the SDK Site before creating the Worker/SiteWorker; if creation
-                    // throws, an active orphan Site with no SiteWorker can remain and permanently block
-                    // re-creating that name. siteDto is null when SiteCreate throws, so match the orphan by
-                    // name and only remove it when it has no active SiteWorker (so we never delete a
-                    // fully-formed worker).
+                    // SiteCreate may throw after committing the Site row but before the SiteWorker is
+                    // created, leaving an active orphan Site that blocks re-creating this name. Match the
+                    // orphan by name and only remove it when it has no active SiteWorker.
                     var orphanSite = await sdkDbContext.Sites
                         .FirstOrDefaultAsync(x => x.Name == siteName
                             && x.WorkflowState != Constants.WorkflowStates.Removed);
@@ -945,7 +941,7 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                     return new OperationDataResult<int>(false, "TheEmployeeAlreadyExist");
                 }
 
-                siteDto = await core.SiteCreate(siteName, deviceUserModel.UserFirstName,
+                var siteDto = await core.SiteCreate(siteName, deviceUserModel.UserFirstName,
                     deviceUserModel.UserLastName,
                     deviceUserModel.WorkerEmail, deviceUserModel.LanguageCode).ConfigureAwait(false);
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
@@ -867,39 +867,58 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
         {
             var sdkDbContext = core.DbContextHelper.GetDbContext();
             SiteDto? siteDto = null;
+            string siteName = null;
 
-            // Compensating cleanup: SiteCreate already committed the SDK Site (and possibly Worker)
-            // before this failure. core.SiteDelete is not null-safe for siteworker-less orphans, so
-            // soft-delete the SDK rows directly to avoid leaving an active orphan that blocks name reuse.
             async Task CleanupOrphanSiteAsync()
             {
-                if (siteDto == null)
+                if (string.IsNullOrEmpty(siteName))
                 {
                     return;
                 }
-
                 try
                 {
+                    // SiteCreate commits the SDK Site before creating the Worker/SiteWorker; if creation
+                    // throws, an active orphan Site with no SiteWorker can remain and permanently block
+                    // re-creating that name. siteDto is null when SiteCreate throws, so match the orphan by
+                    // name and only remove it when it has no active SiteWorker (so we never delete a
+                    // fully-formed worker).
                     var orphanSite = await sdkDbContext.Sites
-                        .FirstOrDefaultAsync(x => x.MicrotingUid == siteDto.SiteId
-                            && x.WorkflowState != Constants.WorkflowStates.Removed).ConfigureAwait(false);
-                    if (orphanSite != null)
+                        .FirstOrDefaultAsync(x => x.Name == siteName
+                            && x.WorkflowState != Constants.WorkflowStates.Removed);
+                    if (orphanSite == null)
                     {
-                        await orphanSite.Delete(sdkDbContext).ConfigureAwait(false);
+                        return;
                     }
+                    var siteHasActiveWorkerLink = await sdkDbContext.SiteWorkers
+                        .AnyAsync(sw => sw.SiteId == orphanSite.Id
+                            && sw.WorkflowState != Constants.WorkflowStates.Removed);
+                    if (siteHasActiveWorkerLink)
+                    {
+                        return; // fully-formed worker, not an orphan — leave it intact
+                    }
+                    await orphanSite.Delete(sdkDbContext);
 
+                    // Also remove a dangling Worker created for this site (no active SiteWorker link).
+                    // The pre-SiteCreate email check guarantees no pre-existing active worker had this email,
+                    // so a match here is the one just created.
                     var orphanWorker = await sdkDbContext.Workers
-                        .FirstOrDefaultAsync(x => x.MicrotingUid == siteDto.WorkerUid
-                            && x.WorkflowState != Constants.WorkflowStates.Removed).ConfigureAwait(false);
+                        .FirstOrDefaultAsync(x => x.Email == deviceUserModel.WorkerEmail
+                            && x.WorkflowState != Constants.WorkflowStates.Removed);
                     if (orphanWorker != null)
                     {
-                        await orphanWorker.Delete(sdkDbContext).ConfigureAwait(false);
+                        var workerHasActiveLink = await sdkDbContext.SiteWorkers
+                            .AnyAsync(sw => sw.WorkerId == orphanWorker.Id
+                                && sw.WorkflowState != Constants.WorkflowStates.Removed);
+                        if (!workerHasActiveLink)
+                        {
+                            await orphanWorker.Delete(sdkDbContext);
+                        }
                     }
                 }
                 catch (Exception cleanupEx)
                 {
                     SentrySdk.CaptureException(cleanupEx);
-                    Console.WriteLine($"[CreateDeviceUser] failed to clean up orphan SDK site after a failed worker create: {cleanupEx}");
+                    Console.WriteLine($"[CreateDeviceUser] orphan-site cleanup failed: {cleanupEx.Message}");
                 }
             }
 
@@ -915,7 +934,7 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                 deviceUserModel.UserFirstName = deviceUserModel.UserFirstName.Trim();
                 deviceUserModel.UserLastName = deviceUserModel.UserLastName.Trim();
                 // var result = await _deviceUsersService.Create(deviceUserModel);
-                var siteName = deviceUserModel.UserFirstName + " " + deviceUserModel.UserLastName;
+                siteName = deviceUserModel.UserFirstName + " " + deviceUserModel.UserLastName;
 
                 var site = await sdkDbContext.Sites.AsNoTracking().SingleOrDefaultAsync(x =>
                     x.Name == deviceUserModel.UserFirstName + " " + deviceUserModel.UserLastName &&
@@ -1139,7 +1158,6 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                     {
                         Console.WriteLine($"[CreateDeviceUser] EXCEPTION: {e}");
                         // _logger.LogError(e.Message);
-                        await CleanupOrphanSiteAsync().ConfigureAwait(false);
                         return new OperationDataResult<int>(false, "DeviceUserCouldNotBeCreated");
                     }
                 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAssignmentWorkerService/BackendConfigurationAssignmentWorkerService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAssignmentWorkerService/BackendConfigurationAssignmentWorkerService.cs
@@ -324,6 +324,21 @@ public class BackendConfigurationAssignmentWorkerService(
                 }
             }
 
+            // Remove the underlying SDK Site (cascades to Worker + SiteWorker, and deregisters remotely)
+            // so a deleted worker does not leave an active orphan Site blocking name reuse.
+            if (site != null && site.MicrotingUid.HasValue)
+            {
+                try
+                {
+                    await core.SiteDelete(site.MicrotingUid.Value).ConfigureAwait(false);
+                }
+                catch (Exception siteDeleteEx)
+                {
+                    SentrySdk.CaptureException(siteDeleteEx);
+                    logger.LogError(siteDeleteEx, "Delete: core.SiteDelete failed for site MicrotingUid {Uid}", site.MicrotingUid);
+                }
+            }
+
             return new OperationResult(true,
                 backendConfigurationLocalizationService.GetString("SuccessfullyDeleteAssignmentsProperties"));
         }


### PR DESCRIPTION
## Problem
Creating a property worker could fail with "Medarbejderen findes allerede" ("employee already exists") for a name that has no visible worker. Root cause: a worker creation that fails partway leaves an **active SDK `sites` row with no Worker/SiteWorker** (an orphan), and the create-time duplicate check (`Sites.Name == FirstName+" "+LastName && WorkflowState != Removed`) then permanently blocks that name. Two sources of orphans:
1. `core.SiteCreate` commits the `sites` row before creating the Worker/SiteWorker and is non-transactional with no rollback — if a later step throws, the site is orphaned. (SDK is NuGet-pinned, so the structural fix can't land here yet.)
2. The worker **delete** path never removed the SDK `Site`/`Worker`.

## Fix (plugin-side)
- **`CreateDeviceUser`**: on any failure after `SiteCreate`, a compensating cleanup matches the orphan **by site name** (available even when `SiteCreate` throws and returns no dto) and soft-deletes it **only when it has no active SiteWorker** — so a fully-formed worker is never deleted. A dangling Worker (matched by email, guarded the same way) is also soft-deleted. Cleanup runs only in the outer catch (not the inner time-registration catch, where the worker is already complete).
- **`Delete`**: after the existing teardown, calls `core.SiteDelete(site.MicrotingUid)` (cascades remote + Worker + SiteWorker) so deleting a worker no longer leaves an orphan.

## Notes / limitations
- `core.SiteDelete` is **not null-safe for siteworker-less orphans** (SDK `Core.cs:3076` NREs), so the create-failure path soft-deletes via the SDK dbContext directly instead.
- **Known minor race**: the name-based match could, under a sub-second concurrent create of two identically-named workers, soft-delete a not-yet-linked legitimate site. This is strictly better than the permanent-orphan status quo; the real structural fix is making `Core.SiteCreate` transactional (SDK change, future NuGet release).
- These paths call the remote Microting API via `core`, so they aren't unit-testable here; verified by compilation + code review. The pre-existing local orphan (site #29) was soft-deleted separately to unblock immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)