### PR TITLE
feat(calendar): assign events to worker tags (dynamic, retroactive)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationCalendarServiceTaskTrackerListTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationCalendarServiceTaskTrackerListTest.cs
@@ -25,6 +25,7 @@ SOFTWARE.
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -108,6 +109,7 @@ public class BackendConfigurationCalendarServiceTaskTrackerListTest : TestBaseSe
             _eventDeployService,
             ItemsPlanningPnDbContext!,
             _taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance
         );
     }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarActionableOnlyTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarActionableOnlyTests.cs
@@ -22,6 +22,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -209,6 +210,7 @@ public class CalendarActionableOnlyTests : TestBaseSetup
             Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext,
             taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance);
 
         // Act — ListEvents-style mobile-worker fetch (ActionableOnly=true) for

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarAttachmentTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarAttachmentTests.cs
@@ -4,6 +4,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -100,6 +101,7 @@ public class CalendarAttachmentTests : TestBaseSetup
             Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance
         );
     }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarBoardDeleteCascadeTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarBoardDeleteCascadeTests.cs
@@ -6,6 +6,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -39,6 +40,7 @@ public class CalendarBoardDeleteCascadeTests : TestBaseSetup
             new BackendConfigurationLocalizationService(), userService,
             BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!, _taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance);
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarCompleteOccurrenceTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarCompleteOccurrenceTests.cs
@@ -22,6 +22,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -165,6 +166,7 @@ public class CalendarCompleteOccurrenceTests : TestBaseSetup
             new BackendConfigurationLocalizationService(), userService,
             BackendConfigurationPnDbContext, coreHelper, Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext, taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance);
 
         // Calendar UI fetch (ActionableOnly=false) for the week of the series.

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarCompletedPeriodSuppressionTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarCompletedPeriodSuppressionTests.cs
@@ -23,6 +23,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -506,6 +507,7 @@ public class CalendarCompletedPeriodSuppressionTests : TestBaseSetup
             new BackendConfigurationLocalizationService(), userService,
             BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!, taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance);
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarComplianceMoveTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarComplianceMoveTests.cs
@@ -23,6 +23,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -269,6 +270,7 @@ public class CalendarComplianceMoveTests : TestBaseSetup
             new BackendConfigurationLocalizationService(), userService,
             BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!, taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance);
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarMultiLanguageTitleDescriptionTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarMultiLanguageTitleDescriptionTests.cs
@@ -16,6 +16,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -266,6 +267,7 @@ public class CalendarMultiLanguageTitleDescriptionTests : TestBaseSetup
             new BackendConfigurationLocalizationService(), userService,
             BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!, taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance);
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOccurrenceExceptionTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOccurrenceExceptionTests.cs
@@ -3,6 +3,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -75,6 +76,7 @@ public class CalendarOccurrenceExceptionTests : TestBaseSetup
             Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance
         );
     }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOrphanRenderComplianceTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarOrphanRenderComplianceTests.cs
@@ -23,6 +23,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -239,6 +240,7 @@ public class CalendarOrphanRenderComplianceTests : TestBaseSetup
             new BackendConfigurationLocalizationService(), userService,
             BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!, taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance);
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarRecurrenceRulePersistenceFixTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarRecurrenceRulePersistenceFixTests.cs
@@ -4,6 +4,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -153,6 +154,7 @@ public class CalendarRecurrenceRulePersistenceFixTests : TestBaseSetup
             Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance
         );
     }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarRepeatPersistenceTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarRepeatPersistenceTests.cs
@@ -3,6 +3,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
 using Microting.eForm.Infrastructure.Data.Entities;
@@ -73,6 +74,7 @@ public class CalendarRepeatPersistenceTests : TestBaseSetup
             Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance
         );
     }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarResizeTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarResizeTests.cs
@@ -3,6 +3,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -73,6 +74,7 @@ public class CalendarResizeTests : TestBaseSetup
             Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance
         );
     }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarTaskListIndexTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarTaskListIndexTest.cs
@@ -26,6 +26,7 @@ using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
 using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -98,6 +99,7 @@ public class CalendarTaskListIndexTest : TestBaseSetup
             _eventDeployService,
             ItemsPlanningPnDbContext!,
             _taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance
         );
     }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarThisAndFollowingMoveBackReproTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarThisAndFollowingMoveBackReproTests.cs
@@ -17,6 +17,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -299,6 +300,7 @@ public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
             new BackendConfigurationLocalizationService(), userService,
             BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!, taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance);
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarUpdateTaskScopeTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarUpdateTaskScopeTests.cs
@@ -4,6 +4,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -88,6 +89,7 @@ public class CalendarUpdateTaskScopeTests : TestBaseSetup
             Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance
         );
     }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarYearlyEnumerateTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarYearlyEnumerateTests.cs
@@ -23,6 +23,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -91,6 +92,7 @@ public class CalendarYearlyEnumerateTests : TestBaseSetup
             new BackendConfigurationLocalizationService(), userService,
             BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!, taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance);
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarYearlyMoveTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarYearlyMoveTests.cs
@@ -3,6 +3,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
 using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
@@ -85,6 +86,7 @@ public class CalendarYearlyMoveTests : TestBaseSetup
             Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance
         );
     }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/DocumentsGrpcServiceCalendarFileTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/DocumentsGrpcServiceCalendarFileTest.cs
@@ -7,6 +7,7 @@ using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
 using BackendConfiguration.Pn.Services.GrpcServices;
 using BackendConfiguration.Pn.Services.UserPropertyAccess;
 using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
 using Grpc.Core;
 using static Grpc.Core.ServerCallContext;
 using Microsoft.AspNetCore.Http;
