### PR TITLE
refactor(timereg): stop writing per-site GpsEnabled (now global-only)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
@@ -394,7 +394,6 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
         {
             deviceUserModel.UserFirstName = deviceUserModel.UserFirstName.Trim();
             deviceUserModel.UserLastName = deviceUserModel.UserLastName.Trim();
-            var globalSettings = await timePlanningDbContext.PluginConfigurationValues.FirstOrDefaultAsync(x => x.Name == "TimePlanningBaseSettings:GpsEnabled");
             try
             {
                 if (deviceUserModel.SiteMicrotingUid == 0)
@@ -621,7 +620,6 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                             {
                                 assignment.Resigned = deviceUserModel.Resigned;
                                 assignment.ResignedAtDate = deviceUserModel.ResignedAtDate;
-                                assignment.GpsEnabled = globalSettings is { Value: "1" };
                                 await assignment.Update(timePlanningDbContext).ConfigureAwait(false);
                             }
                         }
@@ -861,8 +859,7 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                                         FourthShiftActive = deviceUserModel.FourthShiftActive ?? false,
                                         FifthShiftActive = deviceUserModel.FifthShiftActive ?? false,
                                         IsManager = deviceUserModel.IsManager ?? false,
-                                        UseOneMinuteIntervals = true,
-                                        GpsEnabled = globalSettings is { Value: "1" }
+                                        UseOneMinuteIntervals = true
                                         // ManagingTagIds = deviceUserModel.ManagingTagIds ?? [] // TODO: Handle ManagingTagIds separately
                                     };
                                     await assignmentSite.Create(timePlanningDbContext).ConfigureAwait(false);


### PR DESCRIPTION
Part of making GPS/Snapshot **global-only** settings (served from TimePlanning global settings). This removes the now-pointless per-site `GpsEnabled` writes in the device-user flow:
- `UpdateDeviceUser` existing-row update: dropped `assignment.GpsEnabled = …`
- `UpdateDeviceUser` new-`AssignedSite` initializer: dropped `GpsEnabled = …` (kept `UseOneMinuteIntervals = true`)
- removed the now-unused global GPS-setting fetch

`SnapshotEnabled` was never written here. `UseOneMinuteIntervals` (a legitimate per-site flag) is unchanged.

⚠️ **Merge order:** land the TimePlanning serve-path PR (serve gps/snapshot from global) **first**, then this — otherwise newly-created sites' gps would briefly read a stale per-site value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)