### PR TITLE
feat: always show worker-select modal on calendar completion, listing all property workers

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarCompleteInPlaceReportSyncTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarCompleteInPlaceReportSyncTests.cs
@@ -269,4 +269,278 @@ public class CalendarCompleteInPlaceReportSyncTests : TestBaseSetup
                 "PlanningCaseSite DoneByUserId must be the completing site");
         });
     }
+
+    /// <summary>
+    /// The calendar's worker picker lists every active PropertyWorker of the
+    /// event's property, and ToggleComplete attributes the completion to the
+    /// picked site on the in-place path: the SDK case is re-homed
+    /// (Case.SiteId) and the report rows (PlanningCase/PlanningCaseSite
+    /// DoneByUserId/Name) carry the picked site — matching what the
+    /// compliance-form route does via UpdateCase.
+    /// </summary>
+    [Test]
+    public async Task ToggleComplete_InPlace_PickedPropertyWorker_AttributesToPickedSite()
+    {
+        var s = await SeedInPlaceScenario("picked-worker", 4444);
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        // A second property worker — NOT the site the case was deployed to.
+        var pickedSite = new Site
+        {
+            Name = "picked-property-worker-site",
+            MicrotingUid = 4445,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(pickedSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        await BackendConfigurationPnDbContext!.PropertyWorkers.AddAsync(new PropertyWorker
+        {
+            PropertyId = s.PropertyId, WorkerId = pickedSite.Id,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        });
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var result = await s.Service.ToggleComplete(s.ArpId, true, s.ComplianceId, null, pickedSite.Id);
+
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model!.RequiresForm, Is.False, "no-mandatory template must complete in place");
+
+        var reloadedSdkCase = await MicrotingDbContext.Cases
+            .AsNoTracking().FirstAsync(x => x.Id == s.SdkCaseId);
+        var reloadedCase = await ItemsPlanningPnDbContext!.PlanningCases
+            .AsNoTracking().FirstAsync(x => x.Id == s.PlanningCaseId);
+        var reloadedSite = await ItemsPlanningPnDbContext.PlanningCaseSites
+            .AsNoTracking().FirstAsync(x => x.Id == s.PlanningCaseSiteId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(reloadedSdkCase.Status, Is.EqualTo(100));
+            Assert.That(reloadedSdkCase.SiteId, Is.EqualTo(pickedSite.Id),
+                "SDK case must be re-homed to the picked worker (parity with the form route)");
+            Assert.That(reloadedCase.DoneByUserId, Is.EqualTo(pickedSite.Id),
+                "PlanningCase DoneByUserId must be the picked site");
+            Assert.That(reloadedCase.DoneByUserName, Is.EqualTo(pickedSite.Name),
+                "PlanningCase DoneByUserName must be the picked site's name");
+            Assert.That(reloadedSite.DoneByUserId, Is.EqualTo(pickedSite.Id),
+                "PlanningCaseSite DoneByUserId must be the picked site");
+            Assert.That(reloadedSite.DoneByUserName, Is.EqualTo(pickedSite.Name),
+                "PlanningCaseSite DoneByUserName must be the picked site's name");
+        });
+    }
+
+    /// <summary>
+    /// A workerId that is NOT an active PropertyWorker of the event's property
+    /// is rejected up front — before any compliance/case mutation — so a
+    /// crafted request can never attribute a completion to an unrelated site.
+    /// </summary>
+    [Test]
+    public async Task ToggleComplete_PickedWorkerNotPropertyWorker_IsRejectedWithoutMutation()
+    {
+        var s = await SeedInPlaceScenario("rogue-worker", 4446);
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        // A live SDK site that is NOT a PropertyWorker of the property.
+        var rogueSite = new Site
+        {
+            Name = "rogue-unrelated-site",
+            MicrotingUid = 4447,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(rogueSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var result = await s.Service.ToggleComplete(s.ArpId, true, s.ComplianceId, null, rogueSite.Id);
+
+        Assert.That(result.Success, Is.False, "non-property-worker pick must be rejected");
+
+        var reloadedSdkCase = await MicrotingDbContext.Cases
+            .AsNoTracking().FirstAsync(x => x.Id == s.SdkCaseId);
+        var reloadedCase = await ItemsPlanningPnDbContext!.PlanningCases
+            .AsNoTracking().FirstAsync(x => x.Id == s.PlanningCaseId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(reloadedSdkCase.Status, Is.EqualTo(66), "SDK case must be untouched");
+            Assert.That(reloadedSdkCase.SiteId, Is.EqualTo(s.DeployedSiteId), "SDK case site must be untouched");
+            Assert.That(reloadedCase.Status, Is.EqualTo(66), "PlanningCase must be untouched");
+        });
+    }
+
+    private sealed class InPlaceScenario
+    {
+        public BackendConfigurationCalendarService Service = null!;
+        public int ArpId;
+        public int ComplianceId;
+        public int SdkCaseId;
+        public int DeployedSiteId;
+        public int PropertyId;
+        public int PlanningCaseId;
+        public int PlanningCaseSiteId;
+    }
+
+    /// <summary>
+    /// Seeds the same fixture as
+    /// <see cref="ToggleComplete_InPlace_PastEvent_SyncsPlanningCaseDoneAt"/>:
+    /// a no-mandatory-fields template, a deployed SDK case, and a live past
+    /// compliance occurrence wired to an ARP with a CalendarConfiguration —
+    /// so ToggleComplete takes the in-place branch. Distinct names/uids per
+    /// call keep scenarios independent within the fixture.
+    /// </summary>
+    private async Task<InPlaceScenario> SeedInPlaceScenario(string tag, int microtingUid)
+    {
+        var core = await GetCore();
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        var template = await core.TemplateFromXml(CommentTemplateXml);
+        var templateId = await core.TemplateCreate(template);
+
+        var sdkSite = new Site
+        {
+            Name = $"deployed-site-{tag}",
+            MicrotingUid = microtingUid,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(sdkSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var sdkCase = new Microting.eForm.Infrastructure.Data.Entities.Case
+        {
+            SiteId = sdkSite.Id,
+            CheckListId = templateId,
+            Status = 66,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Cases.AddAsync(sdkCase);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var pastDate = DateTime.SpecifyKind(DateTime.UtcNow.Date.AddDays(-30), DateTimeKind.Utc);
+
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"InPlace-{tag}-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id, EformId = templateId,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Week, StartDate = pastDate,
+            RelatedEFormId = templateId, WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
+            ItemPlanningId = planning.Id, StartDate = pastDate, Status = true,
+            RepeatType = 1, RepeatEvery = 1, DayOfWeek = 1,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planningSite = new Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities.PlanningSite
+        {
+            AreaRulePlanningsId = arp.Id, SiteId = sdkSite.Id,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.PlanningSites.AddAsync(planningSite);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // The deployed site is itself a PropertyWorker (the normal shape —
+        // assignees are always property workers).
+        await BackendConfigurationPnDbContext.PropertyWorkers.AddAsync(new PropertyWorker
+        {
+            PropertyId = property.Id, WorkerId = sdkSite.Id,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        });
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var compliance = new Compliance
+        {
+            PlanningId = planning.Id, PropertyId = property.Id, AreaId = area.Id,
+            Deadline = pastDate, StartDate = pastDate.AddDays(-7),
+            MicrotingSdkCaseId = sdkCase.Id, MicrotingSdkeFormId = templateId,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await BackendConfigurationPnDbContext.Compliances.AddAsync(compliance);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planningCase = new PlanningCase
+        {
+            PlanningId = planning.Id, Status = 66,
+            MicrotingSdkCaseId = sdkCase.Id, MicrotingSdkeFormId = templateId,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext.PlanningCases.AddAsync(planningCase);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var planningCaseSite = new PlanningCaseSite
+        {
+            PlanningCaseId = planningCase.Id, PlanningId = planning.Id, Status = 66,
+            MicrotingSdkCaseId = sdkCase.Id, MicrotingSdkSiteId = (int)sdkSite.MicrotingUid!,
+            MicrotingCheckListSitId = templateId,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext.PlanningCaseSites.AddAsync(planningCaseSite);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        userService.GetCurrentUserLanguage().Returns(Task.FromResult(language));
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+        var taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        taskWizardService.DeleteTask(Arg.Any<int>()).Returns(Task.FromResult(new OperationResult(true)));
+
+        var service = new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(), userService,
+            BackendConfigurationPnDbContext, coreHelper, Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext, taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
+            NullLogger<BackendConfigurationCalendarService>.Instance);
+
+        return new InPlaceScenario
+        {
+            Service = service,
+            ArpId = arp.Id,
+            ComplianceId = compliance.Id,
+            SdkCaseId = sdkCase.Id,
+            DeployedSiteId = sdkSite.Id,
+            PropertyId = property.Id,
+            PlanningCaseId = planningCase.Id,
+            PlanningCaseSiteId = planningCaseSite.Id
+        };
+    }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarToggleCompleteModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarToggleCompleteModel.cs
@@ -19,9 +19,12 @@ public class CalendarToggleCompleteModel
     // task.taskDate from the calendar response.
     public string? OccurrenceDate { get; set; }
 
-    // Worker to attribute the completion to. When the task has multiple
-    // assignees (or a single assignee who isn't the current user), the
-    // frontend shows a "Vælg medarbejder" picker and sends the selected
-    // site-user id here. Null means "use the caller's own identity".
+    // SDK site id to attribute the completion to. The calendar frontend
+    // ALWAYS shows the "Vælg medarbejder" picker when completing — listing
+    // every worker assigned to the event's property
+    // (GetLinkedSites(propertyId, compliance: false)) — and sends the
+    // picked id here. Null (gRPC / legacy callers) falls back to the
+    // historical defaults: the task's first PlanningSite when the case is
+    // materialised on demand, or the case's deployed site otherwise.
     public int? WorkerId { get; set; }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -3085,6 +3085,29 @@ public class BackendConfigurationCalendarService(
                     localizationService.GetString("AreaRulePlanningNotFound"));
             }
 
+            // The calendar's worker picker lists GetLinkedSites(propertyId, false):
+            // exactly the active PropertyWorkers of the event's property. Accept
+            // only that set — and reject anything else up front, so a stray id
+            // can never attribute a completion to an unrelated site on either the
+            // on-demand-materialise path or the pre-existing-compliance path
+            // below. (This also matches EventDeployService's leak guard, which
+            // refuses to deploy an on-demand case to a non-property-worker site —
+            // #932/#1377.)
+            if (workerId.HasValue)
+            {
+                var workerAllowed = await backendConfigurationPnDbContext.PropertyWorkers
+                    .AsNoTracking()
+                    .AnyAsync(pw =>
+                        pw.PropertyId == arp.PropertyId
+                        && pw.WorkerId == workerId.Value
+                        && pw.WorkflowState != Constants.WorkflowStates.Removed);
+                if (!workerAllowed)
+                {
+                    return new OperationDataResult<CalendarToggleCompleteResult>(false,
+                        localizationService.GetString("SelectedWorkerNotAssignedToTask"));
+                }
+            }
+
             // Look up the SPECIFIC compliance row the user clicked. Previously
             // this queried by PlanningId and took "latest by Deadline" — that
             // silently picked the wrong week when a planning had multiple
@@ -3120,32 +3143,15 @@ public class BackendConfigurationCalendarService(
 
                 // Resolve the SDK site to materialise the on-demand case for.
                 //
-                // When the caller picks a worker, allow ANY active worker of the
-                // event's PROPERTY — not just the task's assigned PlanningSites.
-                // The calendar / task-tracker worker pickers now list every
-                // property worker (same source as GetLinkedSites:
-                // PropertyWorkers WHERE PropertyId = <property> AND not removed),
-                // so a user can complete a future/on-demand occurrence on behalf
-                // of any property worker. We still reject an arbitrary site id
-                // that is NOT a property worker, so a stray id can never leak a
-                // case to an unrelated worker.
+                // When the caller picks a worker (already validated against the
+                // property's workers above), the case is materialised for that
+                // site so the completion is attributed to the picked worker.
                 //
                 // When no worker is picked, keep the historical default: pick the
                 // first non-removed PlanningSite assigned to the task.
                 int targetSiteId;
                 if (workerId.HasValue)
                 {
-                    var isActivePropertyWorker = await backendConfigurationPnDbContext.PropertyWorkers
-                        .AsNoTracking()
-                        .AnyAsync(pw =>
-                            pw.PropertyId == arp.PropertyId
-                            && pw.WorkerId == workerId.Value
-                            && pw.WorkflowState != Constants.WorkflowStates.Removed);
-                    if (!isActivePropertyWorker)
-                    {
-                        return new OperationDataResult<CalendarToggleCompleteResult>(false,
-                            localizationService.GetString("SelectedWorkerNotAssignedToTask"));
-                    }
                     targetSiteId = workerId.Value;
                 }
                 else
@@ -3256,7 +3262,13 @@ public class BackendConfigurationCalendarService(
                         TemplateId = sdkCase.CheckListId,
                         PropertyId = compliance.PropertyId,
                         ComplianceId = compliance.Id,
-                        WorkerId = sdkCase.SiteId,
+                        // Route the compliance form to the worker the user picked
+                        // in the calendar's select-worker modal (any property
+                        // worker), falling back to the case's deployed site when
+                        // no explicit pick was made (gRPC / legacy callers).
+                        // Mirrors the task-tracker, which routes the selected
+                        // worker even for pre-existing cases.
+                        WorkerId = workerId ?? sdkCase.SiteId,
                         // ISO 8601 with millisecond precision to match the format
                         // the task-tracker uses (`task.deadlineTask.toISOString()`
                         // at task-tracker-table.component.ts:187). The
@@ -3289,6 +3301,15 @@ public class BackendConfigurationCalendarService(
             sdkCase.WorkflowState = Constants.WorkflowStates.Created;
             sdkCase.DoneAt = eventStart;
             sdkCase.DoneAtUserModifiable = eventStart;
+            // Re-home the case to the picked worker so SDK-level attribution
+            // matches the form route (BackendConfigurationCompliancesService.
+            // UpdateCase sets foundCase.SiteId = model.SiteId) — otherwise the
+            // same user gesture would attribute differently depending on
+            // whether the template happens to have mandatory fields.
+            if (workerId.HasValue)
+            {
+                sdkCase.SiteId = workerId.Value;
+            }
             await sdkCase.Update(sdkDbContext).ConfigureAwait(false);
 
             // Mirror the gRPC completion sync (EventsGrpcService:1668-1705) so the
@@ -3298,9 +3319,14 @@ public class BackendConfigurationCalendarService(
             // invisible in reports. We write eventStart (the scheduled, possibly
             // PAST, moment — equal to sdkCase.DoneAt) so the row lands in the
             // period the event was placed in, not "now".
+            // Attribute the completion to the worker picked in the calendar's
+            // select-worker modal when one was picked (validated above as a
+            // property worker); otherwise keep the historical attribution to
+            // the case's deployed site.
+            var doneBySiteId = workerId ?? sdkCase.SiteId ?? 0;
             var siteName = (await sdkDbContext.Sites
                 .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed || x.WorkflowState == null)
-                .FirstOrDefaultAsync(x => x.Id == sdkCase.SiteId)
+                .FirstOrDefaultAsync(x => x.Id == doneBySiteId)
                 .ConfigureAwait(false))?.Name ?? string.Empty;
 
             var planningCaseSite = await itemsPlanningPnDbContext.PlanningCaseSites
@@ -3313,7 +3339,7 @@ public class BackendConfigurationCalendarService(
                 planningCaseSite.Status = 100;
                 planningCaseSite.MicrotingSdkCaseId = sdkCase.Id;
                 planningCaseSite.MicrotingSdkCaseDoneAt = eventStart;
-                planningCaseSite.DoneByUserId = sdkCase.SiteId ?? 0;
+                planningCaseSite.DoneByUserId = doneBySiteId;
                 planningCaseSite.DoneByUserName = siteName;
                 await planningCaseSite.Update(itemsPlanningPnDbContext).ConfigureAwait(false);
 
@@ -3326,7 +3352,7 @@ public class BackendConfigurationCalendarService(
                     planningCase.Status = 100;
                     planningCase.MicrotingSdkCaseDoneAt = eventStart;
                     planningCase.MicrotingSdkCaseId = sdkCase.Id;
-                    planningCase.DoneByUserId = sdkCase.SiteId ?? 0;
+                    planningCase.DoneByUserId = doneBySiteId;
                     planningCase.DoneByUserName = siteName;
                     planningCase.WorkflowState = Constants.WorkflowStates.Processed;
                     await planningCase.Update(itemsPlanningPnDbContext).ConfigureAwait(false);

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/p/calendar-complete.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/p/calendar-complete.spec.ts
@@ -127,14 +127,31 @@ async function closeComplianceDialog(page: import('@playwright/test').Page): Pro
     .catch(() => undefined);
 }
 
-// Dismiss the worker-selection modal that appears when the task's assigned
-// worker is not the current user. With a single worker the modal opens
-// pre-selected — clicking the primary button confirms immediately.
+// Confirm the worker-selection modal that ALWAYS appears when completing an
+// event. It lists every worker assigned to the event's property; with exactly
+// one worker (this seed) it opens preselected, otherwise nothing is selected
+// and the confirm button is disabled — in that case explicitly pick the
+// seeded property worker (falling back to the first option) before confirming.
 async function handleWorkerSelectModal(page: import('@playwright/test').Page): Promise<void> {
   const workerModal = page.locator('app-calendar-select-worker-modal');
   const appeared = await workerModal.waitFor({ state: 'visible', timeout: 3000 }).then(() => true).catch(() => false);
   if (!appeared) return;
-  await page.locator('app-calendar-select-worker-modal button.btn-primary').click();
+  const confirmBtn = page.locator('app-calendar-select-worker-modal button.btn-primary');
+  if (await confirmBtn.isDisabled()) {
+    // The mtx-select dropdown appends to body, so the options live outside
+    // the modal element.
+    await workerModal.locator('mtx-select').click();
+    const seededOption = page
+      .locator('.ng-dropdown-panel .ng-option')
+      .filter({ hasText: `${worker.name} ${worker.surname}` })
+      .first();
+    if ((await seededOption.count()) > 0) {
+      await seededOption.click();
+    } else {
+      await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    }
+  }
+  await confirmBtn.click();
   await workerModal.waitFor({ state: 'detached', timeout: 5000 }).catch(() => undefined);
 }
 

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/p/calendar-complete.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/p/calendar-complete.spec.ts
@@ -134,8 +134,9 @@ async function closeComplianceDialog(page: import('@playwright/test').Page): Pro
 // seeded property worker (falling back to the first option) before confirming.
 async function handleWorkerSelectModal(page: import('@playwright/test').Page): Promise<void> {
   const workerModal = page.locator('app-calendar-select-worker-modal');
-  const appeared = await workerModal.waitFor({ state: 'visible', timeout: 3000 }).then(() => true).catch(() => false);
-  if (!appeared) return;
+  // The modal is part of the completion contract now — fail loudly if it
+  // does not appear instead of silently letting the PUT fire without it.
+  await workerModal.waitFor({ state: 'visible', timeout: 10000 });
   const confirmBtn = page.locator('app-calendar-select-worker-modal button.btn-primary');
   if (await confirmBtn.isDisabled()) {
     // The mtx-select dropdown appends to body, so the options live outside

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-event-card-layout.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-event-card-layout.spec.ts
@@ -46,8 +46,9 @@ let seeded = false;
 // seeded property worker (falling back to the first option) before confirming.
 async function handleWorkerSelectModal(page: import('@playwright/test').Page): Promise<void> {
   const workerModal = page.locator('app-calendar-select-worker-modal');
-  const appeared = await workerModal.waitFor({ state: 'visible', timeout: 3000 }).then(() => true).catch(() => false);
-  if (!appeared) return;
+  // The modal is part of the completion contract now — fail loudly if it
+  // does not appear instead of silently letting the PUT fire without it.
+  await workerModal.waitFor({ state: 'visible', timeout: 10000 });
   const confirmBtn = page.locator('app-calendar-select-worker-modal button.btn-primary');
   if (await confirmBtn.isDisabled()) {
     // The mtx-select dropdown appends to body, so the options live outside

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-event-card-layout.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-event-card-layout.spec.ts
@@ -39,14 +39,31 @@ const worker: PropertyWorker = {
 
 let seeded = false;
 
-// Dismiss the worker-selection modal that appears when the task's assigned
-// worker is not the current user. With a single worker the modal opens
-// pre-selected — clicking the primary button confirms immediately.
+// Confirm the worker-selection modal that ALWAYS appears when completing an
+// event. It lists every worker assigned to the event's property; with exactly
+// one worker (this seed) it opens preselected, otherwise nothing is selected
+// and the confirm button is disabled — in that case explicitly pick the
+// seeded property worker (falling back to the first option) before confirming.
 async function handleWorkerSelectModal(page: import('@playwright/test').Page): Promise<void> {
   const workerModal = page.locator('app-calendar-select-worker-modal');
   const appeared = await workerModal.waitFor({ state: 'visible', timeout: 3000 }).then(() => true).catch(() => false);
   if (!appeared) return;
-  await page.locator('app-calendar-select-worker-modal button.btn-primary').click();
+  const confirmBtn = page.locator('app-calendar-select-worker-modal button.btn-primary');
+  if (await confirmBtn.isDisabled()) {
+    // The mtx-select dropdown appends to body, so the options live outside
+    // the modal element.
+    await workerModal.locator('mtx-select').click();
+    const seededOption = page
+      .locator('.ng-dropdown-panel .ng-option')
+      .filter({ hasText: `${worker.name} ${worker.surname}` })
+      .first();
+    if ((await seededOption.count()) > 0) {
+      await seededOption.click();
+    } else {
+      await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    }
+  }
+  await confirmBtn.click();
   await workerModal.waitFor({ state: 'detached', timeout: 5000 }).catch(() => undefined);
 }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -5,7 +5,7 @@ import {Router} from '@angular/router';
 import {BehaviorSubject, firstValueFrom, Observable, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {Store} from '@ngrx/store';
-import {selectCurrentUserFullName, selectCurrentUserIsAdmin} from 'src/app/state/auth/auth.selector';
+import {selectCurrentUserIsAdmin} from 'src/app/state/auth/auth.selector';
 import {
   BackendConfigurationPnCalendarService,
   BackendConfigurationPnPropertiesService,
@@ -81,7 +81,6 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
   activeTagNames: string[] = [];
   sidebarOpen = true;
   isAdmin = false;
-  private currentUserFullName = '';
 
   constructor(
     private overlay: Overlay,
@@ -99,8 +98,6 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
   ) {
     this.store.select(selectCurrentUserIsAdmin).pipe(takeUntil(this.destroy$))
       .subscribe(isAdmin => this.isAdmin = isAdmin);
-    this.store.select(selectCurrentUserFullName).pipe(takeUntil(this.destroy$))
-      .subscribe(name => (this.currentUserFullName = name ?? ''));
   }
 
   ngOnInit(): void {
@@ -620,43 +617,39 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
   }
 
   async onToggleCompleteRequested(task: CalendarTaskLayoutModel) {
-    const needsWorkerSelect =
-      task.assigneeIds.length > 1 ||
-      (task.assigneeIds.length === 1 && task.workerNames[0] !== this.currentUserFullName);
+    // ALWAYS ask who completed the event — even when the task has a single
+    // assignee or none at all — so the completion is explicitly attributed.
+    // The list is ALL workers assigned to the event's PROPERTY (not just the
+    // task-assigned subset), sorted alphabetically by name.
+    // getLinkedSites(propertyId, false) returns exactly the property's
+    // non-removed PropertyWorkers as CommonDictionaryModel ({id, name,
+    // languageId}) — the shape the modal's `sites` input expects. compliance
+    // must be FALSE here: true appends the calling user's own SDK site, which
+    // EventDeployService's leak guard (#932/#1377) rejects on the on-demand
+    // completion path when that user is not a property worker. Locale-aware
+    // 'da' sort so Danish characters (æ/ø/å) order correctly; copy the array
+    // first (no in-place mutation of the service response).
+    const linked = await firstValueFrom(
+      this.propertiesService.getLinkedSites(task.propertyId, false),
+    );
+    if (!linked?.success || !linked.model) return;
+    const sites: CommonDictionaryModel[] =
+      [...linked.model].sort((a, b) => a.name.localeCompare(b.name, 'da'));
 
-    let selectedWorkerId: number | undefined;
-
-    if (needsWorkerSelect) {
-      // List ALL workers assigned to the event's PROPERTY (not just the
-      // task-assigned subset), sorted alphabetically by name. Mirrors the
-      // task-tracker change (openSelectWorkerModal). getLinkedSites(propertyId,
-      // true) returns the property's non-removed PropertyWorkers as
-      // CommonDictionaryModel ({id, name, languageId}) — the exact shape the
-      // modal's `sites` input expects. Locale-aware 'da' sort so Danish
-      // characters (æ/ø/å) order correctly; copy the array first (no in-place
-      // mutation of the service response).
-      const linked = await firstValueFrom(
-        this.propertiesService.getLinkedSites(task.propertyId, true),
-      );
-      if (!linked?.success || !linked.model) return;
-      const sites: CommonDictionaryModel[] =
-        [...linked.model].sort((a, b) => a.name.localeCompare(b.name, 'da'));
-
-      const ref = this.dialog.open(CalendarSelectWorkerModalComponent, {
-        minWidth: '400px',
-        autoFocus: false,
-      });
-      const instance = ref.componentInstance;
-      instance.sites = sites;
-      if (sites.length === 1) {
-        instance.selectedSite = sites[0];
-      }
-
-      const selected: CommonDictionaryModel | null = await firstValueFrom(ref.afterClosed());
-      if (!selected) return;
-
-      selectedWorkerId = selected.id;
+    const ref = this.dialog.open(CalendarSelectWorkerModalComponent, {
+      minWidth: '400px',
+      autoFocus: false,
+    });
+    const instance = ref.componentInstance;
+    instance.sites = sites;
+    if (sites.length === 1) {
+      instance.selectedSite = sites[0];
     }
+
+    const selected: CommonDictionaryModel | null = await firstValueFrom(ref.afterClosed());
+    if (!selected) return;
+
+    const selectedWorkerId = selected.id;
 
     this.calendarService
       .toggleComplete(task.id, !task.completed, task.complianceId, task.taskDate, selectedWorkerId)


### PR DESCRIPTION
## What

Completing an event from the calendar now **always** opens the worker-select modal ("Vælg medarbejder") — even for single-assignee, self-assigned, or unassigned events — and the modal lists **all workers assigned to the event's property**, not just the event's own assignees.

## Why

Completion should always be explicitly attributed to a worker, and any property worker may be the one who actually did the work — not just the task-assigned subset.

## How

**Frontend** (`calendar-container.component.ts`)
- Removed the `needsWorkerSelect` gate; the modal opens on every completion.
- Picker source is `getLinkedSites(propertyId, compliance: false)` — exactly the property's active workers. `compliance: true` appends the calling user's own SDK site, which `EventDeployService`'s leak guard (#932/#1377) rejects on the on-demand completion path, so it is deliberately excluded (verified live: picking the own-site entry failed the deploy).

**Backend** (`ToggleComplete`)
- Worker validation hoisted above the compliance lookup — a picked id must be an active PropertyWorker of the event's property on **every** path (previously only the on-demand materialise branch validated).
- `RequiresForm` response routes the compliance form to the picked worker (`WorkerId = workerId ?? sdkCase.SiteId`), mirroring the task-tracker.
- In-place completion re-homes `sdkCase.SiteId` to the picked worker and attributes `PlanningCase`/`PlanningCaseSite` `DoneByUserId/Name` to the picked site, so the in-place and form routes attribute identically.
- `workerId = null` (gRPC / legacy callers) keeps the historical defaults byte-for-byte: first PlanningSite on on-demand materialise, case's deployed site otherwise.

**E2E** — `handleWorkerSelectModal` in `calendar-complete.spec.ts` and `calendar-event-card-layout.spec.ts` updated: the modal is now unconditional; with a single property worker it opens preselected, otherwise the helper picks the seeded worker explicitly.

## Verification

Driven end-to-end in the dev stack (Playwright against localhost:4200, property with 2 workers, events assigned to only one):
- Modal appears on every completion; dropdown lists exactly the property's 2 workers.
- Completing as the non-assigned worker succeeds; DB shows `Cases.SiteId`, `PlanningCaseSites.DoneByUserId/Name` = picked worker, `DoneAt` = scheduled event start.
- Cancel closes without side effects (no Compliance row created).
- Completed events' indicator stays inert (no un-complete round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)