@@ -102,6 +103,7 @@ public class DocumentsGrpcServiceCalendarFileTest : TestBaseSetup
             Substitute.For<IEventDeployService>(),
             ItemsPlanningPnDbContext!,
             _taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
             NullLogger<BackendConfigurationCalendarService>.Instance
         );
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/WorkerTagAssignmentTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/WorkerTagAssignmentTest.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+using NUnit.Framework;
+using SdkCase = Microting.eForm.Infrastructure.Data.Entities.Case;
+using BcCompliance = Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities.Compliance;
+using BcPlanningSite = Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities.PlanningSite;
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+/// <summary>
+/// Integration coverage for the calendar worker-tags assignment feature:
+/// <see cref="CalendarAssignmentResolver"/> (effective recipient resolution from
+/// explicit PlanningSites ∪ live SDK SiteTag members) and
+/// <see cref="CalendarAssignmentReconciliationService"/> (retroactive add/remove of
+/// future already-deployed occurrences, past-occurrence skipping, completed-case
+/// immutability).
+///
+/// NB: the test container/DBs are shared across the tests in this fixture (the base
+/// fixture starts the container in [SetUp] but only EnsureCreated()s the schema, so
+/// rows accumulate). Every test therefore seeds its OWN entities (auto-generated SDK
+/// site ids, GUID-named property/tag) and scopes every assertion to those ids — no
+/// hard-coded SDK ids that could collide or leak between tests.
+/// </summary>
+[TestFixture]
+public class WorkerTagAssignmentTest : TestBaseSetup
+{
+    private static readonly DateTime SeriesStart =
+        new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// The shared test container is NOT fully reset between tests: the backend-config
+    /// snapshot SQL re-run each [SetUp] only drops/recreates tables present in that
+    /// (older) dump. <c>AreaRulePlanningWorkerTags</c> was added after the snapshot was
+    /// taken, so it is never recreated and its rows accumulate across tests while
+    /// AreaRulePlannings/Tags ids restart at 1 — causing prior tests' links to attach
+    /// to this test's arp/tag. Clear it explicitly after the base [SetUp] (NUnit runs
+    /// the base-class [SetUp] before this derived one).
+    /// </summary>
+    [SetUp]
+    public async Task ClearAccumulatingTables()
+    {
+        await BackendConfigurationPnDbContext!.Database
+            .ExecuteSqlRawAsync("DELETE FROM `AreaRulePlanningWorkerTags`;");
+    }
+
+    /// <summary>Seeds Area/Property/AreaRule/Planning/AreaRulePlanning and returns the arp + planning.</summary>
+    private async Task<(AreaRulePlanning arp, Planning planning, Property property)> SeedEvent(bool status = true)
+    {
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"WorkerTagTest-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id, EformId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Week, StartDate = SeriesStart,
+            RelatedEFormId = 0, WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
+            ItemPlanningId = planning.Id, StartDate = SeriesStart, Status = status,
+            RepeatType = 2, RepeatEvery = 1,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        return (arp, planning, property);
+    }
+
+    /// <summary>Adds an explicit PlanningSite assignee for the event. Returns the site id.</summary>
+    private async Task<int> AddExplicitSite(int arpId, int siteId)
+    {
+        await BackendConfigurationPnDbContext!.PlanningSites.AddAsync(new BcPlanningSite
+        {
+            AreaRulePlanningsId = arpId, SiteId = siteId,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        });
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        return siteId;
+    }
+
+    /// <summary>Adds a worker-tag assignment link for the event.</summary>
+    private async Task AddWorkerTagLink(int arpId, int tagId, string workflowState = null)
+    {
+        var link = new AreaRulePlanningWorkerTag
+        {
+            AreaRulePlanningId = arpId, TagId = tagId,
+            WorkflowState = workflowState ?? Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.AreaRulePlanningWorkerTags.AddAsync(link);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+    }
+
+    /// <summary>Creates an SDK Site (auto id) and returns its generated id.</summary>
+    private async Task<int> SeedSdkSite()
+    {
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+        var site = new Site
+        {
+            Name = $"site-{Guid.NewGuid()}",
+            MicrotingUid = null,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(site);
+        await MicrotingDbContext.SaveChangesAsync();
+        return site.Id;
+    }
+
+    /// <summary>
+    /// Creates an SDK Tag (auto id) into the SAME SDK db the resolver reads through
+    /// (core.DbContextHelper.GetDbContext()). The resolver's core db and the test
+    /// MicrotingDbContext both map to the 420_SDK schema, so seeding through
+    /// MicrotingDbContext is visible to the resolver. Returns the generated tag id.
+    /// </summary>
+    private async Task<int> SeedSdkTag()
+    {
+        var tag = new Tag
+        {
+            Name = $"worker-tag-{Guid.NewGuid()}",
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext!.Tags.AddAsync(tag);
+        await MicrotingDbContext.SaveChangesAsync();
+        return tag.Id;
+    }
+
+    /// <summary>Links a site to a tag via SDK SiteTag (live or removed).</summary>
+    private async Task LinkSiteToTag(int tagId, int siteId, bool removed = false)
+    {
+        await MicrotingDbContext!.SiteTags.AddAsync(new SiteTag
+        {
+            TagId = tagId, SiteId = siteId,
+            WorkflowState = removed
+                ? Constants.WorkflowStates.Removed
+                : Constants.WorkflowStates.Created
+        });
+        await MicrotingDbContext.SaveChangesAsync();
+    }
+
+    private async Task<CalendarAssignmentResolver> BuildResolver()
+    {
+        var core = await GetCore();
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+        return new CalendarAssignmentResolver(BackendConfigurationPnDbContext!, coreHelper);
+    }
+
+    private async Task<(CalendarAssignmentReconciliationService engine, IEventDeployService deploy)>
+        BuildEngine()
+    {
+        var core = await GetCore();
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+        var resolver = new CalendarAssignmentResolver(BackendConfigurationPnDbContext!, coreHelper);
+        var deploy = Substitute.For<IEventDeployService>();
+        var engine = new CalendarAssignmentReconciliationService(
+            BackendConfigurationPnDbContext!, ItemsPlanningPnDbContext!, coreHelper,
+            deploy, resolver,
+            NullLogger<CalendarAssignmentReconciliationService>.Instance);
+        return (engine, deploy);
+    }
+
+    /// <summary>Deploys a Compliance + backing SDK Case for one (planning, date, site).</summary>
+    private async Task<(int caseId, int complianceId)> SeedDeployedOccurrence(
+        int planningId, DateTime deadline, int siteId, int status, int? microtingUid)
+    {
+        var sdkCase = new SdkCase
+        {
+            SiteId = siteId, Status = status, MicrotingUid = microtingUid,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext!.Cases.AddAsync(sdkCase);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var compliance = new BcCompliance
+        {
+            PlanningId = planningId, Deadline = deadline, MicrotingSdkCaseId = sdkCase.Id,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Compliances.AddAsync(compliance);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        return (sdkCase.Id, compliance.Id);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1 — Resolver: effective set = explicit ∪ tag members
+    // ─────────────────────────────────────────────────────────────────────────
+    [Test]
+    public async Task ResolveEffectiveSiteIds_ReturnsExplicitUnionTagMembers()
+    {
+        var (arp, _, _) = await SeedEvent();
+        var explicitSite = await AddExplicitSite(arp.Id, await SeedSdkSite());
+
+        var memberA = await SeedSdkSite();
+        var memberB = await SeedSdkSite();
+        var tagId = await SeedSdkTag();
+        await LinkSiteToTag(tagId, memberA);
+        await LinkSiteToTag(tagId, memberB);
+        await AddWorkerTagLink(arp.Id, tagId);
+
+        var resolver = await BuildResolver();
+        var result = await resolver.ResolveEffectiveSiteIdsAsync(arp.Id);
+
+        Assert.That(result, Is.EquivalentTo(new[] { explicitSite, memberA, memberB }));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2 — Resolver excludes removed SiteTags and removed worker-tag links
+    // ─────────────────────────────────────────────────────────────────────────
+    [Test]
+    public async Task ResolveEffectiveSiteIds_ExcludesRemovedSiteTag()
+    {
+        var (arp, _, _) = await SeedEvent();
+        var explicitSite = await AddExplicitSite(arp.Id, await SeedSdkSite());
+
+        var liveMember = await SeedSdkSite();
+        var removedMember = await SeedSdkSite();
+        var tagId = await SeedSdkTag();
+        await LinkSiteToTag(tagId, liveMember);
+        await LinkSiteToTag(tagId, removedMember, removed: true);
+        await AddWorkerTagLink(arp.Id, tagId);
+
+        var resolver = await BuildResolver();
+        var result = await resolver.ResolveEffectiveSiteIdsAsync(arp.Id);
+
+        Assert.That(result, Is.EquivalentTo(new[] { explicitSite, liveMember }),
+            "removed SiteTag member must be excluded");
+    }
+
+    [Test]
+    public async Task ResolveEffectiveSiteIds_RemovedWorkerTagLink_YieldsOnlyExplicit()
+    {
+        var (arp, _, _) = await SeedEvent();
+        var explicitSite = await AddExplicitSite(arp.Id, await SeedSdkSite());
+
+        var memberA = await SeedSdkSite();
+        var memberB = await SeedSdkSite();
+        var tagId = await SeedSdkTag();
+        await LinkSiteToTag(tagId, memberA);
+        await LinkSiteToTag(tagId, memberB);
+        // The worker-tag link itself is Removed → no tag members contribute.
+        await AddWorkerTagLink(arp.Id, tagId, Constants.WorkflowStates.Removed);
+
+        var resolver = await BuildResolver();
+        var result = await resolver.ResolveEffectiveSiteIdsAsync(arp.Id);
+
+        Assert.That(result, Is.EquivalentTo(new[] { explicitSite }),
+            "removed worker-tag link must contribute no tag members");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3 — Engine retroactive ADD decision (mock deploy service)
+    // ─────────────────────────────────────────────────────────────────────────
+    [Test]
+    public async Task ReconcileEvent_AddsTagMemberToAlreadyDeployedFutureOccurrence()
+    {
+        var (arp, planning, _) = await SeedEvent();
+
+        // Assigned ONLY via a worker tag whose member is desiredSite (no explicit sites).
+        var desiredSite = await SeedSdkSite();
+        var alreadyDeployedSite = await SeedSdkSite();
+        var tagId = await SeedSdkTag();
+        await LinkSiteToTag(tagId, desiredSite);
+        await AddWorkerTagLink(arp.Id, tagId);
+
+        // A FUTURE already-deployed occurrence for a DIFFERENT site (Status 66).
+        var futureDate = DateTime.UtcNow.Date.AddDays(7);
+        await SeedDeployedOccurrence(planning.Id, futureDate, alreadyDeployedSite,
+            status: 66, microtingUid: 555001);
+
+        var (engine, deploy) = await BuildEngine();
+        await engine.ReconcileEventAsync(arp.Id);
+
+        // desiredSite is desired but not deployed → engine must add it for the future date.
+        await deploy.Received().EnsureComplianceForOccurrenceAsync(
+            Arg.Is<AreaRulePlanning>(a => a.Id == arp.Id),
+            Arg.Is<DateTime>(d => d.Date == futureDate.Date),
+            desiredSite,
+            Arg.Any<CancellationToken>());
+
+        // The already-deployed (non-completed) site → no add for it.
+        await deploy.DidNotReceive().EnsureComplianceForOccurrenceAsync(
+            Arg.Any<AreaRulePlanning>(), Arg.Any<DateTime>(), alreadyDeployedSite,
+            Arg.Any<CancellationToken>());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 4 — Engine skips PAST occurrences and respects future-only
+    // ─────────────────────────────────────────────────────────────────────────
+    [Test]
+    public async Task ReconcileEvent_DoesNotTouchPastOccurrences()
+    {
+        var (arp, planning, _) = await SeedEvent();
+
+        var desiredSite = await SeedSdkSite();
+        var deployedSite = await SeedSdkSite();
+        var tagId = await SeedSdkTag();
+        await LinkSiteToTag(tagId, desiredSite);
+        await AddWorkerTagLink(arp.Id, tagId);
+
+        // PAST occurrence deployed for deployedSite.
+        var pastDate = DateTime.UtcNow.Date.AddDays(-7);
+        await SeedDeployedOccurrence(planning.Id, pastDate, deployedSite,
+            status: 66, microtingUid: 555002);
+
+        var (engine, deploy) = await BuildEngine();
+        await engine.ReconcileEventAsync(arp.Id);
+
+        // Past date must never be reconciled (no add of desiredSite for the past date).
+        await deploy.DidNotReceive().EnsureComplianceForOccurrenceAsync(
+            Arg.Any<AreaRulePlanning>(),
+            Arg.Is<DateTime>(d => d.Date == pastDate.Date),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 5 — Engine retroactive REMOVE + completed immutable
+    // ─────────────────────────────────────────────────────────────────────────
+    [Test]
+    public async Task ReconcileEvent_RemovesUnassignedNonCompleted_KeepsCompleted()
+    {
+        // Effective set is EMPTY: a worker tag with no live members, no explicit sites.
+        var (arp, planning, _) = await SeedEvent();
+        var tagId = await SeedSdkTag();
+        await AddWorkerTagLink(arp.Id, tagId);
+
+        var futureDate = DateTime.UtcNow.Date.AddDays(7);
+
+        var nonCompletedSite = await SeedSdkSite();
+        var completedSite = await SeedSdkSite();
+
+        // The Compliances table has a UNIQUE index on (PlanningId, Deadline), so the
+        // two sites for the same occurrence DATE must carry distinct Deadline times
+        // (the engine groups occurrences by Deadline.Date, so both still belong to the
+        // same occurrence date).
+        // Non-completed deployed case (Status 66) → must be retracted. MicrotingUid=null
+        // so the SDK CaseDelete call is skipped, but the bookkeeping (Compliance
+        // soft-delete) still runs.
+        var (_, nonCompletedComplianceId) = await SeedDeployedOccurrence(
+            planning.Id, futureDate.AddHours(9), nonCompletedSite, status: 66, microtingUid: null);
+
+        // Completed deployed case (Status 100) → immutable.
+        var (_, completedComplianceId) = await SeedDeployedOccurrence(
+            planning.Id, futureDate.AddHours(10), completedSite, status: 100, microtingUid: null);
+
+        var (engine, _) = await BuildEngine();
+        await engine.ReconcileEventAsync(arp.Id);
+
+        // The non-completed compliance must be soft-removed.
+        var reloadedNonCompleted = await BackendConfigurationPnDbContext!.Compliances
+            .AsNoTracking().FirstAsync(x => x.Id == nonCompletedComplianceId);
+        Assert.That(reloadedNonCompleted.WorkflowState,
+            Is.EqualTo(Constants.WorkflowStates.Removed),
+            "non-completed compliance for unassigned site must be soft-removed");
+
+        // The completed compliance must be untouched.
+        var reloadedCompleted = await BackendConfigurationPnDbContext.Compliances
+            .AsNoTracking().FirstAsync(x => x.Id == completedComplianceId);
+        Assert.That(reloadedCompleted.WorkflowState,
+            Is.Not.EqualTo(Constants.WorkflowStates.Removed),
+            "completed compliance (Status 100) is immutable and must survive");
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/AssignmentReconciliationPlannerTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/AssignmentReconciliationPlannerTest.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
+using NUnit.Framework;
+
+namespace BackendConfiguration.Pn.Test;
+
+[TestFixture]
+public class AssignmentReconciliationPlannerTest
+{
+    private static HashSet<int> S(params int[] xs) => new(xs);
+
+    [Test]
+    public void Add_sites_in_desired_but_not_present()
+    {
+        var plan = AssignmentReconciliationPlanner.Plan(
+            desired: S(1, 2, 3), actualNonCompleted: S(1), completed: S());
+        Assert.That(plan.ToAdd, Is.EquivalentTo(new[] { 2, 3 }));
+        Assert.That(plan.ToRemove, Is.Empty);
+    }
+
+    [Test]
+    public void Remove_sites_present_but_not_desired()
+    {
+        var plan = AssignmentReconciliationPlanner.Plan(
+            desired: S(1), actualNonCompleted: S(1, 2, 3), completed: S());
+        Assert.That(plan.ToRemove, Is.EquivalentTo(new[] { 2, 3 }));
+        Assert.That(plan.ToAdd, Is.Empty);
+    }
+
+    [Test]
+    public void Never_recreate_completed_sites()
+    {
+        var plan = AssignmentReconciliationPlanner.Plan(
+            desired: S(1, 2), actualNonCompleted: S(1), completed: S(2));
+        Assert.That(plan.ToAdd, Is.Empty);
+        Assert.That(plan.ToRemove, Is.Empty);
+    }
+
+    [Test]
+    public void Never_remove_completed_sites_even_if_undesired()
+    {
+        var plan = AssignmentReconciliationPlanner.Plan(
+            desired: S(1), actualNonCompleted: S(1), completed: S(9));
+        Assert.That(plan.ToRemove, Is.Empty);
+        Assert.That(plan.ToAdd, Is.Empty);
+    }
+
+    [Test]
+    public void Noop_when_actual_equals_desired()
+    {
+        var plan = AssignmentReconciliationPlanner.Plan(
+            desired: S(1, 2), actualNonCompleted: S(1, 2), completed: S());
+        Assert.That(plan.ToAdd, Is.Empty);
+        Assert.That(plan.ToRemove, Is.Empty);
+    }
+
+    [Test]
+    public void Add_and_remove_simultaneously()
+    {
+        var plan = AssignmentReconciliationPlanner.Plan(
+            desired: S(1, 4), actualNonCompleted: S(1, 2), completed: S(3));
+        Assert.That(plan.ToAdd, Is.EquivalentTo(new[] { 4 }));
+        Assert.That(plan.ToRemove, Is.EquivalentTo(new[] { 2 }));
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -120,6 +120,10 @@ public class EformBackendConfigurationPlugin : IEformPlugin
             Services.GrpcServices.GrpcSiteResolver>();
         services.AddTransient<Services.EventDeployService.IEventDeployService,
             Services.EventDeployService.EventDeployService>();
+        services.AddTransient<Services.CalendarAssignmentReconciliation.ICalendarAssignmentResolver,
+            Services.CalendarAssignmentReconciliation.CalendarAssignmentResolver>();
+        services.AddTransient<Services.CalendarAssignmentReconciliation.ICalendarAssignmentReconciliationService,
+            Services.CalendarAssignmentReconciliation.CalendarAssignmentReconciliationService>();
         services.AddTransient<IBackendConfigurationAreaRulePlanningsService, BackendConfigurationAreaRulePlanningsService>();
         services.AddTransient<IBackendConfigurationAssignmentWorkerService, BackendConfigurationAssignmentWorkerService>();
         services.AddTransient<IBackendConfigurationTaskManagementService, BackendConfigurationTaskManagementService>();

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
@@ -389,7 +389,8 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
             TimePlanningPnDbContext timePlanningDbContext,
             BaseDbContext baseDbContext,
             ILogger logger,
-            ItemsPlanningPnDbContext itemsPlanningPnDbContext)
+            ItemsPlanningPnDbContext itemsPlanningPnDbContext,
+            Services.CalendarAssignmentReconciliation.ICalendarAssignmentReconciliationService? reconciliationService = null)
         {
             deviceUserModel.UserFirstName = deviceUserModel.UserFirstName.Trim();
             deviceUserModel.UserLastName = deviceUserModel.UserLastName.Trim();
@@ -408,6 +409,7 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                 {
                     // var workerDto = await core.Advanced_WorkerRead((int)siteDto.WorkerUid);
                     var worker = await sdkDbContext.Workers.FirstOrDefaultAsync(x => x.MicrotingUid == siteDto.WorkerUid).ConfigureAwait(false);
+                    if (worker == null) return new OperationResult(false, "DeviceUserCouldNotBeObtained");
                     var site = await sdkDbContext.Sites
                         .Include(x => x.SiteTags)
                         .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
@@ -452,7 +454,13 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
 
                         await siteTag.Create(sdkDbContext);
                     }
-                    if (worker == null) return new OperationResult(false, "DeviceUserCouldNotBeObtained");
+
+                    // Reconcile already-deployed future occurrences of any event referencing a changed worker tag
+                    var changedTagIds = forRemove.Concat(forCreate).Distinct().ToList();
+                    if (changedTagIds.Count > 0 && reconciliationService != null)
+                    {
+                        await reconciliationService.ReconcileEventsForWorkerTagsAsync(changedTagIds);
+                    }
                     {
                         var oldEmail = worker.Email;
                         if (sdkDbContext.Workers.Any(x => x.Email == deviceUserModel.WorkerEmail && x.MicrotingUid != siteDto.WorkerUid && x.WorkflowState != Constants.WorkflowStates.Removed))
@@ -477,6 +485,32 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                         worker.EmployeeNo = deviceUserModel.EmployeeNo;
                         worker.Email = deviceUserModel.WorkerEmail;
                         worker.PhoneNumber = deviceUserModel.PhoneNumber;
+
+                        // Authoritative backend block: a worker still effectively assigned to an active
+                        // event (explicitly or via a worker tag) cannot be resigned.
+                        if (deviceUserModel.Resigned && !worker.Resigned)
+                        {
+                            var myTagIds = await sdkDbContext.SiteTags
+                                .Where(st => st.SiteId == site.Id && st.TagId != null
+                                             && st.WorkflowState != Constants.WorkflowStates.Removed)
+                                .Select(st => st.TagId!.Value)
+                                .ToListAsync();
+
+                            var stillAssigned = await backendConfigurationPnDbContext.AreaRulePlannings
+                                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed && x.Status)
+                                .Where(x =>
+                                    x.PlanningSites.Any(y => y.WorkflowState != Constants.WorkflowStates.Removed
+                                                             && y.SiteId == site.Id)
+                                    || x.AreaRulePlanningWorkerTags.Any(wt => wt.WorkflowState != Constants.WorkflowStates.Removed
+                                                                              && myTagIds.Contains(wt.TagId)))
+                                .AnyAsync();
+
+                            if (stillAssigned)
+                            {
+                                return new OperationResult(false, "WorkerStillAssignedToEventsCannotResign");
+                            }
+                        }
+
                         worker.Resigned = deviceUserModel.Resigned;
                         worker.ResignedAtDate = deviceUserModel.ResignedAtDate;
                         await worker.Update(sdkDbContext).ConfigureAwait(false);
@@ -862,7 +896,8 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
 
         public static async Task<OperationDataResult<int>> CreateDeviceUser(DeviceUserModel deviceUserModel, Core core,
             int userId, TimePlanningPnDbContext timePlanningDbContext, BaseDbContext baseDbContext,
-            IUserService userService, UserManager<EformUser> userManager)
+            IUserService userService, UserManager<EformUser> userManager,
+            Services.CalendarAssignmentReconciliation.ICalendarAssignmentReconciliationService? reconciliationService = null)
         {
             var sdkDbContext = core.DbContextHelper.GetDbContext();
             string siteName = null;
@@ -961,6 +996,12 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                         await siteTag.Create(sdkDbContext).ConfigureAwait(false);
                     }
                     Console.WriteLine($"[CreateDeviceUser] Saved {deviceUserModel.Tags.Count} site tags for site {site.Id}");
+
+                    // Reconcile already-deployed future occurrences of any event referencing these worker tags
+                    if (reconciliationService != null && deviceUserModel.Tags is { Count: > 0 })
+                    {
+                        await reconciliationService.ReconcileEventsForWorkerTagsAsync(deviceUserModel.Tags);
+                    }
                 }
 
                 var worker = await sdkDbContext.Workers.SingleAsync(x => x.MicrotingUid == siteDto.WorkerUid)

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskCreateRequestModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskCreateRequestModel.cs
@@ -17,6 +17,8 @@ public class CalendarTaskCreateRequestModel
     public int RepeatEvery { get; set; }
     public int Status { get; set; }
     public List<int> Sites { get; set; } = [];
+    // SDK Tag ids selected as "worker tags" — expand live to all sites carrying the tag.
+    public List<int> WorkerTagIds { get; set; } = [];
     public bool ComplianceEnabled { get; set; }
     public double StartHour { get; set; }
     public double Duration { get; set; }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
@@ -13,6 +13,8 @@ public class CalendarTaskResponseModel
     public string TaskDate { get; set; }
     public List<string> Tags { get; set; } = [];
     public List<int> AssigneeIds { get; set; } = [];
+    // Worker tags assigned to this event (SDK Tag ids).
+    public List<int> WorkerTagIds { get; set; } = [];
     public List<string> WorkerNames { get; set; } = [];
     public int? BoardId { get; set; }
     public string Color { get; set; }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/localization.json
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/localization.json
@@ -4655,6 +4655,12 @@
     }
   },
   {
+    "Key": "WorkerStillAssignedToEventsCannotResign",
+    "LocalizedValue": {
+      "en-US": "Worker is still assigned to one or more events and cannot be resigned. Remove them from those events (or the tags) first."
+    }
+  },
+  {
     "Key": "ReportPeriod",
     "LocalizedValue": {
       "da": "Rapport periode",

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAssignmentWorkerService/BackendConfigurationAssignmentWorkerService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAssignmentWorkerService/BackendConfigurationAssignmentWorkerService.cs
@@ -60,7 +60,8 @@ public class BackendConfigurationAssignmentWorkerService(
     TimePlanningPnDbContext timePlanningDbContext,
     CaseTemplatePnDbContext caseTemplatePnDbContext,
     BaseDbContext baseDbContext,
-    ILogger<BackendConfigurationAssignmentWorkerService> logger)
+    ILogger<BackendConfigurationAssignmentWorkerService> logger,
+    Services.CalendarAssignmentReconciliation.ICalendarAssignmentReconciliationService reconciliationService)
     : IBackendConfigurationAssignmentWorkerService
 {
 
@@ -513,11 +514,16 @@ public class BackendConfigurationAssignmentWorkerService(
                 deviceUserModel.PropertyNames = string.Join(", ", properties);
                 deviceUserModel.PropertyIds = propertyIds;
 
+                var workerTagIds = deviceUserModel.Tags ?? new List<int>();
                 var numberOfAssignements = await backendConfigurationPnDbContext.AreaRulePlannings
                     .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                     .Where(x => x.Status)
                     .Where(x => propertyIds.Contains(x.PropertyId))
-                    .Where(x => x.PlanningSites.Where(y => y.WorkflowState != Constants.WorkflowStates.Removed && y.SiteId == deviceUserModel.SiteId).Select(y => y.SiteId).Any())
+                    .Where(x =>
+                        x.PlanningSites.Any(y => y.WorkflowState != Constants.WorkflowStates.Removed
+                                                 && y.SiteId == deviceUserModel.SiteId)
+                        || x.AreaRulePlanningWorkerTags.Any(wt => wt.WorkflowState != Constants.WorkflowStates.Removed
+                                                                  && workerTagIds.Contains(wt.TagId)))
                     .CountAsync().ConfigureAwait(false);
 
                 if (deviceUserModel.WorkerEmail != null && !deviceUserModel.WorkerEmail.Contains("invalid"))
@@ -596,7 +602,7 @@ public class BackendConfigurationAssignmentWorkerService(
         var core = await coreHelper.GetCore().ConfigureAwait(false);
         var result = await BackendConfigurationAssignmentWorkerServiceHelper.UpdateDeviceUser(deviceUserModel, core,
             userService.UserId, userService, userManager, backendConfigurationPnDbContext,
-            timePlanningDbContext, baseDbContext, logger, itemsPlanningPnDbContext);
+            timePlanningDbContext, baseDbContext, logger, itemsPlanningPnDbContext, reconciliationService);
 
         return new OperationResult(result.Success, backendConfigurationLocalizationService.GetString(result.Message));
     }
@@ -606,7 +612,7 @@ public class BackendConfigurationAssignmentWorkerService(
         var core = await coreHelper.GetCore().ConfigureAwait(false);
         var result = await BackendConfigurationAssignmentWorkerServiceHelper.CreateDeviceUser(deviceUserModel, core,
             userService.UserId,
-            timePlanningDbContext, baseDbContext, userService, userManager);
+            timePlanningDbContext, baseDbContext, userService, userManager, reconciliationService);
 
         return new OperationDataResult<int>(result.Success,
             backendConfigurationLocalizationService.GetString(result.Message), result.Model);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using BackendConfigurationLocalizationService;
 using BackendConfigurationTaskWizardService;
+using CalendarAssignmentReconciliation;
 using EventDeployService;
 using Infrastructure.Models.Calendar;
 using Infrastructure.Models.TaskWizard;
@@ -36,6 +37,7 @@ public class BackendConfigurationCalendarService(
     IEventDeployService eventDeployService,
     ItemsPlanningPnDbContext itemsPlanningPnDbContext,
     IBackendConfigurationTaskWizardService taskWizardService,
+    ICalendarAssignmentReconciliationService reconciliationService,
     ILogger<BackendConfigurationCalendarService> logger)
     : IBackendConfigurationCalendarService
 {
@@ -399,6 +401,14 @@ public class BackendConfigurationCalendarService(
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                 .ToDictionaryAsync(x => x.AreaRulePlanningId);
 
+            // Batch-load raw worker-tag links per ARP so each response model can
+            // round-trip its assigned tags (edit modal would otherwise clear them).
+            var workerTagIdsByArpId = await backendConfigurationPnDbContext.AreaRulePlanningWorkerTags
+                .Where(x => arpIds.Contains(x.AreaRulePlanningId))
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .GroupBy(x => x.AreaRulePlanningId)
+                .ToDictionaryAsync(g => g.Key, g => g.Select(x => x.TagId).ToList());
+
             // Batch-load occurrence exceptions for this week
             var exceptionsInWeek = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
                 .Where(x => arpIds.Contains(x.AreaRulePlanningId))
@@ -600,7 +610,8 @@ public class BackendConfigurationCalendarService(
                         ItemPlanningTagId = arp.ItemPlanningTagId,
                         DescriptionHtml = description,
                         Translations = translations,
-                        Attachments = MapAttachments(arp)
+                        Attachments = MapAttachments(arp),
+                        WorkerTagIds = workerTagIdsByArpId.GetValueOrDefault(arp.Id, new List<int>())
                     };
 
                     // Per-occurrence field overrides from a "this"-scope edit (#885).
@@ -704,7 +715,8 @@ public class BackendConfigurationCalendarService(
                             ItemPlanningTagId = arp.ItemPlanningTagId,
                             DescriptionHtml = description,
                             Translations = translations,
-                            Attachments = MapAttachments(arp)
+                            Attachments = MapAttachments(arp),
+                            WorkerTagIds = workerTagIdsByArpId.GetValueOrDefault(arp.Id, new List<int>())
                         };
 
                         ApplyOccurrenceFieldOverrides(orphanModel, orphan);
@@ -790,7 +802,8 @@ public class BackendConfigurationCalendarService(
                     ItemPlanningTagId = arp.ItemPlanningTagId,
                     DescriptionHtml = description,
                     Translations = translations,
-                    Attachments = MapAttachments(arp)
+                    Attachments = MapAttachments(arp),
+                    WorkerTagIds = workerTagIdsByArpId.GetValueOrDefault(arp.Id, new List<int>())
                 };
 
                 ApplyOccurrenceFieldOverrides(movedModel, movedIn);
@@ -823,6 +836,14 @@ public class BackendConfigurationCalendarService(
                 .Where(x => complianceArpIds.Contains(x.AreaRulePlanningId))
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                 .ToDictionaryAsync(x => x.AreaRulePlanningId);
+
+            // Raw worker-tag links per compliance ARP (same round-trip rationale
+            // as the recurrence path above).
+            var complianceWorkerTagIdsByArpId = await backendConfigurationPnDbContext.AreaRulePlanningWorkerTags
+                .Where(x => complianceArpIds.Contains(x.AreaRulePlanningId))
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .GroupBy(x => x.AreaRulePlanningId)
+                .ToDictionaryAsync(g => g.Key, g => g.Select(x => x.TagId).ToList());
 
             // Top up exceptionsByArp with any exceptions for compliance ARPs not
             // already covered. arpIds now contains all non-Removed plannings
@@ -997,6 +1018,9 @@ public class BackendConfigurationCalendarService(
                     Translations = complianceTranslations,
                     Attachments = MapAttachments(arp),
                     ExceptionId = complianceException?.Id,
+                    WorkerTagIds = arp != null
+                        ? complianceWorkerTagIdsByArpId.GetValueOrDefault(arp.Id, new List<int>())
+                        : new List<int>(),
                 };
 
                 ApplyOccurrenceFieldOverrides(model, complianceException);
@@ -1080,6 +1104,13 @@ public class BackendConfigurationCalendarService(
                 .GroupBy(x => x.AreaRulePlanningId)
                 .ToDictionary(g => g.Key, g => g.First());
 
+            // Raw worker-tag links per ARP so the list/edit round-trips assigned tags.
+            var workerTagIdsByArpId = await backendConfigurationPnDbContext.AreaRulePlanningWorkerTags
+                .Where(x => arpIds.Contains(x.AreaRulePlanningId))
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .GroupBy(x => x.AreaRulePlanningId)
+                .ToDictionaryAsync(g => g.Key, g => g.Select(x => x.TagId).ToList());
+
             var planningTagIds = areaRulePlannings
                 .SelectMany(x => x.AreaRulePlanningTags
                     .Where(y => y.WorkflowState != Constants.WorkflowStates.Removed)
@@ -1150,6 +1181,7 @@ public class BackendConfigurationCalendarService(
                     ItemPlanningTagId = arp.ItemPlanningTagId,
                     DescriptionHtml = description,
                     Translations = translations,
+                    WorkerTagIds = workerTagIdsByArpId.GetValueOrDefault(arp.Id, new List<int>()),
                 };
             }).ToList();
 
@@ -1196,7 +1228,9 @@ public class BackendConfigurationCalendarService(
             // render as a dimmed inactive task with no one to perform it.
             // Reject here with a clear error rather than silently creating
             // an orphan event.
-            if (createModel.Sites is null || createModel.Sites.Count == 0)
+            var hasExplicitSites = createModel.Sites is { Count: > 0 };
+            var hasWorkerTags = createModel.WorkerTagIds is { Count: > 0 };
+            if (!hasExplicitSites && !hasWorkerTags)
             {
                 return new OperationDataResult<int>(false,
                     localizationService.GetString("AtLeastOneWorkerMustBeAssigned"));
@@ -1295,6 +1329,29 @@ public class BackendConfigurationCalendarService(
                     UpdatedByUserId = userService.UserId
                 };
                 await calConfig.Create(backendConfigurationPnDbContext);
+
+                // Persist worker-tag links against the created event. The id is
+                // latestArp.Id (TaskWizard's CreateTask does not surface the ARP
+                // id directly — we correlate it via the latest matching ARP above).
+                if (createModel.WorkerTagIds is { Count: > 0 })
+                {
+                    foreach (var tagId in createModel.WorkerTagIds.Distinct())
+                    {
+                        var link = new AreaRulePlanningWorkerTag
+                        {
+                            AreaRulePlanningId = latestArp.Id,
+                            TagId = tagId,
+                            CreatedByUserId = userService.UserId,
+                            UpdatedByUserId = userService.UserId
+                        };
+                        await link.Create(backendConfigurationPnDbContext);
+                    }
+                }
+
+                // Reconcile the new event so an already-deployed current week
+                // picks up the effective recipient set (explicit PlanningSites ∪
+                // live worker-tag members). Idempotent; no-op if removed/inactive.
+                await reconciliationService.ReconcileEventAsync(latestArp.Id);
             }
 
             // latestArp may be null in the rare edge case where TaskWizard
@@ -1358,7 +1415,9 @@ public class BackendConfigurationCalendarService(
             // assignees would downgrade the task to NotActive (same as the
             // Create path); reject rather than silently producing an
             // inactive task with no one to perform it.
-            if (updateModel.Sites is null || updateModel.Sites.Count == 0)
+            var hasExplicitSites = updateModel.Sites is { Count: > 0 };
+            var hasWorkerTags = updateModel.WorkerTagIds is { Count: > 0 };
+            if (!hasExplicitSites && !hasWorkerTags)
             {
                 return new OperationResult(false,
                     localizationService.GetString("AtLeastOneWorkerMustBeAssigned"));
@@ -1462,6 +1521,15 @@ public class BackendConfigurationCalendarService(
             var arp = await backendConfigurationPnDbContext.AreaRulePlannings
                 .FirstOrDefaultAsync(x => x.Id == updateModel.Id
                     && x.WorkflowState != Constants.WorkflowStates.Removed);
+
+            // Worker-tag diff is a series-level change, applied only on the "all"
+            // scope path (this/thisAndFollowing return earlier). Load the current
+            // links before mutating so we can compute add/remove sets below.
+            var existingWorkerTagIds = await backendConfigurationPnDbContext.AreaRulePlanningWorkerTags
+                .Where(x => x.AreaRulePlanningId == updateModel.Id)
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Select(x => x.TagId)
+                .ToListAsync();
             if (arp != null)
             {
                 // Write end-mode + recurrence fields unconditionally so
@@ -1505,6 +1573,45 @@ public class BackendConfigurationCalendarService(
                         await RelocateNonCompletedComplianceRowsToNewPattern(arp, planning);
                     }
                 }
+
+                // Diff worker-tag links against the desired set. Adds create new
+                // links; removes soft-delete the existing ones. Runs on the
+                // series-level "all" path so the persisted set mirrors the wizard's
+                // PlanningSites mutation above.
+                var desiredWorkerTagIds = (updateModel.WorkerTagIds ?? []).Distinct().ToList();
+                var tagsToAdd = desiredWorkerTagIds.Except(existingWorkerTagIds).ToList();
+                var tagsToRemove = existingWorkerTagIds.Except(desiredWorkerTagIds).ToList();
+
+                foreach (var tagId in tagsToAdd)
+                {
+                    var link = new AreaRulePlanningWorkerTag
+                    {
+                        AreaRulePlanningId = updateModel.Id,
+                        TagId = tagId,
+                        CreatedByUserId = userService.UserId,
+                        UpdatedByUserId = userService.UserId
+                    };
+                    await link.Create(backendConfigurationPnDbContext);
+                }
+
+                foreach (var tagId in tagsToRemove)
+                {
+                    var link = await backendConfigurationPnDbContext.AreaRulePlanningWorkerTags
+                        .Where(x => x.AreaRulePlanningId == updateModel.Id && x.TagId == tagId)
+                        .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                        .FirstOrDefaultAsync();
+                    if (link != null)
+                    {
+                        link.UpdatedByUserId = userService.UserId;
+                        await link.Delete(backendConfigurationPnDbContext);
+                    }
+                }
+
+                // Series-level reconcile: after the recipient set (PlanningSites +
+                // worker-tag links) is mutated, pick up/retract cases for future
+                // already-deployed occurrences. Idempotent; no-op if removed/inactive.
+                // Only the "all" scope reaches here — this/thisAndFollowing return earlier.
+                await reconciliationService.ReconcileEventAsync(updateModel.Id);
             }
 
             // Update or create CalendarConfiguration for calendar-specific fields
@@ -2033,6 +2140,22 @@ public class BackendConfigurationCalendarService(
         foreach (var ex in exceptions)
         {
             await ex.Delete(backendConfigurationPnDbContext);
+        }
+
+        // Soft-delete the event's worker-tag links so they don't linger after the
+        // series is gone. The wizard DeleteTask below already retracts every case
+        // (core.CaseDelete) and soft-deletes Planning/PlanningSites/ARP/Compliances,
+        // so reconciliation is not needed here (and would early-return anyway once
+        // the event is removed/inactive).
+        var workerTagLinks = await backendConfigurationPnDbContext.AreaRulePlanningWorkerTags
+            .Where(x => x.AreaRulePlanningId == arpId)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+
+        foreach (var link in workerTagLinks)
+        {
+            link.UpdatedByUserId = userService.UserId;
+            await link.Delete(backendConfigurationPnDbContext);
         }
 
         var wizardResult = await taskWizardService.DeleteTask(arpId);
@@ -4309,6 +4432,13 @@ public class BackendConfigurationCalendarService(
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                 .ToDictionaryAsync(x => x.AreaRulePlanningId);
 
+            // Raw worker-tag links per compliance ARP so models round-trip them.
+            var complianceWorkerTagIdsByArpId = await backendConfigurationPnDbContext.AreaRulePlanningWorkerTags
+                .Where(x => complianceArpIds.Contains(x.AreaRulePlanningId))
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .GroupBy(x => x.AreaRulePlanningId)
+                .ToDictionaryAsync(g => g.Key, g => g.Select(x => x.TagId).ToList());
+
             var complianceArpTags = await backendConfigurationPnDbContext.AreaRulePlanningTags
                 .Where(x => complianceArpIds.Contains(x.AreaRulePlanningId))
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
@@ -4466,7 +4596,10 @@ public class BackendConfigurationCalendarService(
                     ItemPlanningTagId = arp?.ItemPlanningTagId,
                     DescriptionHtml = descriptionHtml,
                     Attachments = MapAttachments(arp),
-                    TaskIsExpired = taskIsExpired
+                    TaskIsExpired = taskIsExpired,
+                    WorkerTagIds = arp != null
+                        ? complianceWorkerTagIdsByArpId.GetValueOrDefault(arp.Id, new List<int>())
+                        : new List<int>()
                 };
 
                 result.Add(model);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarAssignmentReconciliation/AssignmentReconciliationPlanner.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarAssignmentReconciliation/AssignmentReconciliationPlanner.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
+
+public sealed record OccurrencePlan(IReadOnlyList<int> ToAdd, IReadOnlyList<int> ToRemove);
+
+public static class AssignmentReconciliationPlanner
+{
+    /// Desired = effective recipients. actualNonCompleted = sites with a live (non-completed)
+    /// case for this occurrence. completed = sites whose case is completed (immutable).
+    public static OccurrencePlan Plan(
+        ISet<int> desired, ISet<int> actualNonCompleted, ISet<int> completed)
+    {
+        var toAdd = desired
+            .Where(s => !actualNonCompleted.Contains(s) && !completed.Contains(s))
+            .ToList();
+        var toRemove = actualNonCompleted
+            .Where(s => !desired.Contains(s))
+            .Where(s => !completed.Contains(s))
+            .ToList();
+        return new OccurrencePlan(toAdd, toRemove);
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarAssignmentReconciliation/CalendarAssignmentReconciliationService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarAssignmentReconciliation/CalendarAssignmentReconciliationService.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data;
+using Microting.ItemsPlanningBase.Infrastructure.Data;
+using SdkCore = eFormCore.Core;
+using SdkDbContext = Microting.eForm.Infrastructure.MicrotingDbContext;
+
+namespace BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
+
+/// <summary>
+/// Retroactive reconciliation engine for calendar worker-tag assignments.
+/// For a calendar event (AreaRulePlanning), brings every FUTURE already-deployed
+/// occurrence into line with the event's effective recipient set (explicit
+/// PlanningSites ∪ live worker-tag members): deploys missing sites and retracts
+/// sites no longer assigned. Completed cases (SDK Case.Status == 100) are
+/// immutable and never touched. Occurrences carrying an active per-occurrence
+/// CalendarOccurrenceException are skipped — those are managed explicitly and
+/// worker tags must not fight them.
+/// </summary>
+public class CalendarAssignmentReconciliationService(
+    BackendConfigurationPnDbContext backendConfigurationPnDbContext,
+    ItemsPlanningPnDbContext itemsPlanningPnDbContext,
+    IEFormCoreService coreHelper,
+    IEventDeployService eventDeployService,
+    ICalendarAssignmentResolver resolver,
+    ILogger<CalendarAssignmentReconciliationService> logger)
+    : ICalendarAssignmentReconciliationService
+{
+    private const int CompletedStatus = 100;
+
+    public async Task ReconcileEventAsync(int areaRulePlanningId, CancellationToken ct = default)
+    {
+        // 1. Load the AreaRulePlanning (not removed). Skip if missing or inactive.
+        var arp = await backendConfigurationPnDbContext.AreaRulePlannings
+            .Where(x => x.Id == areaRulePlanningId
+                        && x.WorkflowState != Constants.WorkflowStates.Removed)
+            .FirstOrDefaultAsync(ct).ConfigureAwait(false);
+
+        if (arp == null || !arp.Status)
+        {
+            return;
+        }
+
+        var planningId = arp.ItemPlanningId;
+
+        // 2. Effective recipient set.
+        var desired = await resolver.ResolveEffectiveSiteIdsAsync(areaRulePlanningId, ct)
+            .ConfigureAwait(false);
+
+        // 3. SDK core + db context (needed for case status reads and CaseDelete).
+        var sdkCore = await coreHelper.GetCore().ConfigureAwait(false);
+        await using var sdkDbContext = sdkCore.DbContextHelper.GetDbContext();
+
+        // 4. Future, already-deployed occurrence dates for this planning.
+        var now = DateTime.UtcNow;
+        var futureDeadlines = await backendConfigurationPnDbContext.Compliances
+            .Where(x => x.PlanningId == planningId
+                        && x.WorkflowState != Constants.WorkflowStates.Removed
+                        && x.Deadline > now)
+            .Select(x => x.Deadline)
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        var occurrenceDates = futureDeadlines
+            .Select(d => d.Date)
+            .Distinct()
+            .ToList();
+
+        if (occurrenceDates.Count == 0)
+        {
+            return;
+        }
+
+        // 5. Active per-occurrence exception dates to skip.
+        var exceptions = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
+            .Where(x => x.AreaRulePlanningId == areaRulePlanningId
+                        && x.WorkflowState != Constants.WorkflowStates.Removed
+                        && !x.IsDeleted)
+            .Select(x => new { x.OriginalDate, x.NewDate })
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        var exceptionDates = new HashSet<DateTime>();
+        foreach (var ex in exceptions)
+        {
+            exceptionDates.Add(ex.OriginalDate.Date);
+            if (ex.NewDate.HasValue)
+            {
+                exceptionDates.Add(ex.NewDate.Value.Date);
+            }
+        }
+
+        // 6. Reconcile each remaining occurrence.
+        foreach (var occurrenceDate in occurrenceDates)
+        {
+            if (exceptionDates.Contains(occurrenceDate))
+            {
+                continue;
+            }
+
+            // a. SDK case ids deployed for this (planning, date).
+            var caseIds = await backendConfigurationPnDbContext.Compliances
+                .Where(x => x.PlanningId == planningId
+                            && x.WorkflowState != Constants.WorkflowStates.Removed
+                            && x.MicrotingSdkCaseId > 0)
+                .Where(x => x.Deadline.Date == occurrenceDate)
+                .Select(x => x.MicrotingSdkCaseId)
+                .ToListAsync(ct).ConfigureAwait(false);
+
+            // b. Backing SDK cases (site + status).
+            var sdkCases = caseIds.Count == 0
+                ? new List<CaseStatus>()
+                : await sdkDbContext.Cases
+                    .Where(x => caseIds.Contains(x.Id) && x.SiteId != null)
+                    .Select(x => new CaseStatus(x.SiteId.Value, x.Status))
+                    .ToListAsync(ct).ConfigureAwait(false);
+
+            // c. Split into non-completed and completed site sets.
+            var actualNonCompleted = sdkCases
+                .Where(x => x.Status != CompletedStatus)
+                .Select(x => x.SiteId)
+                .ToHashSet();
+            var completed = sdkCases
+                .Where(x => x.Status == CompletedStatus)
+                .Select(x => x.SiteId)
+                .ToHashSet();
+
+            // d. Plan add/remove.
+            var plan = AssignmentReconciliationPlanner.Plan(desired, actualNonCompleted, completed);
+
+            // e. Deploy missing sites.
+            foreach (var siteId in plan.ToAdd)
+            {
+                try
+                {
+                    await eventDeployService
+                        .EnsureComplianceForOccurrenceAsync(arp, occurrenceDate, siteId, ct)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e,
+                        "Failed to deploy occurrence for AreaRulePlanning {ArpId}, planning {PlanningId}, date {Date}, site {SiteId}",
+                        areaRulePlanningId, planningId, occurrenceDate, siteId);
+                }
+            }
+
+            // f. Retract sites no longer assigned. Load the (planning, date)
+            //    compliance rows ONCE here (tracked, for soft-delete) and reuse
+            //    across every site in ToRemove instead of re-querying per site.
+            List<Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities.Compliance> complianceRowsForDate = null;
+            if (plan.ToRemove.Count > 0)
+            {
+                complianceRowsForDate = await backendConfigurationPnDbContext.Compliances
+                    .Where(x => x.PlanningId == planningId
+                                && x.WorkflowState != Constants.WorkflowStates.Removed
+                                && x.MicrotingSdkCaseId > 0)
+                    .Where(x => x.Deadline.Date == occurrenceDate)
+                    .ToListAsync(ct).ConfigureAwait(false);
+            }
+
+            foreach (var siteId in plan.ToRemove)
+            {
+                try
+                {
+                    await RetractSiteForOccurrenceAsync(
+                            sdkCore, sdkDbContext, complianceRowsForDate, siteId, ct)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e,
+                        "Failed to retract occurrence for AreaRulePlanning {ArpId}, planning {PlanningId}, date {Date}, site {SiteId}",
+                        areaRulePlanningId, planningId, occurrenceDate, siteId);
+                }
+            }
+        }
+    }
+
+    public async Task ReconcileEventsForWorkerTagsAsync(
+        IReadOnlyCollection<int> tagIds, CancellationToken ct = default)
+    {
+        if (tagIds == null || tagIds.Count == 0)
+        {
+            return;
+        }
+
+        var areaRulePlanningIds = await backendConfigurationPnDbContext.AreaRulePlanningWorkerTags
+            .Where(x => tagIds.Contains(x.TagId)
+                        && x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Select(x => x.AreaRulePlanningId)
+            .Distinct()
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        foreach (var areaRulePlanningId in areaRulePlanningIds)
+        {
+            await ReconcileEventAsync(areaRulePlanningId, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Retracts the given site's non-completed case for one (planning, date)
+    /// occurrence, mirroring the canonical retraction path: delete the SDK case
+    /// via core.CaseDelete, set the owning PlanningCase to Retracted, soft-delete
+    /// the matching PlanningCaseSite(s) and the Compliance row. Completed cases
+    /// (Status == 100) are never touched.
+    /// </summary>
+    private async Task RetractSiteForOccurrenceAsync(
+        SdkCore sdkCore,
+        SdkDbContext sdkDbContext,
+        IReadOnlyList<Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities.Compliance> complianceList,
+        int siteId,
+        CancellationToken ct)
+    {
+        // Compliance rows for this (planning, date) with a backing SDK case
+        // are loaded once by the caller and reused across every removed site.
+        foreach (var compliance in complianceList)
+        {
+            var sdkCase = await sdkDbContext.Cases
+                .SingleOrDefaultAsync(x => x.Id == compliance.MicrotingSdkCaseId, ct)
+                .ConfigureAwait(false);
+
+            // Only retract this site's non-completed case.
+            if (sdkCase == null
+                || sdkCase.SiteId != siteId
+                || sdkCase.Status == CompletedStatus)
+            {
+                continue;
+            }
+
+            if (sdkCase.MicrotingUid != null)
+            {
+                await sdkCore.CaseDelete((int)sdkCase.MicrotingUid).ConfigureAwait(false);
+            }
+
+            // Soft-delete the matching PlanningCaseSite(s) and retract their owners.
+            var planningCaseSites = await itemsPlanningPnDbContext.PlanningCaseSites
+                .Where(x => x.MicrotingSdkCaseId == compliance.MicrotingSdkCaseId
+                            && x.WorkflowState != Constants.WorkflowStates.Removed)
+                .ToListAsync(ct).ConfigureAwait(false);
+
+            foreach (var planningCaseSite in planningCaseSites)
+            {
+                var planningCase = await itemsPlanningPnDbContext.PlanningCases
+                    .Where(x => x.Id == planningCaseSite.PlanningCaseId
+                                && x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .FirstOrDefaultAsync(ct).ConfigureAwait(false);
+
+                await planningCaseSite.Delete(itemsPlanningPnDbContext).ConfigureAwait(false);
+
+                if (planningCase != null)
+                {
+                    // Only retract the owning PlanningCase when no non-removed
+                    // PlanningCaseSite children remain. In the calendar deploy
+                    // path PlanningCase is 1:1 per site, but a shared
+                    // PlanningCase with other live sites must survive.
+                    var remainingLiveSites = await itemsPlanningPnDbContext.PlanningCaseSites
+                        .CountAsync(x => x.PlanningCaseId == planningCase.Id
+                                         && x.WorkflowState != Constants.WorkflowStates.Removed,
+                            ct)
+                        .ConfigureAwait(false);
+                    if (remainingLiveSites == 0)
+                    {
+                        planningCase.WorkflowState = Constants.WorkflowStates.Retracted;
+                        await planningCase.Update(itemsPlanningPnDbContext).ConfigureAwait(false);
+                    }
+                }
+            }
+
+            await compliance.Delete(backendConfigurationPnDbContext).ConfigureAwait(false);
+        }
+    }
+
+    private readonly record struct CaseStatus(int SiteId, int? Status);
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarAssignmentReconciliation/CalendarAssignmentResolver.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarAssignmentReconciliation/CalendarAssignmentResolver.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data;
+
+namespace BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
+
+/// <summary>
+/// Resolves the effective set of recipient SDK site ids for a calendar event
+/// (AreaRulePlanning): the union of the event's explicit PlanningSites and the
+/// live members of every worker tag assigned to the event. Worker-tag
+/// membership is read from the SDK <c>SiteTags</c> table, so the set is always
+/// current (members added/removed from a tag immediately change the result).
+/// </summary>
+public class CalendarAssignmentResolver(
+    BackendConfigurationPnDbContext backendConfigurationPnDbContext,
+    IEFormCoreService coreHelper) : ICalendarAssignmentResolver
+{
+    public async Task<HashSet<int>> ResolveEffectiveSiteIdsAsync(
+        int areaRulePlanningId, CancellationToken ct = default)
+    {
+        // 1. Explicit assignees: PlanningSite rows for this event (not removed).
+        var explicitSiteIds = await backendConfigurationPnDbContext.PlanningSites
+            .Where(x => x.AreaRulePlanningsId == areaRulePlanningId
+                        && x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Select(x => x.SiteId)
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        var result = new HashSet<int>(explicitSiteIds);
+
+        // 2. Assigned worker tag ids (not removed).
+        var tagIds = await backendConfigurationPnDbContext.AreaRulePlanningWorkerTags
+            .Where(x => x.AreaRulePlanningId == areaRulePlanningId
+                        && x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Select(x => x.TagId)
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        // 3. Live members of those tags, read from the SDK SiteTags table.
+        if (tagIds.Count > 0)
+        {
+            var sdkCore = await coreHelper.GetCore().ConfigureAwait(false);
+            await using var sdkDbContext = sdkCore.DbContextHelper.GetDbContext();
+
+            var memberSiteIds = await sdkDbContext.SiteTags
+                .Where(x => x.TagId != null && tagIds.Contains(x.TagId.Value)
+                            && x.SiteId != null
+                            && x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Select(x => x.SiteId.Value)
+                .ToListAsync(ct).ConfigureAwait(false);
+
+            foreach (var siteId in memberSiteIds)
+            {
+                result.Add(siteId);
+            }
+        }
+
+        return result;
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarAssignmentReconciliation/ICalendarAssignmentReconciliationService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarAssignmentReconciliation/ICalendarAssignmentReconciliationService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
+
+public interface ICalendarAssignmentReconciliationService
+{
+    Task ReconcileEventAsync(int areaRulePlanningId, CancellationToken ct = default);
+    Task ReconcileEventsForWorkerTagsAsync(IReadOnlyCollection<int> tagIds, CancellationToken ct = default);
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarAssignmentReconciliation/ICalendarAssignmentResolver.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarAssignmentReconciliation/ICalendarAssignmentResolver.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
+
+public interface ICalendarAssignmentResolver
+{
+    // Effective recipient site ids = explicit PlanningSites ∪ live members of each assigned worker tag.
+    Task<HashSet<int>> ResolveEffectiveSiteIdsAsync(int areaRulePlanningId, CancellationToken ct = default);
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
@@ -203,6 +203,46 @@ public class EventDeployService(
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
         var assignedPlanningIdSet = new HashSet<int>(planningIdsAssignedToSite);
+
+        // C4 — also retain plannings where this site qualifies through a worker
+        // tag assigned to the event (not just explicit PlanningSites), so
+        // not-yet-deployed occurrences materialise against live tag membership.
+        // Uses a short-lived SDK context (the pass-wide one is opened below).
+        var sdkCoreForTags = await coreHelper.GetCore().ConfigureAwait(false);
+        await using (var sdkDbContextForTags = sdkCoreForTags.DbContextHelper.GetDbContext())
+        {
+            var siteTagIds = await sdkDbContextForTags.SiteTags
+                .AsNoTracking()
+                .Where(st => st.SiteId == sdkSiteId
+                             && st.TagId != null
+                             && st.WorkflowState != Constants.WorkflowStates.Removed)
+                .Select(st => st.TagId!.Value)
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            if (siteTagIds.Count > 0)
+            {
+                var arpIdsViaTag = await dbContext.AreaRulePlanningWorkerTags
+                    .AsNoTracking()
+                    .Where(wt => siteTagIds.Contains(wt.TagId)
+                                 && wt.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(wt => wt.AreaRulePlanningId)
+                    .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+                if (arpIdsViaTag.Count > 0)
+                {
+                    var planningIdsViaTag = await dbContext.AreaRulePlannings
+                        .AsNoTracking()
+                        .Where(arp => arpIdsViaTag.Contains(arp.Id)
+                                      && arp.ItemPlanningId > 0
+                                      && arp.WorkflowState != Constants.WorkflowStates.Removed)
+                        .Select(arp => arp.ItemPlanningId)
+                        .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+                    foreach (var pid in planningIdsViaTag) assignedPlanningIdSet.Add(pid);
+                }
+            }
+        }
+
         candidates = candidates
             .Where(x => assignedPlanningIdSet.Contains(x.Task.PlanningId!.Value))
             .ToList();
@@ -464,12 +504,36 @@ public class EventDeployService(
                         && pw.WorkflowState != Constants.WorkflowStates.Removed,
                     ct)
                 .ConfigureAwait(false);
+            var siteIsWorkerTagMember = false;
             if (!siteIsActivePropertyWorker)
+            {
+                // Also accept a site that is a live member of any worker tag
+                // assigned to THIS event (C4): not-yet-deployed occurrences
+                // must materialise against live tag membership, even when the
+                // site is neither an explicit PlanningSite nor a property worker.
+                var eventTagIds = await dbContext.AreaRulePlanningWorkerTags
+                    .AsNoTracking()
+                    .Where(wt => wt.AreaRulePlanningId == areaRulePlanning.Id
+                                 && wt.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(wt => wt.TagId)
+                    .ToListAsync(ct).ConfigureAwait(false);
+                if (eventTagIds.Count > 0)
+                {
+                    siteIsWorkerTagMember = await sdkDbContext.SiteTags
+                        .AsNoTracking()
+                        .AnyAsync(st => st.SiteId == sdkSiteId
+                                        && st.TagId != null && eventTagIds.Contains(st.TagId.Value)
+                                        && st.WorkflowState != Constants.WorkflowStates.Removed, ct)
+                        .ConfigureAwait(false);
+                }
+            }
+            if (!siteIsActivePropertyWorker && !siteIsWorkerTagMember)
             {
                 throw new InvalidOperationException(
                     $"EventDeployService refused to deploy planning {planning.Id} to sdkSiteId {sdkSiteId}: "
-                    + "the site is neither in the planning's (non-removed) PlanningSites nor an active "
-                    + $"worker of property {areaRulePlanning.PropertyId}. Deploying here would leak a case "
+                    + "the site is neither in the planning's (non-removed) PlanningSites, an active "
+                    + $"worker of property {areaRulePlanning.PropertyId}, nor a worker-tag member of "
+                    + $"event {areaRulePlanning.Id}. Deploying here would leak a case "
                     + "to an unrelated worker (#932/#1377).");
             }
         }
@@ -626,29 +690,45 @@ public class EventDeployService(
         using var deployLockHandle = await AcquireDeployLockAsync(
             areaRulePlanning.ItemPlanningId, sdkSiteId, cancellationToken).ConfigureAwait(false);
 
-        // Idempotence guard: another caller (nightly batch, parallel request)
-        // may already have materialised this occurrence. Match the natural
-        // key the nightly path uses (PlanningId + Deadline.Date, non-removed)
-        // plus the canonical "case actually exists" filter
-        // (MicrotingSdkCaseId > 0) so we never hand back a half-deployed row.
-        var existing = await dbContext.Compliances
+        // Site-aware idempotence: only treat this occurrence as already
+        // materialised for THIS site if a non-removed compliance row exists
+        // whose backing SDK case belongs to sdkSiteId. A row for a *different*
+        // site must NOT short-circuit deployment of this site (retroactive
+        // worker-tag add path).
+        var candidateComplianceRows = await dbContext.Compliances
             .AsNoTracking()
-            .FirstOrDefaultAsync(c =>
-                    c.PlanningId == areaRulePlanning.ItemPlanningId
-                    && c.Deadline.Date == deadlineDate
-                    && c.WorkflowState != Constants.WorkflowStates.Removed
-                    && c.MicrotingSdkCaseId > 0,
-                cancellationToken)
+            .Where(c =>
+                c.PlanningId == areaRulePlanning.ItemPlanningId
+                && c.Deadline.Date == deadlineDate
+                && c.WorkflowState != Constants.WorkflowStates.Removed
+                && c.MicrotingSdkCaseId > 0)
+            .Select(c => new { c.Id, c.MicrotingSdkCaseId, c.MicrotingSdkeFormId })
+            .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
-        if (existing != null)
+        if (candidateComplianceRows.Count > 0)
         {
-            return new EnsureComplianceResult
+            var candidateCaseIds = candidateComplianceRows.Select(x => x.MicrotingSdkCaseId).ToList();
+            var sdkCoreForGuard = await coreHelper.GetCore().ConfigureAwait(false);
+            await using var sdkDbContextForGuard = sdkCoreForGuard.DbContextHelper.GetDbContext();
+            var matchedCaseId = await sdkDbContextForGuard.Cases
+                .AsNoTracking()
+                .Where(sc => candidateCaseIds.Contains(sc.Id)
+                             && sc.SiteId.HasValue
+                             && sc.SiteId.Value == sdkSiteId)
+                .Select(sc => sc.Id)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+            if (matchedCaseId != 0)
             {
-                Created = false,
-                ComplianceId = existing.Id,
-                SdkCaseId = existing.MicrotingSdkCaseId,
-                TemplateId = existing.MicrotingSdkeFormId
-            };
+                var existing = candidateComplianceRows.First(x => x.MicrotingSdkCaseId == matchedCaseId);
+                return new EnsureComplianceResult
+                {
+                    Created = false,
+                    ComplianceId = existing.Id,
+                    SdkCaseId = existing.MicrotingSdkCaseId,
+                    TemplateId = existing.MicrotingSdkeFormId
+                };
+            }
         }
 
         var planning = await itemsPlanningPnDbContext.Plannings

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/EventDeployService/EventDeployService.cs
@@ -207,34 +207,42 @@ public class EventDeployService(
         // C4 — also retain plannings where this site qualifies through a worker
         // tag assigned to the event (not just explicit PlanningSites), so
         // not-yet-deployed occurrences materialise against live tag membership.
-        // Uses a short-lived SDK context (the pass-wide one is opened below).
-        var sdkCoreForTags = await coreHelper.GetCore().ConfigureAwait(false);
-        await using (var sdkDbContextForTags = sdkCoreForTags.DbContextHelper.GetDbContext())
+        // Cheap backend-config check first: only when some candidate event
+        // actually carries worker tags do we touch the SDK core to resolve the
+        // calling site's tag membership. This preserves the no-op / no-tag fast
+        // paths, which must never reach coreHelper.GetCore().
+        if (candidatePlanningIds.Count > 0)
         {
-            var siteTagIds = await sdkDbContextForTags.SiteTags
+            var candidateArpIdsWithWorkerTags = await dbContext.AreaRulePlannings
                 .AsNoTracking()
-                .Where(st => st.SiteId == sdkSiteId
-                             && st.TagId != null
-                             && st.WorkflowState != Constants.WorkflowStates.Removed)
-                .Select(st => st.TagId!.Value)
+                .Where(arp => candidatePlanningIds.Contains(arp.ItemPlanningId)
+                              && arp.WorkflowState != Constants.WorkflowStates.Removed
+                              && arp.AreaRulePlanningWorkerTags.Any(wt =>
+                                  wt.WorkflowState != Constants.WorkflowStates.Removed))
+                .Select(arp => arp.Id)
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-            if (siteTagIds.Count > 0)
+            if (candidateArpIdsWithWorkerTags.Count > 0)
             {
-                var arpIdsViaTag = await dbContext.AreaRulePlanningWorkerTags
+                var sdkCoreForTags = await coreHelper.GetCore().ConfigureAwait(false);
+                await using var sdkDbContextForTags = sdkCoreForTags.DbContextHelper.GetDbContext();
+                var siteTagIds = await sdkDbContextForTags.SiteTags
                     .AsNoTracking()
-                    .Where(wt => siteTagIds.Contains(wt.TagId)
-                                 && wt.WorkflowState != Constants.WorkflowStates.Removed)
-                    .Select(wt => wt.AreaRulePlanningId)
+                    .Where(st => st.SiteId == sdkSiteId
+                                 && st.TagId != null
+                                 && st.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(st => st.TagId!.Value)
                     .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-                if (arpIdsViaTag.Count > 0)
+                if (siteTagIds.Count > 0)
                 {
                     var planningIdsViaTag = await dbContext.AreaRulePlannings
                         .AsNoTracking()
-                        .Where(arp => arpIdsViaTag.Contains(arp.Id)
+                        .Where(arp => candidateArpIdsWithWorkerTags.Contains(arp.Id)
                                       && arp.ItemPlanningId > 0
-                                      && arp.WorkflowState != Constants.WorkflowStates.Removed)
+                                      && arp.AreaRulePlanningWorkerTags.Any(wt =>
+                                          wt.WorkflowState != Constants.WorkflowStates.Removed
+                                          && siteTagIds.Contains(wt.TagId)))
                         .Select(arp => arp.ItemPlanningId)
                         .ToListAsync(cancellationToken).ConfigureAwait(false);
 

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/l/calendar-worker-tags.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/l/calendar-worker-tags.spec.ts
@@ -1,0 +1,271 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../../Page objects/Login.page';
+import { generateRandmString } from '../../../helper-functions';
+import { CalendarUiEnhancementsPage } from '../calendar-ui-enhancements.page';
+import {
+  BackendConfigurationPropertiesPage,
+  PropertyCreateUpdate,
+} from '../BackendConfigurationProperties.page';
+import {
+  BackendConfigurationPropertyWorkersPage,
+  PropertyWorker,
+} from '../BackendConfigurationPropertyWorkers.page';
+
+/**
+ * E2E for the calendar create/edit modal's "Assign to worker tags" field
+ * (id="calendarEventWorkerTags").
+ *
+ * The field is an mtx-select (multiple) whose items come from ALL existing
+ * core tags (GET /api/tags via getAvailableTags(); the modal exposes them as
+ * data.workerTags) and is hidden when there are zero tags
+ * (*ngIf="data.workerTags.length > 0"). When the user picks worker tags the
+ * backend expands each tag to every worker carrying it, so an event can be
+ * assigned via tags ALONE — the create-validation was relaxed from
+ * "≥1 assignee" to "≥1 assignee OR ≥1 worker tag".
+ *
+ * The create POST (.../calendar/tasks) buildPayload() ships:
+ *   - sites        : number[]  (explicit assignee site ids — LEFT EMPTY here)
+ *   - workerTagIds : number[]  (the picked worker-tag ids — the field under test)
+ *
+ * Step-1 decision (how the worker tag is created + assigned to a worker):
+ * UI-only, via the existing, ID-stable property-workers page objects.
+ *   (a) Create the tag with workersPage.createTag(name) — the "Manage Tags"
+ *       modal on the property-workers page (#sitesManageTagsBtn → #newTagBtn →
+ *       #newTagName → #newTagSaveBtn). This persists to the core /api/tags
+ *       store, the same source the calendar worker-tags dropdown reads.
+ *   (b) Create a worker carrying that tag via workersPage.create({tags:[name]})
+ *       — the create modal's #tagSelector ng-select. This proves a worker
+ *       actually carries the tag (the tag→workers expansion target), not just
+ *       that an orphan tag exists.
+ * No direct API call is needed; both flows use stable element ids already
+ * exercised by other specs, so the UI path is the most robust choice.
+ *
+ * Placed in the l/ shard alongside the other calendar specs; reuses
+ * CalendarUiEnhancementsPage (parent-level page object).
+ */
+
+const rand = generateRandmString(5);
+
+const property: PropertyCreateUpdate = {
+  name: `PropWT-${rand}`,
+  chrNumber: generateRandmString(5),
+  address: generateRandmString(5),
+  cvrNumber: '1111111',
+};
+
+const workerTagName = `WT-${rand}`;
+
+const worker: PropertyWorker = {
+  name: generateRandmString(5),
+  surname: generateRandmString(5),
+  language: 'Dansk',
+  properties: [property.name],
+  workerEmail: generateRandmString(5) + '@test.com',
+  tags: [workerTagName],
+};
+
+const title = `EventWT-${rand}`;
+
+// Predicate: the create backend call (POST .../calendar/tasks) excluding the
+// week reload + move/resize sibling routes.
+function isCreatePost(method: string, url: string): boolean {
+  return (
+    url.includes('/api/backend-configuration-pn/calendar/tasks') &&
+    !url.includes('/tasks/week') &&
+    !url.includes('/tasks/move') &&
+    !url.includes('/tasks/resize') &&
+    method === 'POST'
+  );
+}
+
+test.describe.serial('Calendar "Assign to worker tags" field', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4200');
+    await new LoginPage(page).login();
+    await page.waitForTimeout(2000);
+  });
+
+  test('tag-only event: pick a worker tag, no explicit assignee, save', async ({ page }) => {
+    test.setTimeout(900000);
+
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    const propertiesPage = new BackendConfigurationPropertiesPage(page);
+    const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+
+    // ------------------------------------------------------------------
+    // Step 1: seed property + a worker carrying a freshly-created tag.
+    // ------------------------------------------------------------------
+    await propertiesPage.goToProperties();
+    await propertiesPage.createProperty(property);
+
+    await workersPage.goToPropertyWorkers();
+    // Create the worker tag first so #tagSelector can pick it when creating
+    // the worker (and so it shows up in the calendar worker-tags dropdown).
+    await workersPage.createTag(workerTagName);
+    await workersPage.create(worker);
+
+    // ------------------------------------------------------------------
+    // Step 2: open the calendar, select the property, open create modal on
+    // a FUTURE slot (next week, Monday 09:00).
+    // ------------------------------------------------------------------
+    await calendarPage.goToCalendar();
+    await calendarPage.ensureSidebarOpen();
+
+    const folderResp = page.waitForResponse(
+      r => r.url().includes('/api/backend-configuration-pn/properties/get-folder-dtos'),
+      { timeout: 60000 }
+    );
+    await calendarPage.selectProperty(property.name);
+    await folderResp.catch(() => undefined);
+    await page.waitForTimeout(1500);
+
+    await calendarPage.openCreateModalAtSlot(0, 9);
+
+    // ------------------------------------------------------------------
+    // Step 3: fill required fields (title + first eForm + first report
+    // headline). Deliberately leave #calendarEventAssignee EMPTY so the
+    // event is assigned by WORKER TAG only.
+    // ------------------------------------------------------------------
+    await page.locator('#calendarEventTitle').fill(title);
+
+    const eform = page.locator('#calendarEventEform');
+    await eform.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+
+    const planningTag = page.locator('#calendarEventPlanningTag');
+    await planningTag.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+
+    // ------------------------------------------------------------------
+    // Step 4: the worker-tags field must be present (the seeded tag makes
+    // data.workerTags non-empty). Pick the seeded tag by name.
+    // ------------------------------------------------------------------
+    const workerTags = page.locator('#calendarEventWorkerTags');
+    await expect(
+      workerTags,
+      'worker-tags field should render once at least one tag exists'
+    ).toBeVisible({ timeout: 10000 });
+
+    await workerTags.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page
+      .locator('.ng-dropdown-panel .ng-option')
+      .filter({ hasText: workerTagName })
+      .first()
+      .click();
+    await page.waitForTimeout(300);
+    // Close the dropdown by clicking the title input.
+    await page.locator('#calendarEventTitle').click();
+    await page.waitForTimeout(300);
+
+    await expect(
+      page.locator('#calendarEventWorkerTags .ng-value-label').filter({ hasText: workerTagName }).first(),
+      'the picked worker tag should display as a chip'
+    ).toBeVisible({ timeout: 5000 });
+
+    // Sanity: assignee was left empty — prove tag-only assignment.
+    expect(
+      await page.locator('#calendarEventAssignee .ng-value-label').count(),
+      'assignee must be empty to prove tag-only assignment'
+    ).toBe(0);
+
+    // ------------------------------------------------------------------
+    // Step 5: save — capture the create POST body + response.
+    // ------------------------------------------------------------------
+    const reqPromise = page.waitForRequest(
+      r => isCreatePost(r.method(), r.url()),
+      { timeout: 30000 }
+    );
+    const respPromise = page.waitForResponse(
+      r => isCreatePost(r.request().method(), r.url()),
+      { timeout: 30000 }
+    );
+    await page.locator('#calendarEventSaveBtn').click();
+    const req = await reqPromise;
+    const resp = await respPromise;
+    const body = req.postDataJSON();
+    const resBody = await resp.json().catch(() => null);
+
+    console.log(
+      `POST /calendar/tasks: status=${resp.status()}, success=${resBody?.success}, ` +
+      `workerTagIds=${JSON.stringify(body?.workerTagIds)}, sites=${JSON.stringify(body?.sites)}`
+    );
+
+    // The relaxed validation accepted a tag-only event (200).
+    expect(resp.status(), 'create POST should return 200').toBe(200);
+    expect(resBody?.success, 'create should report success').toBeTruthy();
+
+    // workerTagIds is a non-empty number[].
+    expect(
+      Array.isArray(body?.workerTagIds),
+      `workerTagIds should be an array; got ${JSON.stringify(body?.workerTagIds)}`
+    ).toBeTruthy();
+    expect(
+      body.workerTagIds.length,
+      'workerTagIds should be non-empty (the picked tag)'
+    ).toBeGreaterThanOrEqual(1);
+    for (const id of body.workerTagIds) {
+      expect(typeof id).toBe('number');
+      expect(id).toBeGreaterThan(0);
+    }
+
+    // No explicit assignee → sites empty/absent (proves relaxed validation).
+    const sites = Array.isArray(body?.sites) ? body.sites : [];
+    expect(
+      sites.length,
+      `sites should be empty for a tag-only event; got ${JSON.stringify(body?.sites)}`
+    ).toBe(0);
+
+    // ------------------------------------------------------------------
+    // Step 6: the event renders on the calendar grid.
+    // ------------------------------------------------------------------
+    await page.waitForTimeout(1500);
+    await calendarPage
+      .findEventBlock(title)
+      .waitFor({ state: 'visible', timeout: 15000 });
+
+    // ------------------------------------------------------------------
+    // Step 7 (round-trip): reopen in edit mode; the worker-tags field
+    // should be pre-populated with the seeded tag.
+    // ------------------------------------------------------------------
+    await calendarPage.openEditModal(title);
+    await expect(
+      page.locator('#calendarEventWorkerTags .ng-value-label').filter({ hasText: workerTagName }).first(),
+      'edit mode should rehydrate the worker-tags field with the seeded tag'
+    ).toBeVisible({ timeout: 10000 });
+    // Close the edit modal without saving.
+    await calendarPage.closeEventModal();
+  });
+
+  // Best-effort cleanup; the matrix slot runs against an ephemeral DB.
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    const cleanup = async () => {
+      await page.goto('http://localhost:4200');
+      await new LoginPage(page).login();
+
+      const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+      await workersPage.goToPropertyWorkers();
+      await page.waitForTimeout(1000);
+      await workersPage.clearTable();
+
+      const propertiesPage = new BackendConfigurationPropertiesPage(page);
+      await propertiesPage.goToProperties();
+      await page.waitForTimeout(1000);
+      await propertiesPage.clearTable();
+    };
+    try {
+      await Promise.race([
+        cleanup(),
+        new Promise(resolve => setTimeout(resolve, 60000)),
+      ]);
+    } catch (err: any) {
+      console.log(`afterAll cleanup failed (non-fatal): ${err?.message ?? err}`);
+    }
+    try { await page.close(); } catch {}
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -508,4 +508,7 @@ export const bgBG = {
   'Edit repeat': 'Редактиране на повторение',
   'Move repeat': 'Повторение на движението',
   'Delete repeat': 'Изтриване на повторение',
+  'At least one worker or worker tag must be assigned': 'Трябва да бъде зададен поне един работник или етикет на работник',
+  'Assign to worker tags': 'Присвояване на етикети на работници',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Това ще изтрие завинаги дъската и нейните {{count}} събития. Това действие не може да бъде отменено.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -508,4 +508,7 @@ export const csCZ = {
   'Edit repeat': 'Upravit opakování',
   'Move repeat': 'Opakování pohybu',
   'Delete repeat': 'Smazat opakování',
+  'At least one worker or worker tag must be assigned': 'Musí být přiřazen alespoň jeden pracovník nebo tag pracovníka.',
+  'Assign to worker tags': 'Přiřadit k tagům pracovníka',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tímto se nástěnka a její {{count}} události trvale smažou. Tuto akci nelze vrátit zpět.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -510,4 +510,6 @@ export const da = {
   'Edit repeat': 'Rediger gentagelse',
   'Move repeat': 'Flyt gentagelse',
   'Delete repeat': 'Slet gentagelse',
+  'At least one worker or worker tag must be assigned': 'Mindst én medarbejder eller medarbejder-tag skal tildeles',
+  'Assign to worker tags': 'Tildel til medarbejder-tags',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -559,4 +559,7 @@ export const deDE = {
   'Edit repeat': 'Bearbeiten wiederholen',
   'Move repeat': 'Bewegung wiederholen',
   'Delete repeat': 'Löschen Sie die Wiederholung',
+  'At least one worker or worker tag must be assigned': 'Mindestens ein Arbeiter oder ein Arbeiterausweis muss zugewiesen werden.',
+  'Assign to worker tags': 'Mitarbeiter-Tags zuweisen',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Dadurch werden das Board und alle darin enthaltenen {{count}} Ereignisse endgültig gelöscht. Dieser Vorgang kann nicht rückgängig gemacht werden.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -508,4 +508,7 @@ export const elGR = {
   'Edit repeat': 'Επεξεργασία επανάληψης',
   'Move repeat': 'Επανάληψη κίνησης',
   'Delete repeat': 'Διαγραφή επανάληψης',
+  'At least one worker or worker tag must be assigned': 'Πρέπει να αντιστοιχιστεί τουλάχιστον ένας εργαζόμενος ή ετικέτα εργαζομένου',
+  'Assign to worker tags': 'Ανάθεση σε ετικέτες εργαζομένων',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Αυτό θα διαγράψει οριστικά τον πίνακα και τα {{count}} συμβάντα που τον αποτελούν. Δεν είναι δυνατή η αναίρεση αυτής της ενέργειας.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -455,6 +455,8 @@ export const enUS= {
   'Create new': 'Create new',
   'Error': 'Error',
   'At least one worker must be assigned': 'At least one worker must be assigned',
+  'At least one worker or worker tag must be assigned': 'At least one worker or worker tag must be assigned',
+  'Assign to worker tags': 'Assign to worker tags',
   'Previous week': 'Previous week',
   'Next week': 'Next week',
   'Previous day': 'Previous day',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -508,4 +508,7 @@ export const esES = {
   'Edit repeat': 'Editar repetir',
   'Move repeat': 'Mover repetir',
   'Delete repeat': 'Eliminar repetir',
+  'At least one worker or worker tag must be assigned': 'Se debe asignar al menos un trabajador o una etiqueta de trabajador.',
+  'Assign to worker tags': 'Asignar a etiquetas de trabajador',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Esto eliminará permanentemente el tablero y sus {{count}} eventos. Esta acción no se puede deshacer.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -508,4 +508,7 @@ export const etET = {
   'Edit repeat': 'Redigeeri kordust',
   'Move repeat': 'Liigutuse kordus',
   'Delete repeat': 'Kustuta kordus',
+  'At least one worker or worker tag must be assigned': 'Vähemalt üks töötaja või töötaja silt peab olema määratud',
+  'Assign to worker tags': 'Määra töötaja siltidele',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'See kustutab tahvli ja selle {{count}} sündmust jäädavalt. Seda ei saa tagasi võtta.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -508,4 +508,7 @@ export const fiFI = {
   'Edit repeat': 'Muokkaa toistoa',
   'Move repeat': 'Siirrä toisto',
   'Delete repeat': 'Poista toisto',
+  'At least one worker or worker tag must be assigned': 'Vähintään yksi työntekijä tai työntekijätunniste on liitettävä',
+  'Assign to worker tags': 'Määritä työntekijätunnisteille',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tämä poistaa pysyvästi taulun ja sen {{count}} tapahtumaa. Tätä ei voi perua.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -507,4 +507,7 @@ export const frFR = {
   'Edit repeat': 'Répéter la modification',
   'Move repeat': 'Répéter le déplacement',
   'Delete repeat': 'Supprimer la répétition',
+  'At least one worker or worker tag must be assigned': 'Au moins un travailleur ou une étiquette de travailleur doit être attribué(e).',
+  'Assign to worker tags': 'Attribuer aux étiquettes de travailleur',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Cette action supprimera définitivement le plateau et ses {{count}} événements. Elle est irréversible.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -508,4 +508,7 @@ export const hrHR = {
   'Edit repeat': 'Uredi ponavljanje',
   'Move repeat': 'Ponavljanje poteza',
   'Delete repeat': 'Izbriši ponavljanje',
+  'At least one worker or worker tag must be assigned': 'Mora biti dodijeljen barem jedan radnik ili oznaka radnika',
+  'Assign to worker tags': 'Dodijeli oznakama radnika',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Ovim će se trajno izbrisati ploča i njezinih {{count}} događaja. Ova radnja se ne može poništiti.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -508,4 +508,7 @@ export const huHU = {
   'Edit repeat': 'Szerkesztés ismétlése',
   'Move repeat': 'Mozgás ismétlése',
   'Delete repeat': 'Ismétlés törlése',
+  'At least one worker or worker tag must be assigned': 'Legalább egy munkavállalót vagy munkavállalói címkét hozzá kell rendelni',
+  'Assign to worker tags': 'Munkavállalói címkék hozzárendelése',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Ez véglegesen törli a táblát és a hozzá tartozó {{count}} eseményt. A művelet nem vonható vissza.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -508,4 +508,7 @@ export const isIS = {
   'Edit repeat': 'Breyta endurtekningu',
   'Move repeat': 'Færa endurtekið',
   'Delete repeat': 'Eyða endurtekningu',
+  'At least one worker or worker tag must be assigned': 'Að minnsta kosti einn starfsmaður eða starfsmannamerki verður að vera úthlutað',
+  'Assign to worker tags': 'Úthluta til starfsmannamerkja',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Þetta mun eyða borðinu og {{count}} atburðum þess fyrir fullt og allt. Þetta er ekki hægt að afturkalla.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -508,4 +508,7 @@ export const itIT = {
   'Edit repeat': 'Modifica ripeti',
   'Move repeat': 'Muoviti ripeti',
   'Delete repeat': 'Elimina ripeti',
+  'At least one worker or worker tag must be assigned': 'Deve essere assegnato almeno un lavoratore o un tag lavoratore',
+  'Assign to worker tags': 'Assegnare ai tag dei lavoratori',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Questa operazione eliminerà definitivamente la bacheca e i suoi {{count}} eventi. Non è possibile annullare l&#39;operazione.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -508,4 +508,7 @@ export const ltLT = {
   'Edit repeat': 'Redaguoti kartojimą',
   'Move repeat': 'Judėjimo kartojimas',
   'Delete repeat': 'Ištrinti kartojimą',
+  'At least one worker or worker tag must be assigned': 'Turi būti priskirtas bent vienas darbuotojas arba darbuotojo žymė',
+  'Assign to worker tags': 'Priskirti darbuotojo žymes',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tai visam laikui ištrins lentą ir jos {{count}} įvykius. Šio veiksmo atšaukti negalima.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -508,4 +508,7 @@ export const lvLV = {
   'Edit repeat': 'Rediģēt atkārtojumu',
   'Move repeat': 'Pārvietošanas atkārtošana',
   'Delete repeat': 'Dzēst atkārtojumu',
+  'At least one worker or worker tag must be assigned': 'Jāpiešķir vismaz viens darbinieks vai darbinieka atzīme',
+  'Assign to worker tags': 'Piešķirt darbinieka tagiem',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tas neatgriezeniski izdzēsīs tāfeli un tā {{count}} notikumus. Šo darbību nevar atsaukt.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -508,4 +508,7 @@ export const nlNL = {
   'Edit repeat': 'Herhalen bewerken',
   'Move repeat': 'Verplaats herhalen',
   'Delete repeat': 'Verwijder herhaling',
+  'At least one worker or worker tag must be assigned': 'Er moet ten minste één medewerker of medewerkerslabel worden toegewezen.',
+  'Assign to worker tags': 'Wijs toe aan werknemerslabels',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Dit verwijdert het bord en de bijbehorende {{count}} gebeurtenissen permanent. Dit kan niet ongedaan worden gemaakt.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -508,4 +508,7 @@ export const noNO = {
   'Edit repeat': 'Rediger gjentakelse',
   'Move repeat': 'Flytt gjenta',
   'Delete repeat': 'Slett gjentakelse',
+  'At least one worker or worker tag must be assigned': 'Minst én arbeider eller arbeidermerke må tilordnes',
+  'Assign to worker tags': 'Tildel til arbeider-tagger',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Dette vil slette brettet og dets {{count}} hendelser permanent. Dette kan ikke angres.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -508,4 +508,7 @@ export const plPL = {
   'Edit repeat': 'Edytuj powtórzenie',
   'Move repeat': 'Przesuń powtórz',
   'Delete repeat': 'Usuń powtórzenie',
+  'At least one worker or worker tag must be assigned': 'Należy przypisać co najmniej jednego pracownika lub znacznik pracownika',
+  'Assign to worker tags': 'Przypisz do tagów pracownika',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Spowoduje to trwałe usunięcie tablicy i {{count}} jej zdarzeń. Tej czynności nie można cofnąć.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -508,4 +508,7 @@ export const ptBR = {
   'Edit repeat': 'Editar repetição',
   'Move repeat': 'Repita o movimento',
   'Delete repeat': 'Excluir repetição',
+  'At least one worker or worker tag must be assigned': 'Pelo menos um trabalhador ou uma etiqueta de trabalhador deve ser atribuída.',
+  'Assign to worker tags': 'Atribuir às etiquetas do trabalhador',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Isso excluirá permanentemente o quadro e seus {{count}} eventos. Essa ação não pode ser desfeita.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -508,4 +508,7 @@ export const ptPT = {
   'Edit repeat': 'Editar repetição',
   'Move repeat': 'Repita o movimento',
   'Delete repeat': 'Excluir repetição',
+  'At least one worker or worker tag must be assigned': 'Pelo menos um trabalhador ou uma etiqueta de trabalhador deve ser atribuída.',
+  'Assign to worker tags': 'Atribuir às etiquetas do trabalhador',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Isso excluirá permanentemente o quadro e seus {{count}} eventos. Essa ação não pode ser desfeita.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -508,4 +508,7 @@ export const roRO = {
   'Edit repeat': 'Repetare editare',
   'Move repeat': 'Repetare mutare',
   'Delete repeat': 'Ștergeți repetarea',
+  'At least one worker or worker tag must be assigned': 'Trebuie atribuit cel puțin un lucrător sau o etichetă de lucrător',
+  'Assign to worker tags': 'Atribuiți etichetelor lucrătorilor',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Aceasta acțiune va șterge definitiv forumul și {{count}} evenimentele sale. Această acțiune nu poate fi anulată.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -508,4 +508,7 @@ export const skSK = {
   'Edit repeat': 'Upraviť opakovanie',
   'Move repeat': 'Opakovanie pohybu',
   'Delete repeat': 'Odstrániť opakovanie',
+  'At least one worker or worker tag must be assigned': 'Musí byť priradený aspoň jeden pracovník alebo značka pracovníka',
+  'Assign to worker tags': 'Priradiť k značkám pracovníka',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Týmto sa natrvalo vymaže nástenka a jej {{count}} udalostí. Túto akciu nie je možné vrátiť späť.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -508,4 +508,7 @@ export const slSL = {
   'Edit repeat': 'Uredi ponovitev',
   'Move repeat': 'Ponavljanje premikanja',
   'Delete repeat': 'Izbriši ponovitev',
+  'At least one worker or worker tag must be assigned': 'Dodeljen mora biti vsaj en delavec ali oznaka delavca',
+  'Assign to worker tags': 'Dodeli oznakam delavcev',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'S tem boste trajno izbrisali tablo in {{count}} dogodkov na njej. Tega ni mogoče razveljaviti.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -508,4 +508,7 @@ export const svSE = {
   'Edit repeat': 'Redigera upprepning',
   'Move repeat': 'Flytta upprepa',
   'Delete repeat': 'Ta bort upprepning',
+  'At least one worker or worker tag must be assigned': 'Minst en arbetare eller arbetartagg måste tilldelas',
+  'Assign to worker tags': 'Tilldela till arbetartaggar',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Detta kommer att permanent radera brädet och dess {{count}} händelser. Detta kan inte ångras.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -508,4 +508,7 @@ export const ukUA = {
   'Edit repeat': 'Редагувати повторення',
   'Move repeat': 'Повторення руху',
   'Delete repeat': 'Видалити повторення',
+  'At least one worker or worker tag must be assigned': 'Повинен бути призначений принаймні один працівник або тег працівника',
+  'Assign to worker tags': 'Призначити тегам працівника',
+  'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Це назавжди видалить дошку та її {{count}} подій. Цю дію неможливо скасувати.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
@@ -19,6 +19,11 @@ export interface CalendarTaskModel {
   tags: string[];
   assigneeIds: number[];
   workerNames: string[];
+  // Worker-tag assignment (distinct from the item-planning `tags` above).
+  // Backend CalendarTaskResponseModel.WorkerTagIds — ids only; the container
+  // resolves them to display names (workerTagNames) using its `teams` list.
+  workerTagIds?: number[];
+  workerTagNames?: string[];
   boardId: number;
   color: string;
   descriptionHtml: string;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar-task-list/components/calendar-task-list-page/calendar-task-list-page.component.ts
@@ -5,7 +5,7 @@ import {TranslateService} from '@ngx-translate/core';
 import {of} from 'rxjs';
 import {dialogConfigHelper} from 'src/app/common/helpers';
 import {CommonDictionaryModel, SharedTagModel, TemplateRequestModel} from 'src/app/common/models';
-import {EFormService} from 'src/app/common/services';
+import {EFormService, EformTagService} from 'src/app/common/services';
 import {
   CalendarBoardModel,
   CalendarTaskListFiltrationModel,
@@ -34,6 +34,8 @@ export class CalendarTaskListPageComponent implements OnInit {
   properties: CommonDictionaryModel[] = [];
   boards: CalendarBoardModel[] = [];
   workers: CommonDictionaryModel[] = [];
+  // Available worker tags (a.k.a. "teams") for the edit modal's worker-tag field.
+  teams: CommonDictionaryModel[] = [];
   eforms: {id: number; label: string}[] = [];
   tags: SharedTagModel[] = [];
   tasks: CalendarTaskModel[] = [];
@@ -51,14 +53,24 @@ export class CalendarTaskListPageComponent implements OnInit {
     private propertiesService: BackendConfigurationPnPropertiesService,
     private tagsService: ItemsPlanningPnTagsService,
     private eformService: EFormService,
+    private eformTagService: EformTagService,
     private repeatService: CalendarRepeatService,
   ) {}
 
   ngOnInit() {
     this.loadProperties();
     this.loadTags();
+    this.loadWorkerTags();
     this.loadEforms();
     this.loadTasks();
+  }
+
+  loadWorkerTags() {
+    this.eformTagService.getAvailableTags().subscribe(res => {
+      if (res && res.success) {
+        this.teams = res.model;
+      }
+    });
   }
 
   loadProperties() {
@@ -155,6 +167,7 @@ export class CalendarTaskListPageComponent implements OnInit {
       selectedBoardId: task.boardId ?? undefined,
       employees: this.workers,
       tags: this.tags.map(t => t.name),
+      workerTags: this.teams,
       propertyId: task.propertyId,
       properties: this.properties,
       eforms: of(this.eforms),

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -279,7 +279,16 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       )
       .subscribe(res => {
         if (res && res.success) {
-          this.tasks = (res.model || []).map((t: any) => mapResponseToCalendarTask(t));
+          const teamNameById = new Map(this.teams.map(t => [t.id, t.name]));
+          this.tasks = (res.model || []).map((t: any) => {
+            const task = mapResponseToCalendarTask(t);
+            // Resolve worker-tag ids to display names here (the container owns
+            // `teams`); child views render the names without needing the list.
+            task.workerTagNames = (task.workerTagIds ?? [])
+              .map(id => teamNameById.get(id))
+              .filter((name): name is string => !!name);
+            return task;
+          });
           this.rebuildLayout(monday);
         }
       });
@@ -356,6 +365,7 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
           : (this.activeBoardIds.length === 1 ? this.activeBoardIds[0] : undefined),
       employees: this.employees,
       tags: this.tags.map(t => t.name),
+      workerTags: this.teams,
       propertyId: this.currentPropertyId!,
       properties: this.properties,
       eforms: this.eforms$,
@@ -764,6 +774,7 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       boards: this.boards,
       employees: this.employees,
       tags: this.tags.map(t => t.name),
+      workerTags: this.teams,
       propertyId: task.propertyId,
       properties: this.properties,
       eforms: this.eforms$,
@@ -836,6 +847,7 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       boards: this.boards,
       employees: this.employees,
       tags: this.tags.map(t => t.name),
+      workerTags: this.teams,
       propertyId: sourceTask.propertyId,
       properties: this.properties,
       eforms: this.eforms$,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.html
@@ -27,6 +27,9 @@
         <span class="task-tags" *ngIf="task.tags?.length">
           <span class="tag" *ngFor="let tag of task.tags">{{ tag }}</span>
         </span>
+        <span class="task-worker-tags" *ngIf="task.workerTagNames?.length">
+          <span class="worker-tag" *ngFor="let wt of task.workerTagNames">{{ wt }}</span>
+        </span>
       </div>
     </div>
   </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-schedule-view/calendar-schedule-view.component.scss
@@ -50,6 +50,11 @@
         // Light grey chips fail contrast on the green row — give them a
         // translucent-white pill with white text instead.
         .task-tags .tag { background: rgba(255, 255, 255, 0.25); color: #fff; }
+        .task-worker-tags .worker-tag {
+          background: rgba(255, 255, 255, 0.25);
+          color: #fff;
+          border-color: rgba(255, 255, 255, 0.4);
+        }
 
         &:hover { background: #4f6823; }
       }
@@ -107,6 +112,25 @@
 
           .tag {
             background: #e0e0e0;
+            border-radius: 12px;
+            padding: 2px 8px;
+            font-size: 11px;
+          }
+        }
+
+        // Worker-tag (assignment) chips — visually distinct from the grey
+        // item-planning .task-tags: blue-tinted pill so the two concepts
+        // don't read as the same thing.
+        .task-worker-tags {
+          display: flex;
+          gap: 4px;
+          flex-wrap: wrap;
+          margin-top: 4px;
+
+          .worker-tag {
+            background: #e3f0fb;
+            color: #1565c0;
+            border: 1px solid #90caf9;
             border-radius: 12px;
             padding: 2px 8px;
             font-size: 11px;

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
@@ -180,6 +180,25 @@
       </div>
     </div>
 
+    <!-- Worker tags (assignment) row -->
+    <div class="gcal-row" *ngIf="data.workerTags.length > 0">
+      <mat-icon class="gcal-icon">groups</mat-icon>
+      <div class="gcal-row-content">
+        <mat-form-field class="w-100">
+          <mat-label>{{ 'Assign to worker tags' | translate }}</mat-label>
+          <mtx-select
+            id="calendarEventWorkerTags"
+            [formControl]="workerTagsControl"
+            [items]="data.workerTags"
+            bindValue="id"
+            bindLabel="name"
+            [multiple]="true"
+            [clearable]="true"
+          ></mtx-select>
+        </mat-form-field>
+      </div>
+    </div>
+
     <!-- Report headline row -->
     <div class="gcal-row">
       <mat-icon class="gcal-icon">view_compact</mat-icon>
@@ -461,8 +480,8 @@
 
   <div class="gcal-actions" *ngIf="!isReadonly">
     <button id="calendarEventSaveBtn" class="btn-primary btn-primary--icon-left"
-            [disabled]="titleControl.invalid || !(assigneeControl.value?.length)"
-            [title]="!(assigneeControl.value?.length) ? ('At least one worker must be assigned' | translate) : ''"
+            [disabled]="titleControl.invalid || !((assigneeControl.value?.length) || (workerTagsControl.value?.length))"
+            [title]="!((assigneeControl.value?.length) || (workerTagsControl.value?.length)) ? ('At least one worker or worker tag must be assigned' | translate) : ''"
             (click)="onSave()">
       {{ isEditMode ? ('Save changes' | translate) : ('Save' | translate) }}
     </button>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -48,6 +48,7 @@ export interface TaskCreateEditModalData {
   selectedBoardId?: number;
   employees: CommonDictionaryModel[];
   tags: string[];
+  workerTags: CommonDictionaryModel[];
   propertyId: number;
   properties: CommonDictionaryModel[];
   eforms: Observable<{id: number; label: string}[]>;
@@ -138,6 +139,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
   endTimeControl = new FormControl('10:00');
   repeatControl = new FormControl('none');
   assigneeControl = new FormControl<number[]>([]);
+  workerTagsControl = new FormControl<number[]>([]);
   tagsControl = new FormControl<string[]>([]);
   descriptionControl = new FormControl('');
   driveLinkControl = new FormControl('');
@@ -306,6 +308,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
         this.repeatControl.setValue(task.repeatRule ?? 'none');
       }
       this.assigneeControl.setValue(task.assigneeIds ?? []);
+      this.workerTagsControl.setValue(task.workerTagIds ?? []);
       this.tagsControl.setValue(task.tags ?? []);
       this.descriptionControl.setValue(task.descriptionHtml ?? '');
       // Prefill the per-language Title/Description fields from the saved
@@ -345,6 +348,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
         this.repeatControl.setValue(sourceTask.repeatRule ?? 'none');
       }
       this.assigneeControl.setValue(sourceTask.assigneeIds ?? []);
+      this.workerTagsControl.setValue(sourceTask.workerTagIds ?? []);
       this.tagsControl.setValue(sourceTask.tags ?? []);
       this.descriptionControl.setValue(sourceTask.descriptionHtml ?? '');
       this.driveLinkControl.setValue(sourceTask.driveLink ?? '');
@@ -390,6 +394,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
         this.endTimeControl.disable();
         this.repeatControl.disable();
         this.assigneeControl.disable();
+        this.workerTagsControl.disable();
         this.tagsControl.disable();
         this.descriptionControl.disable();
         this.driveLinkControl.disable();
@@ -950,6 +955,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       startHour,
       duration,
       sites: this.assigneeControl.value ?? [],
+      workerTagIds: this.workerTagsControl.value ?? [],
       tagIds: (this.tagsControl.value ?? []).map((t: any) => {
         if (typeof t === 'number') return t;
         const match = this.data.planningTags.find(pt => pt.name === t);


### PR DESCRIPTION
## What

Adds the ability to assign backend-configuration **calendar events to worker tags**. A worker tag expands **live** to all workers carrying it, and membership/assignment changes are **retroactive** — they create or retract the real eForm cases for already-deployed future occurrences.

## How
- **Persist**: `AreaRulePlanningWorkerTag` links (new entity in base **v10.0.43**) written on create/update; validation relaxed to require explicit workers **or** worker tags.
- **Resolve**: `CalendarAssignmentResolver` — effective recipients = explicit `PlanningSites` ∪ live `SiteTag` members of the event's worker tags.
- **Reconcile**: pure `AssignmentReconciliationPlanner` + `CalendarAssignmentReconciliationService` — idempotent retroactive add/retract over future already-deployed occurrences; completed cases immutable; per-occurrence-exception aware.
- **Deploy**: `EventDeployService` unions tag members into the deploy path (forward direction) and gains a **site-aware** idempotency guard.
- **Triggers**: calendar create/update/delete; worker-tag changes on property-workers; **tag-aware resignation lock** + authoritative backend block.
- **Frontend**: new "Assign to worker tags" field (distinct from the item-planning "Set tags"), card chips, i18n across 26 languages.

## Tests
- Unit: `AssignmentReconciliationPlannerTest` (6 edge-case tests)
- Integration: `WorkerTagAssignmentTest` (6 tests — resolver union, removed-exclusion, retroactive add, past-skip, remove-non-completed/keep-completed)
- e2e: `calendar-worker-tags.spec.ts` (tag-only event create + edit round-trip)

## Notes
- Requires base **Microting.EformBackendConfigurationBase 10.0.43** (already published); ref bumped in this PR.
- Known limitation: real-time reconcile on *global* worker-tag deletion is deferred (no core→plugin hook); resolver excludes deleted-tag members automatically, residual cases clean up on next event edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)