### PR TITLE
fix(calendar): thisAndFollowing delete retracts deployed occurrences + add includingCompleted scope

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarDeleteThisAndFollowingTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarDeleteThisAndFollowingTests.cs
@@ -1,0 +1,566 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+*/
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+using System.Globalization;
+using eFormCore;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+
+/// <summary>
+/// Regression coverage for the "thisAndFollowing" delete leaving deployed
+/// occurrences behind.
+///
+/// <c>BackendConfigurationCalendarService.DeleteTask</c> with
+/// <c>scope == "thisAndFollowing"</c> trims the series end
+/// (<c>planning.RepeatUntil</c> / <c>arp.EndDate</c>) and deletes stale
+/// <c>CalendarOccurrenceException</c>s, but did NOT retract the already-DEPLOYED
+/// <c>Compliance</c> rows / SDK cases for occurrence dates on/after the clicked
+/// date. The compliance-render loop in <c>GetTasksForWeek</c> is NOT bounded by
+/// <c>RepeatUntil</c>/<c>EndDate</c> — it only skips per-occurrence
+/// <c>CalendarOccurrenceException</c> with <c>IsDeleted == true</c> — so deployed
+/// occurrences on/after the clicked date kept rendering ("not deleted").
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarDeleteThisAndFollowingTests : TestBaseSetup
+{
+    private static string IsoUtc(DateTime d) =>
+        DateTime.SpecifyKind(d, DateTimeKind.Utc)
+            .ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+    private static string Key(DateTime d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static DateTime GetNextMonday()
+    {
+        var today = DateTime.UtcNow.Date;
+        var daysUntilMonday = ((int)DayOfWeek.Monday - (int)today.DayOfWeek + 7) % 7;
+        if (daysUntilMonday == 0) daysUntilMonday = 7; // always strictly future
+        return DateTime.SpecifyKind(today.AddDays(daysUntilMonday), DateTimeKind.Utc);
+    }
+
+    [SetUp]
+    public async Task CleanCalendarTables()
+    {
+        // FK-safe cleanup so each test starts fresh (base [SetUp] already ran).
+        BackendConfigurationPnDbContext!.CalendarOccurrenceExceptionSites.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarOccurrenceExceptionSites);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.CalendarOccurrenceExceptions.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarOccurrenceExceptions);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.Compliances.RemoveRange(
+            BackendConfigurationPnDbContext.Compliances);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.CalendarConfigurations.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarConfigurations);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRulePlannings.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRulePlannings);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRules.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRules);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.Areas.RemoveRange(
+            BackendConfigurationPnDbContext.Areas);
+        BackendConfigurationPnDbContext.Properties.RemoveRange(
+            BackendConfigurationPnDbContext.Properties);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        ItemsPlanningPnDbContext!.PlanningCaseSites.RemoveRange(
+            ItemsPlanningPnDbContext.PlanningCaseSites);
+        ItemsPlanningPnDbContext.PlanningCases.RemoveRange(
+            ItemsPlanningPnDbContext.PlanningCases);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        ItemsPlanningPnDbContext.Plannings.RemoveRange(
+            ItemsPlanningPnDbContext.Plannings);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        MicrotingDbContext!.Cases.RemoveRange(MicrotingDbContext.Cases);
+        await MicrotingDbContext.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Seeds an SDK Site + Case with the given completion status and returns the
+    /// Case Id. The Case is left with a null MicrotingUid (no real
+    /// deployed-to-device backing): the retraction path guards
+    /// <c>MicrotingUid != null</c> before <c>core.CaseDelete</c>, so this keeps the
+    /// test deterministic while still exercising the Compliance + PlanningCase /
+    /// PlanningCaseSite bookkeeping retraction (the same approach
+    /// CalendarComplianceMoveTests uses).
+    /// </summary>
+    private async Task<int> SeedSdkCase(int status, int siteUid)
+    {
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        var sdkSite = new Site
+        {
+            Name = $"delete-thisandfollowing-site-{siteUid}",
+            MicrotingUid = siteUid,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(sdkSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var sdkCase = new Case
+        {
+            SiteId = sdkSite.Id,
+            Status = status,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Cases.AddAsync(sdkCase);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        return sdkCase.Id;
+    }
+
+    /// <summary>
+    /// Seeds Area→Property→AreaRule(+translation)→Planning(daily)→
+    /// AreaRulePlanning(daily)→CalendarConfiguration. Returns
+    /// (arpId, propertyId, planningId, areaId).
+    /// </summary>
+    private async Task<(int ArpId, int PropertyId, int PlanningId, int AreaId)> SeedDailySeries(
+        DateTime startDate)
+    {
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"DeleteThisAndFollowingTest-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id, EformId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRuleTranslation = new AreaRuleTranslation
+        {
+            AreaRuleId = areaRule.Id, LanguageId = 1, Name = "Delete ThisAndFollowing Title",
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRuleTranslations.AddAsync(areaRuleTranslation);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Day,
+            StartDate = DateTime.SpecifyKind(startDate, DateTimeKind.Utc),
+            RelatedEFormId = 0, WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        // Daily series: RepeatType=1 (days), RepeatEvery=1.
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
+            ItemPlanningId = planning.Id,
+            StartDate = DateTime.SpecifyKind(startDate, DateTimeKind.Utc), Status = true,
+            RepeatType = 1, RepeatEvery = 1,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        return (arp.Id, property.Id, planning.Id, area.Id);
+    }
+
+    /// <summary>
+    /// Seeds a DEPLOYED Compliance row (MicrotingSdkCaseId &gt; 0) at the given
+    /// deadline, plus its backing PlanningCase + PlanningCaseSite bookkeeping.
+    /// Returns the Compliance Id.
+    /// </summary>
+    private async Task<int> SeedDeployedCompliance(int planningId, int propertyId, int areaId,
+        DateTime deadline, int sdkCaseId, int sdkSiteId)
+    {
+        var planningCase = new PlanningCase
+        {
+            PlanningId = planningId,
+            MicrotingSdkCaseId = sdkCaseId,
+            MicrotingSdkeFormId = 0,
+            Status = 66,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.PlanningCases.AddAsync(planningCase);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var planningCaseSite = new PlanningCaseSite
+        {
+            PlanningCaseId = planningCase.Id,
+            PlanningId = planningId,
+            MicrotingSdkCaseId = sdkCaseId,
+            MicrotingSdkSiteId = sdkSiteId,
+            MicrotingSdkeFormId = 0,
+            Status = 66,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext.PlanningCaseSites.AddAsync(planningCaseSite);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var compliance = new Compliance
+        {
+            PlanningId = planningId,
+            PropertyId = propertyId,
+            AreaId = areaId,
+            Deadline = DateTime.SpecifyKind(deadline, DateTimeKind.Utc),
+            StartDate = DateTime.SpecifyKind(deadline.AddDays(-1), DateTimeKind.Utc),
+            MicrotingSdkCaseId = sdkCaseId,
+            MicrotingSdkeFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Compliances.AddAsync(compliance);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        return compliance.Id;
+    }
+
+    private BackendConfigurationCalendarService BuildService(Core core)
+    {
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        userService.GetCurrentUserLanguage().Returns(Task.FromResult(
+            new Language { Id = 1, Name = "English", LanguageCode = "en-US" }));
+
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+
+        var taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        taskWizardService.DeleteTask(Arg.Any<int>())
+            .Returns(Task.FromResult(new OperationResult(true)));
+
+        return new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(), userService,
+            BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext!, taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
+            NullLogger<BackendConfigurationCalendarService>.Instance);
+    }
+
+    private async Task<List<CalendarTaskResponseModel>> TilesForWeek(
+        BackendConfigurationCalendarService service, int propertyId, DateTime weekMonday, int planningId)
+    {
+        var result = await service.GetTasksForWeek(new CalendarTaskRequestModel
+        {
+            PropertyId = propertyId,
+            WeekStart = IsoUtc(weekMonday),
+            WeekEnd = IsoUtc(weekMonday.AddDays(6).AddHours(23).AddMinutes(59)),
+            ActionableOnly = false,
+            BoardIds = [], TagNames = [], SiteIds = []
+        });
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model, Is.Not.Null);
+        return result.Model.Where(t => t.PlanningId == planningId).ToList();
+    }
+
+    [Test]
+    public async Task DeleteThisAndFollowing_RetractsDeployedOccurrencesOnOrAfterOriginalDate()
+    {
+        var core = await GetCore();
+
+        var monday = GetNextMonday();
+        var (arpId, propertyId, planningId, areaId) = await SeedDailySeries(monday);
+
+        // The clicked ("originalDate") day is StartDate + 2 (strictly after StartDate
+        // so it does NOT fall into DeleteEntireSeries).
+        var originalDate = monday.AddDays(2);
+
+        // SURVIVOR: a deployed occurrence on StartDate (before originalDate).
+        var beforeCaseId = await SeedSdkCase(status: 66, siteUid: 7001);
+        var beforeSdkSiteId = (await MicrotingDbContext!.Sites
+            .OrderBy(s => s.Id).LastAsync()).Id;
+        var beforeComplianceId = await SeedDeployedCompliance(
+            planningId, propertyId, areaId, monday, beforeCaseId, beforeSdkSiteId);
+
+        // RETRACT: deployed occurrence ON originalDate (StartDate + 2).
+        var onCaseId = await SeedSdkCase(status: 66, siteUid: 7002);
+        var onSdkSiteId = (await MicrotingDbContext.Sites
+            .OrderBy(s => s.Id).LastAsync()).Id;
+        var onComplianceId = await SeedDeployedCompliance(
+            planningId, propertyId, areaId, originalDate, onCaseId, onSdkSiteId);
+
+        // RETRACT: deployed occurrence on originalDate + 1 (StartDate + 3).
+        var afterCaseId = await SeedSdkCase(status: 66, siteUid: 7003);
+        var afterSdkSiteId = (await MicrotingDbContext.Sites
+            .OrderBy(s => s.Id).LastAsync()).Id;
+        var afterComplianceId = await SeedDeployedCompliance(
+            planningId, propertyId, areaId, originalDate.AddDays(1), afterCaseId, afterSdkSiteId);
+
+        var service = BuildService(core);
+
+        // Sanity: before delete, the week shows tiles on/after originalDate.
+        var before = await TilesForWeek(service, propertyId, monday, planningId);
+        Assert.That(before.Any(t => t.TaskDate == Key(originalDate)), Is.True,
+            "pre-delete sanity: originalDate occurrence renders");
+
+        // ----- ACT: delete this and following -----
+        var deleteResult = await service.DeleteTask(new CalendarTaskDeleteRequestModel
+        {
+            Id = arpId,
+            Scope = "thisAndFollowing",
+            OriginalDate = originalDate.ToString("yyyy-MM-dd")
+        });
+        Assert.That(deleteResult.Success, Is.True, deleteResult.Message);
+
+        // ----- ASSERT (a): render-level -----
+        var after = await TilesForWeek(service, propertyId, monday, planningId);
+        Assert.Multiple(() =>
+        {
+            Assert.That(after.Any(t => t.TaskDate == Key(monday)), Is.True,
+                "the occurrence BEFORE originalDate must survive and still render");
+            Assert.That(after.Any(t => string.Compare(t.TaskDate, Key(originalDate),
+                    StringComparison.Ordinal) >= 0), Is.False,
+                "no occurrence on/after originalDate may render after thisAndFollowing delete");
+        });
+
+        // ----- ASSERT (b): Compliance soft-deleted on/after, survivor untouched -----
+        var beforeCompliance = await BackendConfigurationPnDbContext!.Compliances
+            .AsNoTracking().SingleAsync(x => x.Id == beforeComplianceId);
+        var onCompliance = await BackendConfigurationPnDbContext.Compliances
+            .AsNoTracking().SingleAsync(x => x.Id == onComplianceId);
+        var afterCompliance = await BackendConfigurationPnDbContext.Compliances
+            .AsNoTracking().SingleAsync(x => x.Id == afterComplianceId);
+        Assert.Multiple(() =>
+        {
+            Assert.That(beforeCompliance.WorkflowState, Is.Not.EqualTo(Constants.WorkflowStates.Removed),
+                "the survivor compliance (before originalDate) stays live");
+            Assert.That(onCompliance.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed),
+                "the compliance ON originalDate is soft-deleted");
+            Assert.That(afterCompliance.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed),
+                "the compliance AFTER originalDate is soft-deleted");
+        });
+
+        // ----- ASSERT (c): bookkeeping + SDK case retracted on/after -----
+        var onPlanningCaseSites = await ItemsPlanningPnDbContext!.PlanningCaseSites
+            .AsNoTracking()
+            .Where(x => x.MicrotingSdkCaseId == onCaseId
+                        && x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        var afterPlanningCaseSites = await ItemsPlanningPnDbContext.PlanningCaseSites
+            .AsNoTracking()
+            .Where(x => x.MicrotingSdkCaseId == afterCaseId
+                        && x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        var survivorPlanningCaseSites = await ItemsPlanningPnDbContext.PlanningCaseSites
+            .AsNoTracking()
+            .Where(x => x.MicrotingSdkCaseId == beforeCaseId
+                        && x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        Assert.Multiple(() =>
+        {
+            Assert.That(onPlanningCaseSites, Is.Empty,
+                "the PlanningCaseSite for the originalDate occurrence is retracted");
+            Assert.That(afterPlanningCaseSites, Is.Empty,
+                "the PlanningCaseSite for the after-originalDate occurrence is retracted");
+            Assert.That(survivorPlanningCaseSites, Has.Count.EqualTo(1),
+                "the survivor's PlanningCaseSite is untouched");
+        });
+    }
+
+    /// <summary>
+    /// Default <c>scope == "thisAndFollowing"</c> preserves COMPLETED history:
+    /// a deployed occurrence ON originalDate whose backing SDK Case is Status=100
+    /// must STILL render (and its Compliance row must NOT be removed), while a
+    /// pending occurrence after it is retracted. Locks the "completed = frozen"
+    /// default behavior.
+    /// </summary>
+    [Test]
+    public async Task DeleteThisAndFollowing_PreservesCompletedOccurrence()
+    {
+        var core = await GetCore();
+
+        var monday = GetNextMonday();
+        var (arpId, propertyId, planningId, areaId) = await SeedDailySeries(monday);
+
+        var originalDate = monday.AddDays(2);
+
+        // COMPLETED occurrence ON originalDate (Status=100 backing SDK case).
+        var completedCaseId = await SeedSdkCase(status: 100, siteUid: 7101);
+        var completedSdkSiteId = (await MicrotingDbContext!.Sites
+            .OrderBy(s => s.Id).LastAsync()).Id;
+        var completedComplianceId = await SeedDeployedCompliance(
+            planningId, propertyId, areaId, originalDate, completedCaseId, completedSdkSiteId);
+
+        // PENDING occurrence on originalDate + 1.
+        var pendingCaseId = await SeedSdkCase(status: 66, siteUid: 7102);
+        var pendingSdkSiteId = (await MicrotingDbContext.Sites
+            .OrderBy(s => s.Id).LastAsync()).Id;
+        var pendingComplianceId = await SeedDeployedCompliance(
+            planningId, propertyId, areaId, originalDate.AddDays(1), pendingCaseId, pendingSdkSiteId);
+
+        var service = BuildService(core);
+
+        var before = await TilesForWeek(service, propertyId, monday, planningId);
+        Assert.That(before.Any(t => t.TaskDate == Key(originalDate)), Is.True,
+            "pre-delete sanity: completed originalDate occurrence renders");
+
+        var deleteResult = await service.DeleteTask(new CalendarTaskDeleteRequestModel
+        {
+            Id = arpId,
+            Scope = "thisAndFollowing",
+            OriginalDate = originalDate.ToString("yyyy-MM-dd")
+        });
+        Assert.That(deleteResult.Success, Is.True, deleteResult.Message);
+
+        // ----- ASSERT (a): render-level — completed survives, pending removed -----
+        var after = await TilesForWeek(service, propertyId, monday, planningId);
+        Assert.Multiple(() =>
+        {
+            Assert.That(after.Any(t => t.TaskDate == Key(originalDate)), Is.True,
+                "the COMPLETED occurrence ON originalDate must still render (frozen history)");
+            Assert.That(after.Any(t => t.TaskDate == Key(originalDate.AddDays(1))), Is.False,
+                "the pending occurrence after originalDate is removed");
+        });
+
+        // ----- ASSERT (b): completed Compliance NOT removed, pending removed -----
+        var completedCompliance = await BackendConfigurationPnDbContext!.Compliances
+            .AsNoTracking().SingleAsync(x => x.Id == completedComplianceId);
+        var pendingCompliance = await BackendConfigurationPnDbContext.Compliances
+            .AsNoTracking().SingleAsync(x => x.Id == pendingComplianceId);
+        Assert.Multiple(() =>
+        {
+            Assert.That(completedCompliance.WorkflowState, Is.Not.EqualTo(Constants.WorkflowStates.Removed),
+                "the COMPLETED compliance on originalDate stays live (frozen history)");
+            Assert.That(pendingCompliance.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed),
+                "the pending compliance after originalDate is soft-deleted");
+        });
+    }
+
+    /// <summary>
+    /// New <c>scope == "thisAndFollowingIncludingCompleted"</c> ALSO retracts
+    /// COMPLETED occurrences on/after originalDate (full removal, like
+    /// DeleteEntireSeries). The completed occurrence must NOT render after the
+    /// delete, and must be suppressed at the DB level (Compliance soft-deleted
+    /// and/or CalendarOccurrenceException IsDeleted written).
+    /// </summary>
+    [Test]
+    public async Task DeleteThisAndFollowingIncludingCompleted_RemovesCompletedOccurrence()
+    {
+        var core = await GetCore();
+
+        var monday = GetNextMonday();
+        var (arpId, propertyId, planningId, areaId) = await SeedDailySeries(monday);
+
+        var originalDate = monday.AddDays(2);
+
+        // SURVIVOR: completed occurrence BEFORE originalDate (must stay).
+        var survivorCaseId = await SeedSdkCase(status: 100, siteUid: 7201);
+        var survivorSdkSiteId = (await MicrotingDbContext!.Sites
+            .OrderBy(s => s.Id).LastAsync()).Id;
+        var survivorComplianceId = await SeedDeployedCompliance(
+            planningId, propertyId, areaId, monday, survivorCaseId, survivorSdkSiteId);
+
+        // COMPLETED occurrence ON originalDate (Status=100) — must be removed.
+        var completedCaseId = await SeedSdkCase(status: 100, siteUid: 7202);
+        var completedSdkSiteId = (await MicrotingDbContext.Sites
+            .OrderBy(s => s.Id).LastAsync()).Id;
+        var completedComplianceId = await SeedDeployedCompliance(
+            planningId, propertyId, areaId, originalDate, completedCaseId, completedSdkSiteId);
+
+        var service = BuildService(core);
+
+        var before = await TilesForWeek(service, propertyId, monday, planningId);
+        Assert.That(before.Any(t => t.TaskDate == Key(originalDate)), Is.True,
+            "pre-delete sanity: completed originalDate occurrence renders");
+
+        var deleteResult = await service.DeleteTask(new CalendarTaskDeleteRequestModel
+        {
+            Id = arpId,
+            Scope = "thisAndFollowingIncludingCompleted",
+            OriginalDate = originalDate.ToString("yyyy-MM-dd")
+        });
+        Assert.That(deleteResult.Success, Is.True, deleteResult.Message);
+
+        // ----- ASSERT (a): render-level — completed on originalDate gone, survivor stays -----
+        var after = await TilesForWeek(service, propertyId, monday, planningId);
+        Assert.Multiple(() =>
+        {
+            Assert.That(after.Any(t => t.TaskDate == Key(monday)), Is.True,
+                "the completed occurrence BEFORE originalDate must survive and still render");
+            Assert.That(after.Any(t => t.TaskDate == Key(originalDate)), Is.False,
+                "the COMPLETED occurrence ON originalDate must NOT render after includingCompleted delete");
+        });
+
+        // ----- ASSERT (b): DB-level suppression for the removed completed occurrence -----
+        var completedCompliance = await BackendConfigurationPnDbContext!.Compliances
+            .AsNoTracking().SingleAsync(x => x.Id == completedComplianceId);
+        var survivorCompliance = await BackendConfigurationPnDbContext.Compliances
+            .AsNoTracking().SingleAsync(x => x.Id == survivorComplianceId);
+        var deletedException = await BackendConfigurationPnDbContext.CalendarOccurrenceExceptions
+            .AsNoTracking()
+            .Where(x => x.AreaRulePlanningId == arpId
+                        && x.OriginalDate.Date == originalDate.Date
+                        && x.IsDeleted
+                        && x.WorkflowState != Constants.WorkflowStates.Removed)
+            .ToListAsync();
+        Assert.Multiple(() =>
+        {
+            Assert.That(survivorCompliance.WorkflowState, Is.Not.EqualTo(Constants.WorkflowStates.Removed),
+                "the survivor compliance (before originalDate) stays live");
+            Assert.That(completedCompliance.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed),
+                "the completed occurrence's Compliance row is soft-deleted on the includingCompleted path");
+            Assert.That(deletedException, Is.Not.Empty,
+                "an IsDeleted CalendarOccurrenceException is written so the completed tile stops rendering");
+        });
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -2076,8 +2076,15 @@ public class BackendConfigurationCalendarService(
                 return new OperationResult(true,
                     localizationService.GetString("CalendarTaskDeletedSuccessfully"));
             }
-            else if (scope == "thisAndFollowing" && !string.IsNullOrEmpty(deleteModel.OriginalDate))
+            else if ((scope == "thisAndFollowing" || scope == "thisAndFollowingIncludingCompleted")
+                     && !string.IsNullOrEmpty(deleteModel.OriginalDate))
             {
+                // thisAndFollowingIncludingCompleted behaves identically to
+                // thisAndFollowing EXCEPT it ALSO retracts completed occurrences
+                // (backing SDK Case Status==100) on/after originalDate — full
+                // removal, the way DeleteEntireSeries treats the whole series.
+                var includeCompleted = scope == "thisAndFollowingIncludingCompleted";
+
                 var originalDate = DateTime.Parse(deleteModel.OriginalDate, CultureInfo.InvariantCulture,
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal).Date;
 
@@ -2122,6 +2129,130 @@ public class BackendConfigurationCalendarService(
                 foreach (var stale in staleExceptions)
                 {
                     await stale.Delete(backendConfigurationPnDbContext);
+                }
+
+                // Trimming RepeatUntil/EndDate stops FUTURE (never-deployed)
+                // occurrences from being emitted by the recurrence loop, but the
+                // compliance-render loop in GetTasksForWeek is NOT bounded by
+                // RepeatUntil — it emits every live Compliance row regardless of
+                // date. So already-DEPLOYED occurrences on/after originalDate keep
+                // rendering ("not deleted"). Retract them the same way
+                // DeleteEntireSeries / CalendarAssignmentReconciliation do:
+                // delete the backing SDK case, retract the PlanningCase bookkeeping
+                // and soft-delete the Compliance row. COMPLETED occurrences
+                // (backing SDK Case Status==100) are frozen history — left intact.
+                // Compliance.Deadline is stored as a non-Kind DateTime (deploy
+                // writes it at midnight); strip Kind off originalDate so the
+                // EF >= comparison is not offset by the parsed UTC kind.
+                var originalDateMidnight = DateTime.SpecifyKind(originalDate.Date, DateTimeKind.Unspecified);
+                var deployedToRetract = await backendConfigurationPnDbContext.Compliances
+                    .Where(c => c.PlanningId == arp.ItemPlanningId
+                                && c.Deadline >= originalDateMidnight
+                                && c.MicrotingSdkCaseId > 0
+                                && c.WorkflowState != Constants.WorkflowStates.Removed)
+                    .ToListAsync();
+
+                // Only reach for the SDK core when there is actually something to
+                // retract — a delete with no deployed occurrences must not require
+                // coreHelper.GetCore() (it may be absent for never-deployed series).
+                if (deployedToRetract.Count > 0)
+                {
+                var core = await coreHelper.GetCore();
+                await using var sdkDbContext = core.DbContextHelper.GetDbContext();
+
+                foreach (var compliance in deployedToRetract)
+                {
+                    var sdkCase = await sdkDbContext.Cases
+                        .SingleOrDefaultAsync(x => x.Id == compliance.MicrotingSdkCaseId);
+
+                    // Completed occurrences are immutable history — never retract
+                    // under the default scope. The includeCompleted scope opts in
+                    // to removing them too.
+                    var isCompleted = sdkCase?.Status == 100;
+                    if (!includeCompleted && isCompleted)
+                    {
+                        continue;
+                    }
+
+                    if (sdkCase?.MicrotingUid != null)
+                    {
+                        await core.CaseDelete((int)sdkCase.MicrotingUid);
+                    }
+
+                    // The compliance-render loop in GetTasksForWeek emits
+                    // removed-but-COMPLETED Compliance rows (backing SDK Case
+                    // Status==100) so a just-completed occurrence doesn't snap
+                    // back to uncompleted. Soft-deleting the Compliance + the SDK
+                    // case is therefore NOT enough to hide a completed occurrence
+                    // we deliberately remove here — that render branch keys off
+                    // Status==100, which CaseDelete does not change. Write an
+                    // IsDeleted occurrence exception so the render loop's
+                    // `complianceException?.IsDeleted == true → continue` gate
+                    // suppresses it. Only for the includeCompleted scope and only
+                    // for completed occurrences we retract.
+                    if (includeCompleted && isCompleted)
+                    {
+                        var occurrenceDate = DateTime.SpecifyKind(
+                            compliance.Deadline.Date, DateTimeKind.Utc);
+                        var existingException = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
+                            .Where(x => x.AreaRulePlanningId == deleteModel.Id)
+                            .Where(x => x.OriginalDate == occurrenceDate)
+                            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                            .FirstOrDefaultAsync();
+
+                        if (existingException != null)
+                        {
+                            existingException.IsDeleted = true;
+                            existingException.UpdatedByUserId = userService.UserId;
+                            await existingException.Update(backendConfigurationPnDbContext);
+                        }
+                        else
+                        {
+                            var deletedException = new CalendarOccurrenceException
+                            {
+                                AreaRulePlanningId = deleteModel.Id,
+                                OriginalDate = occurrenceDate,
+                                IsDeleted = true,
+                                CreatedByUserId = userService.UserId,
+                                UpdatedByUserId = userService.UserId
+                            };
+                            await deletedException.Create(backendConfigurationPnDbContext);
+                        }
+                    }
+
+                    var planningCaseSites = await itemsPlanningPnDbContext.PlanningCaseSites
+                        .Where(pcs => pcs.MicrotingSdkCaseId == compliance.MicrotingSdkCaseId
+                                      && pcs.WorkflowState != Constants.WorkflowStates.Removed)
+                        .ToListAsync();
+
+                    foreach (var pcs in planningCaseSites)
+                    {
+                        var planningCase = await itemsPlanningPnDbContext.PlanningCases
+                            .Where(x => x.Id == pcs.PlanningCaseId
+                                        && x.WorkflowState != Constants.WorkflowStates.Removed)
+                            .FirstOrDefaultAsync();
+
+                        await pcs.Delete(itemsPlanningPnDbContext);
+
+                        if (planningCase != null)
+                        {
+                            // Retract the owning PlanningCase only when no live
+                            // PlanningCaseSite children remain (calendar deploy is
+                            // 1:1 site→case, but a shared case with other live sites
+                            // must survive) — mirrors RetractSiteForOccurrenceAsync.
+                            var remainingLiveSites = await itemsPlanningPnDbContext.PlanningCaseSites
+                                .CountAsync(x => x.PlanningCaseId == planningCase.Id
+                                                 && x.WorkflowState != Constants.WorkflowStates.Removed);
+                            if (remainingLiveSites == 0)
+                            {
+                                planningCase.WorkflowState = Constants.WorkflowStates.Retracted;
+                                await planningCase.Update(itemsPlanningPnDbContext);
+                            }
+                        }
+                    }
+
+                    await compliance.Delete(backendConfigurationPnDbContext);
+                }
                 }
 
                 return new OperationResult(true,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -511,4 +511,5 @@ export const bgBG = {
   'At least one worker or worker tag must be assigned': 'Трябва да бъде зададен поне един работник или етикет на работник',
   'Assign to worker tags': 'Присвояване на етикети на работници',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Това ще изтрие завинаги дъската и нейните {{count}} събития. Това действие не може да бъде отменено.',
+  'This and following (incl. completed)': 'Това и следващите (вкл. завършени)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -511,4 +511,5 @@ export const csCZ = {
   'At least one worker or worker tag must be assigned': 'Musí být přiřazen alespoň jeden pracovník nebo tag pracovníka.',
   'Assign to worker tags': 'Přiřadit k tagům pracovníka',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tímto se nástěnka a její {{count}} události trvale smažou. Tuto akci nelze vrátit zpět.',
+  'This and following (incl. completed)': 'Toto a následující (včetně dokončených)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -512,4 +512,5 @@ export const da = {
   'Delete repeat': 'Slet gentagelse',
   'At least one worker or worker tag must be assigned': 'Mindst én medarbejder eller medarbejder-tag skal tildeles',
   'Assign to worker tags': 'Tildel til medarbejder-tags',
+  'This and following (incl. completed)': 'Dette og følgende (inkl. færdiggjorte)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -562,4 +562,5 @@ export const deDE = {
   'At least one worker or worker tag must be assigned': 'Mindestens ein Arbeiter oder ein Arbeiterausweis muss zugewiesen werden.',
   'Assign to worker tags': 'Mitarbeiter-Tags zuweisen',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Dadurch werden das Board und alle darin enthaltenen {{count}} Ereignisse endgültig gelöscht. Dieser Vorgang kann nicht rückgängig gemacht werden.',
+  'This and following (incl. completed)': 'Dies und Folgendes (einschließlich abgeschlossener)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -511,4 +511,5 @@ export const elGR = {
   'At least one worker or worker tag must be assigned': 'Πρέπει να αντιστοιχιστεί τουλάχιστον ένας εργαζόμενος ή ετικέτα εργαζομένου',
   'Assign to worker tags': 'Ανάθεση σε ετικέτες εργαζομένων',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Αυτό θα διαγράψει οριστικά τον πίνακα και τα {{count}} συμβάντα που τον αποτελούν. Δεν είναι δυνατή η αναίρεση αυτής της ενέργειας.',
+  'This and following (incl. completed)': 'Αυτό και τα επόμενα (συμπεριλαμβανομένων των ολοκληρωμένων)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -514,6 +514,7 @@ export const enUS= {
   'Complete task': 'Complete task',
   'Only this': 'Only this',
   'This and following': 'This and following',
+  'This and following (incl. completed)': 'This and following (incl. completed)',
   'All in series': 'All in series',
   'Date is required': 'Date is required',
   'Open link': 'Open link',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -511,4 +511,5 @@ export const esES = {
   'At least one worker or worker tag must be assigned': 'Se debe asignar al menos un trabajador o una etiqueta de trabajador.',
   'Assign to worker tags': 'Asignar a etiquetas de trabajador',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Esto eliminará permanentemente el tablero y sus {{count}} eventos. Esta acción no se puede deshacer.',
+  'This and following (incl. completed)': 'Esto y lo siguiente (incluidos los completados)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -511,4 +511,5 @@ export const etET = {
   'At least one worker or worker tag must be assigned': 'Vähemalt üks töötaja või töötaja silt peab olema määratud',
   'Assign to worker tags': 'Määra töötaja siltidele',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'See kustutab tahvli ja selle {{count}} sündmust jäädavalt. Seda ei saa tagasi võtta.',
+  'This and following (incl. completed)': 'See ja järgnev (sh lõpetatud)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -511,4 +511,5 @@ export const fiFI = {
   'At least one worker or worker tag must be assigned': 'Vähintään yksi työntekijä tai työntekijätunniste on liitettävä',
   'Assign to worker tags': 'Määritä työntekijätunnisteille',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tämä poistaa pysyvästi taulun ja sen {{count}} tapahtumaa. Tätä ei voi perua.',
+  'This and following (incl. completed)': 'Tämä ja seuraavat (mukaan lukien valmiit)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -510,4 +510,5 @@ export const frFR = {
   'At least one worker or worker tag must be assigned': 'Au moins un travailleur ou une étiquette de travailleur doit être attribué(e).',
   'Assign to worker tags': 'Attribuer aux étiquettes de travailleur',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Cette action supprimera définitivement le plateau et ses {{count}} événements. Elle est irréversible.',
+  'This and following (incl. completed)': 'Ceci et les suivants (y compris les éléments terminés)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -511,4 +511,5 @@ export const hrHR = {
   'At least one worker or worker tag must be assigned': 'Mora biti dodijeljen barem jedan radnik ili oznaka radnika',
   'Assign to worker tags': 'Dodijeli oznakama radnika',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Ovim će se trajno izbrisati ploča i njezinih {{count}} događaja. Ova radnja se ne može poništiti.',
+  'This and following (incl. completed)': 'Ovo i sljedeće (uklj. dovršeno)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -511,4 +511,5 @@ export const huHU = {
   'At least one worker or worker tag must be assigned': 'Legalább egy munkavállalót vagy munkavállalói címkét hozzá kell rendelni',
   'Assign to worker tags': 'Munkavállalói címkék hozzárendelése',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Ez véglegesen törli a táblát és a hozzá tartozó {{count}} eseményt. A művelet nem vonható vissza.',
+  'This and following (incl. completed)': 'Ez és a következő (beleértve a befejezetteket is)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -511,4 +511,5 @@ export const isIS = {
   'At least one worker or worker tag must be assigned': 'Að minnsta kosti einn starfsmaður eða starfsmannamerki verður að vera úthlutað',
   'Assign to worker tags': 'Úthluta til starfsmannamerkja',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Þetta mun eyða borðinu og {{count}} atburðum þess fyrir fullt og allt. Þetta er ekki hægt að afturkalla.',
+  'This and following (incl. completed)': 'Þetta og eftirfarandi (þar með talið lokið)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -511,4 +511,5 @@ export const itIT = {
   'At least one worker or worker tag must be assigned': 'Deve essere assegnato almeno un lavoratore o un tag lavoratore',
   'Assign to worker tags': 'Assegnare ai tag dei lavoratori',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Questa operazione eliminerà definitivamente la bacheca e i suoi {{count}} eventi. Non è possibile annullare l&#39;operazione.',
+  'This and following (incl. completed)': 'Questo e i seguenti (compresi quelli completati)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -511,4 +511,5 @@ export const ltLT = {
   'At least one worker or worker tag must be assigned': 'Turi būti priskirtas bent vienas darbuotojas arba darbuotojo žymė',
   'Assign to worker tags': 'Priskirti darbuotojo žymes',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tai visam laikui ištrins lentą ir jos {{count}} įvykius. Šio veiksmo atšaukti negalima.',
+  'This and following (incl. completed)': 'Šis ir tolesni (įskaitant užbaigtus)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -511,4 +511,5 @@ export const lvLV = {
   'At least one worker or worker tag must be assigned': 'Jāpiešķir vismaz viens darbinieks vai darbinieka atzīme',
   'Assign to worker tags': 'Piešķirt darbinieka tagiem',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tas neatgriezeniski izdzēsīs tāfeli un tā {{count}} notikumus. Šo darbību nevar atsaukt.',
+  'This and following (incl. completed)': 'Šis un turpmākie (ieskaitot pabeigtos)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -511,4 +511,5 @@ export const nlNL = {
   'At least one worker or worker tag must be assigned': 'Er moet ten minste één medewerker of medewerkerslabel worden toegewezen.',
   'Assign to worker tags': 'Wijs toe aan werknemerslabels',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Dit verwijdert het bord en de bijbehorende {{count}} gebeurtenissen permanent. Dit kan niet ongedaan worden gemaakt.',
+  'This and following (incl. completed)': 'Dit en het volgende (inclusief voltooid)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -511,4 +511,5 @@ export const noNO = {
   'At least one worker or worker tag must be assigned': 'Minst én arbeider eller arbeidermerke må tilordnes',
   'Assign to worker tags': 'Tildel til arbeider-tagger',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Dette vil slette brettet og dets {{count}} hendelser permanent. Dette kan ikke angres.',
+  'This and following (incl. completed)': 'Dette og følgende (inkl. fullført)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -511,4 +511,5 @@ export const plPL = {
   'At least one worker or worker tag must be assigned': 'Należy przypisać co najmniej jednego pracownika lub znacznik pracownika',
   'Assign to worker tags': 'Przypisz do tagów pracownika',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Spowoduje to trwałe usunięcie tablicy i {{count}} jej zdarzeń. Tej czynności nie można cofnąć.',
+  'This and following (incl. completed)': 'To i następne (w tym ukończone)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -511,4 +511,5 @@ export const ptBR = {
   'At least one worker or worker tag must be assigned': 'Pelo menos um trabalhador ou uma etiqueta de trabalhador deve ser atribuída.',
   'Assign to worker tags': 'Atribuir às etiquetas do trabalhador',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Isso excluirá permanentemente o quadro e seus {{count}} eventos. Essa ação não pode ser desfeita.',
+  'This and following (incl. completed)': 'Isto e o seguinte (incluindo o já concluído)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -511,4 +511,5 @@ export const ptPT = {
   'At least one worker or worker tag must be assigned': 'Pelo menos um trabalhador ou uma etiqueta de trabalhador deve ser atribuída.',
   'Assign to worker tags': 'Atribuir às etiquetas do trabalhador',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Isso excluirá permanentemente o quadro e seus {{count}} eventos. Essa ação não pode ser desfeita.',
+  'This and following (incl. completed)': 'Isto e o seguinte (incluindo o já concluído)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -511,4 +511,5 @@ export const roRO = {
   'At least one worker or worker tag must be assigned': 'Trebuie atribuit cel puțin un lucrător sau o etichetă de lucrător',
   'Assign to worker tags': 'Atribuiți etichetelor lucrătorilor',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Aceasta acțiune va șterge definitiv forumul și {{count}} evenimentele sale. Această acțiune nu poate fi anulată.',
+  'This and following (incl. completed)': 'Aceasta și următoarele (inclusiv finalizate)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -511,4 +511,5 @@ export const skSK = {
   'At least one worker or worker tag must be assigned': 'Musí byť priradený aspoň jeden pracovník alebo značka pracovníka',
   'Assign to worker tags': 'Priradiť k značkám pracovníka',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Týmto sa natrvalo vymaže nástenka a jej {{count}} udalostí. Túto akciu nie je možné vrátiť späť.',
+  'This and following (incl. completed)': 'Toto a nasledujúce (vrátane dokončených)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -511,4 +511,5 @@ export const slSL = {
   'At least one worker or worker tag must be assigned': 'Dodeljen mora biti vsaj en delavec ali oznaka delavca',
   'Assign to worker tags': 'Dodeli oznakam delavcev',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'S tem boste trajno izbrisali tablo in {{count}} dogodkov na njej. Tega ni mogoče razveljaviti.',
+  'This and following (incl. completed)': 'To in naslednje (vključno z dokončanim)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -511,4 +511,5 @@ export const svSE = {
   'At least one worker or worker tag must be assigned': 'Minst en arbetare eller arbetartagg måste tilldelas',
   'Assign to worker tags': 'Tilldela till arbetartaggar',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Detta kommer att permanent radera brädet och dess {{count}} händelser. Detta kan inte ångras.',
+  'This and following (incl. completed)': 'Detta och följande (inkl. färdigställda)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -511,4 +511,5 @@ export const ukUA = {
   'At least one worker or worker tag must be assigned': 'Повинен бути призначений принаймні один працівник або тег працівника',
   'Assign to worker tags': 'Призначити тегам працівника',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Це назавжди видалить дошку та її {{count}} подій. Цю дію неможливо скасувати.',
+  'This and following (incl. completed)': 'Це та наступні (включно з завершеними)',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task-request.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task-request.model.ts
@@ -28,4 +28,4 @@ export interface CalendarTaskUpdateModel extends CalendarTaskCreateModel {
 }
 
 export type RepeatEditScope = 'this' | 'thisAndFollowing' | 'all';
-export type RepeatDeleteScope = 'this' | 'thisAndFollowing' | 'all';
+export type RepeatDeleteScope = 'this' | 'thisAndFollowing' | 'thisAndFollowingIncludingCompleted' | 'all';

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/repeat-scope-modal/repeat-scope-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/repeat-scope-modal/repeat-scope-modal.component.html
@@ -6,6 +6,7 @@
   <mat-radio-group [(ngModel)]="scope" class="scope-group">
     <mat-radio-button value="this">{{ 'Only this' | translate }}</mat-radio-button>
     <mat-radio-button value="thisAndFollowing">{{ 'This and following' | translate }}</mat-radio-button>
+    <mat-radio-button *ngIf="data.mode === 'delete'" value="thisAndFollowingIncludingCompleted">{{ 'This and following (incl. completed)' | translate }}</mat-radio-button>
     <mat-radio-button value="all">{{ 'All in series' | translate }}</mat-radio-button>
   </mat-radio-group>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/repeat-scope-modal/repeat-scope-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/repeat-scope-modal/repeat-scope-modal.component.ts
@@ -1,6 +1,6 @@
 import {Component, Inject} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
-import {RepeatEditScope} from '../../../../models/calendar';
+import {RepeatDeleteScope, RepeatEditScope} from '../../../../models/calendar';
 
 export interface RepeatScopeModalData {
   mode: 'edit' | 'delete' | 'move';
@@ -12,7 +12,7 @@ export interface RepeatScopeModalData {
   templateUrl: './repeat-scope-modal.component.html',
 })
 export class RepeatScopeModalComponent {
-  scope: RepeatEditScope = 'this';
+  scope: RepeatEditScope | RepeatDeleteScope = 'this';
 
   constructor(
     private dialogRef: MatDialogRef<RepeatScopeModalComponent>,


### PR DESCRIPTION
## Bug

User report (DK): deleting a **Daily** recurring task with **"Dette og følgende"** ("This and following") → Confirm → the tasks are **not deleted**.

## Root cause

`DeleteTask` scope `thisAndFollowing` trimmed the recurrence (`planning.RepeatUntil`) and deleted stale exceptions, but **never retracted the already-DEPLOYED `Compliance` rows / SDK cases** for dates ≥ the clicked date. The compliance-render loop in `GetTasksForWeek` is **not** bounded by `RepeatUntil`, so deployed occurrences kept rendering. Daily tasks are worst-hit (every visible day is eagerly deployed). Pre-existing — scope `this` (writes an `IsDeleted` exception) and `all` (`DeleteEntireSeries`) were unaffected.

## Changes

- **Fix**: `thisAndFollowing` now retracts deployed occurrences ≥ originalDate — `core.CaseDelete` + retract `PlanningCase`/`PlanningCaseSite` + soft-delete `Compliance`, mirroring `DeleteEntireSeries` / the reconciliation engine. Completed occurrences (`Status==100`) preserved as immutable history.
- **New option** "This and following (incl. completed)" (delete-only radio → scope `thisAndFollowingIncludingCompleted`): also removes completed occurrences, suppressing the tile via an `IsDeleted` `CalendarOccurrenceException` (the calendar renders completed history off `Status==100`, which `CaseDelete` doesn't change).
- SDK core only opened when there are deployed occurrences to retract (preserves the never-deployed fast-path with a null/absent core).
- Kind-safe `Deadline` comparison.

## Tests

`CalendarDeleteThisAndFollowingTests` (Testcontainers + real SDK core): pending-retract, completed-preserved (default), completed-removed (includingCompleted). Verified green together with the existing `CalendarOccurrenceExceptionTests` (14/14 locally, incl. the null-`coreHelper` delete paths).

## Note

Rebased cleanly on current `stable` (preserves #1007's `TaskIsExpired` work in `GetTasksForWeek` — disjoint from this `DeleteTask` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)