### PR TITLE
feat(property-workers): pay rule set selector + one-way 1-minute intervals

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationAssignmentWorkerServiceHelperTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationAssignmentWorkerServiceHelperTest.cs
@@ -137,8 +137,86 @@ public class BackendConfigurationAssignmentWorkerServiceHelperTest : TestBaseSet
         Assert.That(timeregistrationSiteAssignments.Count, Is.EqualTo(31));
         Assert.That(timeregistrationSiteAssignments[30].SiteId, Is.EqualTo(sites[2].MicrotingUid));
 
-        // Newly-created AssignedSite must default UseOneMinuteIntervals to true (CreateDeviceUser path)
+        // Newly-created AssignedSite no longer hardcodes UseOneMinuteIntervals to true; it defaults to
+        // false when the DeviceUserModel does not specify it (CreateDeviceUser path)
+        Assert.That(timeregistrationSiteAssignments[30].UseOneMinuteIntervals, Is.False);
+    }
+
+    // Should test the CreateDeviceUser method with TimeRegistrationEnabled, UseOneMinuteIntervals and
+    // PayRuleSetId set, verifying both new fields pass through onto the created AssignedSite
+    [Test]
+    public async Task
+        BackendConfigurationAssignmentWorkerServiceHelper_CreateDeviceUser_TimeRegistrationEnabled_UseOneMinuteIntervalsAndPayRuleSetId_ReturnsSuccess()
+    {
+        // Arrange
+        var core = await GetCore();
+
+        // PayRuleSetId is a real FK on AssignedSite, so seed a PayRuleSet row
+        // to reference rather than an arbitrary int. Inserted via raw SQL
+        // (rather than the PayRuleSet EF entity) because the integration
+        // tests' checked-in SQL/420_eform-angular-time-planning-plugin.sql
+        // fixture predates PayRuleSet's HolidayPaidOff* columns — an EF
+        // Create() against the full entity 500s with "Unknown column
+        // 'HolidayPaidOffFixedSeconds'". The FK only cares that the row
+        // exists, so a minimal insert is sufficient here.
+        int payRuleSetId;
+        {
+            var connection = TimePlanningPnDbContext!.Database.GetDbConnection();
+            if (connection.State != System.Data.ConnectionState.Open)
+            {
+                await connection.OpenAsync();
+            }
+            await using var command = connection.CreateCommand();
+            command.CommandText =
+                "INSERT INTO PayRuleSets (Name, CreatedAt, WorkflowState, CreatedByUserId, UpdatedByUserId, Version) " +
+                "VALUES (@name, UTC_TIMESTAMP(), 'created', 1, 1, 1); SELECT LAST_INSERT_ID();";
+            var nameParam = command.CreateParameter();
+            nameParam.ParameterName = "@name";
+            nameParam.Value = Guid.NewGuid().ToString();
+            command.Parameters.Add(nameParam);
+            payRuleSetId = Convert.ToInt32(await command.ExecuteScalarAsync());
+        }
+
+        var deviceUserModel = new DeviceUserModel
+        {
+            CustomerNo = 0,
+            HasWorkOrdersAssigned = false,
+            IsBackendUser = false,
+            IsLocked = false,
+            LanguageCode = "da",
+            TimeRegistrationEnabled = true,
+            UseOneMinuteIntervals = true,
+            PayRuleSetId = payRuleSetId,
+            UserFirstName = Guid.NewGuid().ToString(),
+            UserLastName = Guid.NewGuid().ToString(),
+            WorkerEmail = $"{Guid.NewGuid()}@test.com"
+        };
+
+        // Act
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        var userManager = IdentityTestUtils.CreateRealUserManager(BaseDbContext!);
+
+        // Act
+        var result = await BackendConfigurationAssignmentWorkerServiceHelper.CreateDeviceUser(deviceUserModel, core, 1,
+            TimePlanningPnDbContext!, BaseDbContext!,
+        userService,
+        userManager);
+
+        // Assert
+        var sites = await MicrotingDbContext!.Sites.ToListAsync();
+        var timeregistrationSiteAssignments = await TimePlanningPnDbContext!.AssignedSites.ToListAsync();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(sites.Count, Is.EqualTo(3));
+
+        // Assert timeregistrationSiteAssignments
+        Assert.That(timeregistrationSiteAssignments.Count, Is.EqualTo(31));
+        Assert.That(timeregistrationSiteAssignments[30].SiteId, Is.EqualTo(sites[2].MicrotingUid));
+
+        // Newly-created AssignedSite must pass through UseOneMinuteIntervals and PayRuleSetId from the DeviceUserModel
         Assert.That(timeregistrationSiteAssignments[30].UseOneMinuteIntervals, Is.True);
+        Assert.That(timeregistrationSiteAssignments[30].PayRuleSetId, Is.EqualTo(payRuleSetId));
     }
 
     // Should test the UpdateDeviceUser method and return success
@@ -342,8 +420,9 @@ public class BackendConfigurationAssignmentWorkerServiceHelperTest : TestBaseSet
         Assert.That(timeregistrationSiteAssignments.Count, Is.EqualTo(31));
         Assert.That(timeregistrationSiteAssignments[30].SiteId, Is.EqualTo(sites[2].MicrotingUid));
 
-        // Newly-created AssignedSite must default UseOneMinuteIntervals to true (UpdateDeviceUser create path)
-        Assert.That(timeregistrationSiteAssignments[30].UseOneMinuteIntervals, Is.True);
+        // Newly-created AssignedSite no longer hardcodes UseOneMinuteIntervals to true; it defaults to
+        // false when the DeviceUserModel does not specify it (UpdateDeviceUser create path)
+        Assert.That(timeregistrationSiteAssignments[30].UseOneMinuteIntervals, Is.False);
     }
 
     // Should test the UpdateDeviceUser method with timeRegistration set to false and return success

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarThisAndFollowingMoveBackReproTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarThisAndFollowingMoveBackReproTests.cs
@@ -35,15 +35,24 @@ using NSubstitute;
 /// "1st Saturday" task's date to Friday (an earlier day in the SAME period)
 /// with scope "thisAndFollowing" lands the routine on Thursday and/or copies it.
 ///
-/// Scenario: monthly 1st Saturday, anchored Sat 6 Jun 2026. User edits the
-/// July occurrence (Sat 4 Jul) → Fri 3 Jul, scope=thisAndFollowing.
-/// July 2026: 1st Thu=Jul 2, 1st Fri=Jul 3, 1st Sat=Jul 4.
+/// Scenario: monthly 1st Saturday, anchored on the 1st Saturday of a future
+/// "anchor month". User edits the following month's occurrence (1st Saturday)
+/// → the preceding Friday, scope=thisAndFollowing.
+/// Target month: 1st Thu, 1st Fri, 1st Sat are three consecutive days.
 ///
-/// A UTC+2 browser serialises the picked "Fri 3 Jul" (local-midnight Date)
-/// as 2026-07-02T22:00:00Z (toISOString). On a UTC server the BE reads that
-/// StartDate as Thu 2 Jul (it does NOT apply the AssumeUniversal|AdjustToUniversal
-/// normalisation it uses for OriginalDate), so the series re-anchors to the
-/// 1st THURSDAY.
+/// A UTC+2 browser serialises the picked "Friday, local-midnight" Date as
+/// 22:00Z the day before (toISOString). On a UTC server the BE reads that
+/// StartDate as the preceding Thursday (it does NOT apply the
+/// AssumeUniversal|AdjustToUniversal normalisation it uses for OriginalDate),
+/// so the series re-anchors to the 1st THURSDAY.
+///
+/// All dates below are computed relative to DateTime.UtcNow (rather than
+/// hardcoded) so the tests stay valid regardless of which real-world date CI
+/// runs them on — UpdateTask legitimately rejects moving a task's StartDate
+/// into the past (see BackendConfigurationCalendarService.UpdateTask's
+/// "CannotCreateTaskInThePast" guard), so any hardcoded past-year date would
+/// eventually go stale and start failing for reasons unrelated to what these
+/// tests exercise.
 /// </summary>
 [Parallelizable(ParallelScope.Fixtures)]
 [TestFixture]
@@ -52,6 +61,34 @@ public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
     private static string IsoUtc(DateTime d) =>
         DateTime.SpecifyKind(d, DateTimeKind.Utc).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
     private static string Key(DateTime d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    // Mirrors BackendConfigurationCalendarService.NthWeekdayOfMonth exactly so
+    // the computed anchor/target dates can never drift from the production
+    // "Nth weekday of month" convention (targetDow: 0=Sun..6=Sat).
+    private static DateTime NthWeekdayOfMonth(int year, int month, int ordinal, int targetDow)
+    {
+        var firstOfMonth = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var dowOffset = (targetDow - (int)firstOfMonth.DayOfWeek + 7) % 7;
+        return firstOfMonth.AddDays(dowOffset + (ordinal - 1) * 7);
+    }
+
+    // Anchor everything 2 months ahead of "now" so the scenario's dates are
+    // always safely in the future (comfortably clear of the production
+    // "cannot move a task into the past" guard) no matter what day-of-week or
+    // day-of-month the test happens to run on.
+    private static readonly DateTime AnchorMonthStart =
+        new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc).AddMonths(2);
+    private static readonly DateTime SeriesAnchorSaturday =
+        NthWeekdayOfMonth(AnchorMonthStart.Year, AnchorMonthStart.Month, 1, (int)DayOfWeek.Saturday);
+    private static readonly DateTime TargetMonthStart = AnchorMonthStart.AddMonths(1);
+    private static readonly DateTime TargetSaturday =
+        NthWeekdayOfMonth(TargetMonthStart.Year, TargetMonthStart.Month, 1, (int)DayOfWeek.Saturday);
+    private static readonly DateTime TargetFriday = TargetSaturday.AddDays(-1);
+    private static readonly DateTime TargetThursday = TargetSaturday.AddDays(-2);
+    private static readonly DateTime TargetWeekMonday =
+        TargetSaturday.AddDays(-(((int)TargetSaturday.DayOfWeek + 6) % 7));
+    private static readonly string TargetMonthPrefix =
+        TargetSaturday.ToString("yyyy-MM", CultureInfo.InvariantCulture);
 
     // The fixture shares one MariaDb container across its test methods and
     // TestBaseSetup only disposes the contexts between tests (no DB reset), so
@@ -94,7 +131,7 @@ public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
 
     private sealed record Seed(int PropertyId, int ArpId, int SiteId, int PlanningId, int AreaId);
 
-    // Seeds a monthly 1st-Saturday series anchored on Sat 6 Jun 2026.
+    // Seeds a monthly 1st-Saturday series anchored on SeriesAnchorSaturday.
     private async Task<Seed> SeedFirstSaturdaySeries()
     {
         var language = await MicrotingDbContext!.Languages.FirstAsync();
@@ -121,7 +158,7 @@ public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
         { AreaRuleId = areaRule.Id, LanguageId = language.Id, Name = "Tank 4", WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1 });
         await BackendConfigurationPnDbContext.SaveChangesAsync();
 
-        var startDate = new DateTime(2026, 6, 6, 0, 0, 0, DateTimeKind.Utc); // 1st Saturday of June 2026
+        var startDate = SeriesAnchorSaturday; // 1st Saturday of the (future) anchor month
         var planning = new Planning
         {
             Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Month, StartDate = startDate,
@@ -149,7 +186,7 @@ public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
     private CalendarTaskUpdateRequestModel BuildEdit(Seed s, DateTime startDateUtc, string scope = "thisAndFollowing") => new()
     {
         Id = s.ArpId, Scope = scope,
-        OriginalDate = "2026-07-04T00:00:00Z", // clicked occurrence = 1st Saturday of July
+        OriginalDate = IsoUtc(TargetSaturday), // clicked occurrence = 1st Saturday of the target month
         StartDate = startDateUtc,
         StartHour = 9.0, Duration = 1.0, Status = 1,
         RepeatType = 3, RepeatEvery = 1, RepeatOrdinalWeek = 1, DayOfMonth = 0,
@@ -159,7 +196,7 @@ public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
 
     private async Task<List<string>> JulyWeekTiles(BackendConfigurationCalendarService svc, int propertyId)
     {
-        var weekStart = new DateTime(2026, 6, 29, 0, 0, 0, DateTimeKind.Utc); // Mon containing Jul 2-4
+        var weekStart = TargetWeekMonday; // Mon containing the target Thu/Fri/Sat
         var res = await svc.GetTasksForWeek(new CalendarTaskRequestModel
         {
             PropertyId = propertyId, WeekStart = IsoUtc(weekStart),
@@ -178,20 +215,20 @@ public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
         var s = await SeedFirstSaturdaySeries();
         var svc = BuildService(core);
 
-        // 2026-07-02T22:00:00Z == Fri 3 Jul local-midnight in UTC+2 (Denmark).
-        await svc.UpdateTask(BuildEdit(s, new DateTime(2026, 7, 2, 22, 0, 0, DateTimeKind.Utc)));
+        // TargetFriday 00:00Z minus 2 hours == TargetFriday local-midnight in UTC+2 (Denmark).
+        await svc.UpdateTask(BuildEdit(s, TargetFriday.AddHours(-2)));
 
         var tiles = await JulyWeekTiles(svc, s.PropertyId);
-        TestContext.WriteLine("Rendered July-week tiles (tz-shifted): " + string.Join(", ", tiles));
+        TestContext.WriteLine("Rendered target-week tiles (tz-shifted): " + string.Join(", ", tiles));
 
-        // EXPECTED (correct) behaviour: a single tile on Friday 3 Jul.
-        Assert.That(tiles, Does.Contain(Key(new DateTime(2026, 7, 3))),
-            "routine should move to Friday 3 Jul");
-        Assert.That(tiles, Does.Not.Contain(Key(new DateTime(2026, 7, 2))),
-            "routine must NOT land on Thursday 2 Jul");
+        // EXPECTED (correct) behaviour: a single tile on the target Friday.
+        Assert.That(tiles, Does.Contain(Key(TargetFriday)),
+            "routine should move to the target Friday");
+        Assert.That(tiles, Does.Not.Contain(Key(TargetThursday)),
+            "routine must NOT land on the target Thursday");
     }
 
-    // ---- Control: tz-stable StartDate (Fri 3 Jul 00:00Z) → correct weekday ----
+    // ---- Control: tz-stable StartDate (target Friday 00:00Z) → correct weekday ----
     [Test]
     public async Task Control_ThisAndFollowing_TzStableFriday_LandsOnFriday()
     {
@@ -199,25 +236,25 @@ public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
         var s = await SeedFirstSaturdaySeries();
         var svc = BuildService(core);
 
-        await svc.UpdateTask(BuildEdit(s, new DateTime(2026, 7, 3, 0, 0, 0, DateTimeKind.Utc)));
+        await svc.UpdateTask(BuildEdit(s, TargetFriday));
 
         var tiles = await JulyWeekTiles(svc, s.PropertyId);
-        TestContext.WriteLine("Rendered July-week tiles (tz-stable): " + string.Join(", ", tiles));
+        TestContext.WriteLine("Rendered target-week tiles (tz-stable): " + string.Join(", ", tiles));
 
-        Assert.That(tiles, Does.Contain(Key(new DateTime(2026, 7, 3))), "Friday 3 Jul present");
-        Assert.That(tiles, Does.Not.Contain(Key(new DateTime(2026, 7, 2))), "no Thursday");
-        Assert.That(tiles.Count(t => t.StartsWith("2026-07")), Is.EqualTo(1),
-            "exactly one July tile (no copy)");
+        Assert.That(tiles, Does.Contain(Key(TargetFriday)), "target Friday present");
+        Assert.That(tiles, Does.Not.Contain(Key(TargetThursday)), "no Thursday");
+        Assert.That(tiles.Count(t => t.StartsWith(TargetMonthPrefix)), Is.EqualTo(1),
+            "exactly one target-month tile (no copy)");
     }
 
-    // ---- Repro 2: deployed (not completed) compliance at Jul 4 → duplicate? ----
+    // ---- Repro 2: deployed (not completed) compliance at the target Saturday → duplicate? ----
     [Test]
     public async Task Repro_ThisAndFollowing_WithDeployedComplianceAtJul4_NoDuplicate()
     {
         var core = await GetCore();
         var s = await SeedFirstSaturdaySeries();
 
-        // A deployed-but-not-completed occurrence already exists at Sat 4 Jul.
+        // A deployed-but-not-completed occurrence already exists at the target Saturday.
         var sdkCase = new Microting.eForm.Infrastructure.Data.Entities.Case
         { SiteId = s.SiteId, Status = 66, WorkflowState = Constants.WorkflowStates.Created };
         await MicrotingDbContext!.Cases.AddAsync(sdkCase);
@@ -225,20 +262,20 @@ public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
         await BackendConfigurationPnDbContext!.Compliances.AddAsync(new Compliance
         {
             PlanningId = s.PlanningId, PropertyId = s.PropertyId, AreaId = s.AreaId,
-            Deadline = new DateTime(2026, 7, 4, 0, 0, 0, DateTimeKind.Utc), StartDate = new DateTime(2026, 6, 4, 0, 0, 0, DateTimeKind.Utc),
+            Deadline = TargetSaturday, StartDate = TargetSaturday.AddMonths(-1),
             MicrotingSdkCaseId = sdkCase.Id, MicrotingSdkeFormId = 0, WorkflowState = Constants.WorkflowStates.Created
         });
         await BackendConfigurationPnDbContext.SaveChangesAsync();
 
         var svc = BuildService(core);
         // Use the tz-stable Friday to isolate the duplicate from the weekday bug.
-        await svc.UpdateTask(BuildEdit(s, new DateTime(2026, 7, 3, 0, 0, 0, DateTimeKind.Utc)));
+        await svc.UpdateTask(BuildEdit(s, TargetFriday));
 
         var tiles = await JulyWeekTiles(svc, s.PropertyId);
-        TestContext.WriteLine("Rendered July-week tiles (compliance@Jul4): " + string.Join(", ", tiles));
+        TestContext.WriteLine("Rendered target-week tiles (compliance@target Saturday): " + string.Join(", ", tiles));
 
-        Assert.That(tiles.Count(t => t.StartsWith("2026-07")), Is.EqualTo(1),
-            "exactly one July tile after move — original Sat 4 Jul must not remain as a copy");
+        Assert.That(tiles.Count(t => t.StartsWith(TargetMonthPrefix)), Is.EqualTo(1),
+            "exactly one target-month tile after move — original target Saturday must not remain as a copy");
     }
 
     // ---- RC1 parity: the tz-shift bug affects every entry point that reads
@@ -256,14 +293,14 @@ public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
         var s = await SeedFirstSaturdaySeries();
         var svc = BuildService(core);
 
-        await svc.UpdateTask(BuildEdit(s, new DateTime(2026, 7, 2, 22, 0, 0, DateTimeKind.Utc), "this"));
+        await svc.UpdateTask(BuildEdit(s, TargetFriday.AddHours(-2), "this"));
 
         var tiles = await JulyWeekTiles(svc, s.PropertyId);
-        TestContext.WriteLine("Rendered July-week tiles (this, tz-shifted): " + string.Join(", ", tiles));
+        TestContext.WriteLine("Rendered target-week tiles (this, tz-shifted): " + string.Join(", ", tiles));
 
-        Assert.That(tiles, Does.Contain(Key(new DateTime(2026, 7, 3))), "occurrence should move to Friday 3 Jul");
-        Assert.That(tiles, Does.Not.Contain(Key(new DateTime(2026, 7, 2))), "must NOT land on Thursday 2 Jul");
-        Assert.That(tiles.Count(t => t.StartsWith("2026-07")), Is.EqualTo(1), "exactly one July tile");
+        Assert.That(tiles, Does.Contain(Key(TargetFriday)), "occurrence should move to the target Friday");
+        Assert.That(tiles, Does.Not.Contain(Key(TargetThursday)), "must NOT land on the target Thursday");
+        Assert.That(tiles.Count(t => t.StartsWith(TargetMonthPrefix)), Is.EqualTo(1), "exactly one target-month tile");
     }
 
     // scope="all" re-anchors the whole series; arp.DayOfWeek is derived from
@@ -276,13 +313,13 @@ public class CalendarThisAndFollowingMoveBackReproTests : TestBaseSetup
         var s = await SeedFirstSaturdaySeries();
         var svc = BuildService(core);
 
-        await svc.UpdateTask(BuildEdit(s, new DateTime(2026, 7, 2, 22, 0, 0, DateTimeKind.Utc), "all"));
+        await svc.UpdateTask(BuildEdit(s, TargetFriday.AddHours(-2), "all"));
 
         var tiles = await JulyWeekTiles(svc, s.PropertyId);
-        TestContext.WriteLine("Rendered July-week tiles (all, tz-shifted): " + string.Join(", ", tiles));
+        TestContext.WriteLine("Rendered target-week tiles (all, tz-shifted): " + string.Join(", ", tiles));
 
-        Assert.That(tiles, Does.Contain(Key(new DateTime(2026, 7, 3))), "series should re-pattern to 1st Friday 3 Jul");
-        Assert.That(tiles, Does.Not.Contain(Key(new DateTime(2026, 7, 2))), "must NOT re-pattern to 1st Thursday 2 Jul");
+        Assert.That(tiles, Does.Contain(Key(TargetFriday)), "series should re-pattern to the 1st target Friday");
+        Assert.That(tiles, Does.Not.Contain(Key(TargetThursday)), "must NOT re-pattern to the 1st target Thursday");
     }
 
     private BackendConfigurationCalendarService BuildService(eFormCore.Core core)

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
@@ -810,6 +810,9 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                                     assignments.First().FourthShiftActive = deviceUserModel.FourthShiftActive ?? false;
                                     assignments.First().FifthShiftActive = deviceUserModel.FifthShiftActive ?? false;
                                     assignments.First().IsManager = deviceUserModel.IsManager ?? false;
+                                    // PayRuleSetId/UseOneMinuteIntervals intentionally not updated here —
+                                    // for existing sites they are owned by TimePlanning's updateAssignedSite PUT
+                                    // (UseOneMinuteIntervals is one-way there and must never be reset from this path)
                                     // assignments.First().// ManagingTagIds = deviceUserModel.ManagingTagIds ?? [] // TODO: Handle ManagingTagIds separately; // TODO: Handle ManagingTagIds separately
                                     await assignments.First().Update(timePlanningDbContext).ConfigureAwait(false);
                                     return new OperationDataResult<int>(true, siteDto.SiteId);
@@ -859,7 +862,8 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                                         FourthShiftActive = deviceUserModel.FourthShiftActive ?? false,
                                         FifthShiftActive = deviceUserModel.FifthShiftActive ?? false,
                                         IsManager = deviceUserModel.IsManager ?? false,
-                                        UseOneMinuteIntervals = true
+                                        UseOneMinuteIntervals = deviceUserModel.UseOneMinuteIntervals ?? false,
+                                        PayRuleSetId = deviceUserModel.PayRuleSetId
                                         // ManagingTagIds = deviceUserModel.ManagingTagIds ?? [] // TODO: Handle ManagingTagIds separately
                                     };
                                     await assignmentSite.Create(timePlanningDbContext).ConfigureAwait(false);
@@ -1154,7 +1158,8 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                             FourthShiftActive = deviceUserModel.FourthShiftActive ?? false,
                             FifthShiftActive = deviceUserModel.FifthShiftActive ?? false,
                             IsManager = deviceUserModel.IsManager ?? false,
-                            UseOneMinuteIntervals = true,
+                            UseOneMinuteIntervals = deviceUserModel.UseOneMinuteIntervals ?? false,
+                            PayRuleSetId = deviceUserModel.PayRuleSetId,
                             // ManagingTagIds = deviceUserModel.ManagingTagIds ?? [] // TODO: Handle ManagingTagIds separately
                         };
                         Console.WriteLine($"[CreateDeviceUser] Creating AssignedSite for siteId={site.MicrotingUid} user={user?.Id}");

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/DeviceUserModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/DeviceUserModel.cs
@@ -133,6 +133,8 @@ public class DeviceUserModel
     public bool? FifthShiftActive { get; set; }
     public bool? IsManager { get; set; }
     public List<int> ManagingTagIds { get; set; } = [];
+    public int? PayRuleSetId { get; set; }
+    public bool? UseOneMinuteIntervals { get; set; }
 
     public static implicit operator DeviceUserModel(Microting.EformAngularFrontendBase.Infrastructure.Data.Models.DeviceUserModel model)
     {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/backend-configuration-pn.module.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/backend-configuration-pn.module.ts
@@ -46,7 +46,7 @@ import {MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {ItemsPlanningPnTagsService} from 'src/app/plugins/modules/items-planning-pn/services';
-import {TimePlanningPnSettingsService} from 'src/app/plugins/modules/time-planning-pn/services';
+import {TimePlanningPnSettingsService, TimePlanningPnPayRuleSetsService} from 'src/app/plugins/modules/time-planning-pn/services';
 import {MatDatepickerModule} from '@angular/material/datepicker';
 import {StoreModule} from '@ngrx/store';
 import {
@@ -140,7 +140,8 @@ import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
     BackendConfigurationPnChemicalsService,
     BackendConfigurationPnTaskTrackerService,
     ItemsPlanningPnTagsService,
-    TimePlanningPnSettingsService
+    TimePlanningPnSettingsService,
+    TimePlanningPnPayRuleSetsService
   ],
 })
 export class BackendConfigurationPnModule {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -512,4 +512,13 @@ export const bgBG = {
   'Assign to worker tags': 'Присвояване на етикети на работници',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Това ще изтрие завинаги дъската и нейните {{count}} събития. Това действие не може да бъде отменено.',
   'This and following (incl. completed)': 'Това и следващите (вкл. завършени)',
+  'Payroll rules': 'Правила за изплащане на заплати',
+  'Pay Rule Set': 'Набор от правила за плащане',
+  'Select the pay rule set for this worker': 'Изберете набор от правила за заплащане за този работник',
+  'View pay rule set': 'Преглед на набора от правила за плащане',
+  None: 'Няма',
+  'Advanced settings': 'Разширени настройки',
+  'Use 1-minute intervals': 'Използвайте интервали от 1 минута',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Активирайте гранулиране от 1 минута за въвеждане на време. Стъпките по подразбиране са 5 или 15 минути.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'След като са активирани, интервалите от 1 минута не могат да бъдат изключени',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -512,4 +512,13 @@ export const csCZ = {
   'Assign to worker tags': 'Přiřadit k tagům pracovníka',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tímto se nástěnka a její {{count}} události trvale smažou. Tuto akci nelze vrátit zpět.',
   'This and following (incl. completed)': 'Toto a následující (včetně dokončených)',
+  'Payroll rules': 'Pravidla pro výplaty',
+  'Pay Rule Set': 'Sada pravidel pro platby',
+  'Select the pay rule set for this worker': 'Vyberte sadu pravidel pro odměňování pro tohoto pracovníka',
+  'View pay rule set': 'Zobrazit sadu pravidel pro platby',
+  None: 'Žádný',
+  'Advanced settings': 'Pokročilá nastavení',
+  'Use 1-minute intervals': 'Používejte minutové intervaly',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Povolte zadávání času s granularitou po 1 minutě. Výchozí přírůstky jsou 5 nebo 15 minut.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Po zapnutí nelze minutové intervaly vypnout.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -513,4 +513,13 @@ export const da = {
   'At least one worker or worker tag must be assigned': 'Mindst én medarbejder eller medarbejder-tag skal tildeles',
   'Assign to worker tags': 'Tildel til medarbejder-tags',
   'This and following (incl. completed)': 'Dette og følgende (inkl. færdiggjorte)',
+  'Payroll rules': 'Lønregler',
+  'Pay Rule Set': 'Lønregelsæt',
+  'Select the pay rule set for this worker': 'Vælg lønregelsættet for denne arbejder',
+  'View pay rule set': 'Vis lønregelsæt',
+  None: 'Ingen',
+  'Advanced settings': 'Avancerede indstillinger',
+  'Use 1-minute intervals': 'Brug 1-minutters intervaller',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Aktiver 1-minutters granularitet for tidsregistrering. Standardintervaller er 5 eller 15 minutter.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Når 1-minutters intervaller er aktiveret, kan de ikke slås fra',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -563,4 +563,13 @@ export const deDE = {
   'Assign to worker tags': 'Mitarbeiter-Tags zuweisen',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Dadurch werden das Board und alle darin enthaltenen {{count}} Ereignisse endgültig gelöscht. Dieser Vorgang kann nicht rückgängig gemacht werden.',
   'This and following (incl. completed)': 'Dies und Folgendes (einschließlich abgeschlossener)',
+  'Payroll rules': 'Lohnabrechnungsregeln',
+  'Pay Rule Set': 'Gehaltsregeln',
+  'Select the pay rule set for this worker': 'Wählen Sie die für diesen Mitarbeiter festgelegte Vergütungsregel aus.',
+  'View pay rule set': 'Gehaltsregelsatz anzeigen',
+  None: 'Keiner',
+  'Advanced settings': 'Erweiterte Einstellungen',
+  'Use 1-minute intervals': 'Verwenden Sie 1-Minuten-Intervalle.',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Aktivieren Sie die 1-Minuten-Granularität für die Zeiteingabe. Standardmäßig werden 5 oder 15 Minuten eingestellt.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Sobald die 1-Minuten-Intervalle aktiviert sind, können sie nicht mehr deaktiviert werden.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -512,4 +512,13 @@ export const elGR = {
   'Assign to worker tags': 'Ανάθεση σε ετικέτες εργαζομένων',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Αυτό θα διαγράψει οριστικά τον πίνακα και τα {{count}} συμβάντα που τον αποτελούν. Δεν είναι δυνατή η αναίρεση αυτής της ενέργειας.',
   'This and following (incl. completed)': 'Αυτό και τα επόμενα (συμπεριλαμβανομένων των ολοκληρωμένων)',
+  'Payroll rules': 'Κανόνες μισθοδοσίας',
+  'Pay Rule Set': 'Σύνολο κανόνων πληρωμής',
+  'Select the pay rule set for this worker': 'Επιλέξτε τον κανόνα πληρωμής που έχει οριστεί για αυτόν τον εργαζόμενο',
+  'View pay rule set': 'Δείτε το σύνολο κανόνων πληρωμής',
+  None: 'Κανένας',
+  'Advanced settings': 'Προηγμένες ρυθμίσεις',
+  'Use 1-minute intervals': 'Χρησιμοποιήστε διαστήματα 1 λεπτού',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Ενεργοποιήστε την ευαισθησία 1 λεπτού για την εισαγωγή χρόνου. Τα προεπιλεγμένα βήματα είναι 5 ή 15 λεπτά.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Μόλις ενεργοποιηθεί, τα διαστήματα 1 λεπτού δεν μπορούν να απενεργοποιηθούν',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -531,4 +531,13 @@ export const enUS= {
   'Edit repeat': 'Edit repeat',
   'Move repeat': 'Move repeat',
   'Delete repeat': 'Delete repeat',
+  'Payroll rules': 'Payroll rules',
+  'Pay Rule Set': 'Pay Rule Set',
+  'Select the pay rule set for this worker': 'Select the pay rule set for this worker',
+  'View pay rule set': 'View pay rule set',
+  None: 'None',
+  'Advanced settings': 'Advanced settings',
+  'Use 1-minute intervals': 'Use 1-minute intervals',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Once enabled, 1-minute intervals cannot be turned off',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -512,4 +512,13 @@ export const esES = {
   'Assign to worker tags': 'Asignar a etiquetas de trabajador',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Esto eliminará permanentemente el tablero y sus {{count}} eventos. Esta acción no se puede deshacer.',
   'This and following (incl. completed)': 'Esto y lo siguiente (incluidos los completados)',
+  'Payroll rules': 'Normas de nómina',
+  'Pay Rule Set': 'Conjunto de reglas de pago',
+  'Select the pay rule set for this worker': 'Seleccione el conjunto de reglas de pago para este trabajador.',
+  'View pay rule set': 'Ver conjunto de reglas de pago',
+  None: 'Ninguno',
+  'Advanced settings': 'Configuración avanzada',
+  'Use 1-minute intervals': 'Utilice intervalos de 1 minuto.',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Habilite la granularidad de 1 minuto para el registro de tiempo. Los incrementos predeterminados son de 5 o 15 minutos.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Una vez activados, los intervalos de 1 minuto no se pueden desactivar.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -512,4 +512,13 @@ export const etET = {
   'Assign to worker tags': 'Määra töötaja siltidele',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'See kustutab tahvli ja selle {{count}} sündmust jäädavalt. Seda ei saa tagasi võtta.',
   'This and following (incl. completed)': 'See ja järgnev (sh lõpetatud)',
+  'Payroll rules': 'Palgaarvestuse reeglid',
+  'Pay Rule Set': 'Palgareeglite komplekt',
+  'Select the pay rule set for this worker': 'Valige sellele töötajale määratud palgareegel',
+  'View pay rule set': 'Kuva palgareeglite komplekt',
+  None: 'Puudub',
+  'Advanced settings': 'Täpsemad seaded',
+  'Use 1-minute intervals': 'Kasutage 1-minutilisi intervalle',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Luba aja sisestamisel 1-minutiline täpsus. Vaikimisi sammud on 5 või 15 minutit.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Kui see on lubatud, ei saa 1-minutilisi intervalle välja lülitada.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -512,4 +512,13 @@ export const fiFI = {
   'Assign to worker tags': 'Määritä työntekijätunnisteille',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tämä poistaa pysyvästi taulun ja sen {{count}} tapahtumaa. Tätä ei voi perua.',
   'This and following (incl. completed)': 'Tämä ja seuraavat (mukaan lukien valmiit)',
+  'Payroll rules': 'Palkanlaskentasäännöt',
+  'Pay Rule Set': 'Maksusääntöjoukko',
+  'Select the pay rule set for this worker': 'Valitse tälle työntekijälle asetettu palkkasääntö',
+  'View pay rule set': 'Näytä maksusääntöjoukko',
+  None: 'Ei mitään',
+  'Advanced settings': 'Lisäasetukset',
+  'Use 1-minute intervals': 'Käytä 1 minuutin välein',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Ota käyttöön 1 minuutin tarkkuudella ajan syöttö. Oletusarvoinen lisäys on 5 tai 15 minuuttia.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Kun 1 minuutin välein on otettu käyttöön, niitä ei voi poistaa käytöstä.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -511,4 +511,13 @@ export const frFR = {
   'Assign to worker tags': 'Attribuer aux étiquettes de travailleur',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Cette action supprimera définitivement le plateau et ses {{count}} événements. Elle est irréversible.',
   'This and following (incl. completed)': 'Ceci et les suivants (y compris les éléments terminés)',
+  'Payroll rules': 'Règles de paie',
+  'Pay Rule Set': 'Règles de rémunération',
+  'Select the pay rule set for this worker': 'Sélectionnez le régime de rémunération applicable à ce travailleur.',
+  'View pay rule set': 'Afficher les règles de rémunération',
+  None: 'Aucun',
+  'Advanced settings': 'Paramètres avancés',
+  'Use 1-minute intervals': 'Utilisez des intervalles d&#39;une minute.',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Activez la granularité à la minute pour la saisie de l&#39;heure. Les incréments par défaut sont de 5 ou 15 minutes.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Une fois activées, les intervalles d&#39;une minute ne peuvent pas être désactivés.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -512,4 +512,13 @@ export const hrHR = {
   'Assign to worker tags': 'Dodijeli oznakama radnika',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Ovim će se trajno izbrisati ploča i njezinih {{count}} događaja. Ova radnja se ne može poništiti.',
   'This and following (incl. completed)': 'Ovo i sljedeće (uklj. dovršeno)',
+  'Payroll rules': 'Pravila o obračunu plaća',
+  'Pay Rule Set': 'Skup pravila plaćanja',
+  'Select the pay rule set for this worker': 'Odaberite skup pravila plaćanja za ovog radnika',
+  'View pay rule set': 'Prikaži skup pravila plaćanja',
+  None: 'Ništa',
+  'Advanced settings': 'Napredne postavke',
+  'Use 1-minute intervals': 'Koristite intervale od 1 minute',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Omogućite granularnost od 1 minute za unos vremena. Zadani koraci su 5 ili 15 minuta.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Nakon što su omogućeni, intervali od 1 minute ne mogu se isključiti',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -512,4 +512,13 @@ export const huHU = {
   'Assign to worker tags': 'Munkavállalói címkék hozzárendelése',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Ez véglegesen törli a táblát és a hozzá tartozó {{count}} eseményt. A művelet nem vonható vissza.',
   'This and following (incl. completed)': 'Ez és a következő (beleértve a befejezetteket is)',
+  'Payroll rules': 'Bérszámfejtési szabályok',
+  'Pay Rule Set': 'Fizetési szabályok',
+  'Select the pay rule set for this worker': 'Válassza ki a munkavállalóhoz tartozó fizetési szabálykészletet',
+  'View pay rule set': 'Fizetési szabálykészlet megtekintése',
+  None: 'Egyik sem',
+  'Advanced settings': 'Speciális beállítások',
+  'Use 1-minute intervals': 'Használjon 1 perces intervallumokat',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': '1 perces részletesség engedélyezése az időbevitelhez. Az alapértelmezett lépésköz 5 vagy 15 perc.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Engedélyezés után az 1 perces intervallumok nem kapcsolhatók ki.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -512,4 +512,13 @@ export const isIS = {
   'Assign to worker tags': 'Úthluta til starfsmannamerkja',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Þetta mun eyða borðinu og {{count}} atburðum þess fyrir fullt og allt. Þetta er ekki hægt að afturkalla.',
   'This and following (incl. completed)': 'Þetta og eftirfarandi (þar með talið lokið)',
+  'Payroll rules': 'Launareglur',
+  'Pay Rule Set': 'Launareglur settar',
+  'Select the pay rule set for this worker': 'Veldu launareglusettið fyrir þennan starfsmann',
+  'View pay rule set': 'Skoða greiðslureglusett',
+  None: 'Enginn',
+  'Advanced settings': 'Ítarlegar stillingar',
+  'Use 1-minute intervals': 'Notið 1 mínútu millibil',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Virkjaðu 1 mínútu nákvæmni fyrir tímaskráningu. Sjálfgefin þrep eru 5 eða 15 mínútur.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Þegar 1 mínútu millibili hefur verið virkjað er ekki hægt að slökkva á því',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -512,4 +512,13 @@ export const itIT = {
   'Assign to worker tags': 'Assegnare ai tag dei lavoratori',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Questa operazione eliminerà definitivamente la bacheca e i suoi {{count}} eventi. Non è possibile annullare l&#39;operazione.',
   'This and following (incl. completed)': 'Questo e i seguenti (compresi quelli completati)',
+  'Payroll rules': 'Regole di gestione delle retribuzioni',
+  'Pay Rule Set': 'Set di regole di pagamento',
+  'Select the pay rule set for this worker': 'Seleziona il set di regole di pagamento per questo lavoratore',
+  'View pay rule set': 'Visualizza il set di regole di pagamento',
+  None: 'Nessuno',
+  'Advanced settings': 'Impostazioni avanzate',
+  'Use 1-minute intervals': 'Utilizzare intervalli di 1 minuto',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Abilita la granularità di 1 minuto per l&#39;inserimento dell&#39;ora. Gli incrementi predefiniti sono 5 o 15 minuti.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Una volta attivati, gli intervalli di 1 minuto non possono essere disattivati.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -512,4 +512,13 @@ export const ltLT = {
   'Assign to worker tags': 'Priskirti darbuotojo žymes',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tai visam laikui ištrins lentą ir jos {{count}} įvykius. Šio veiksmo atšaukti negalima.',
   'This and following (incl. completed)': 'Šis ir tolesni (įskaitant užbaigtus)',
+  'Payroll rules': 'Darbo užmokesčio taisyklės',
+  'Pay Rule Set': 'Mokėjimo taisyklių rinkinys',
+  'Select the pay rule set for this worker': 'Pasirinkite šiam darbuotojui nustatytą mokėjimo taisyklę',
+  'View pay rule set': 'Peržiūrėti mokėjimo taisyklių rinkinį',
+  None: 'Nėra',
+  'Advanced settings': 'Išplėstiniai nustatymai',
+  'Use 1-minute intervals': 'Naudokite 1 minutės intervalus',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Įgalinti 1 minutės tikslumą laiko įvedimui. Numatytieji žingsniai yra 5 arba 15 minučių.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Įjungus 1 minutės intervalus, jų išjungti negalima.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -512,4 +512,13 @@ export const lvLV = {
   'Assign to worker tags': 'Piešķirt darbinieka tagiem',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Tas neatgriezeniski izdzēsīs tāfeli un tā {{count}} notikumus. Šo darbību nevar atsaukt.',
   'This and following (incl. completed)': 'Šis un turpmākie (ieskaitot pabeigtos)',
+  'Payroll rules': 'Algu aprēķināšanas noteikumi',
+  'Pay Rule Set': 'Maksājumu noteikumu kopa',
+  'Select the pay rule set for this worker': 'Atlasiet šim darbiniekam noteikto algas noteikumu kopu',
+  'View pay rule set': 'Skatīt algas noteikumu kopu',
+  None: 'Neviens',
+  'Advanced settings': 'Papildu iestatījumi',
+  'Use 1-minute intervals': 'Izmantojiet 1 minūtes intervālus',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Iespējot 1 minūtes granularitāti laika ievadei. Noklusējuma intervāli ir 5 vai 15 minūtes.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Kad 1 minūtes intervāli ir iespējoti, tos nevar izslēgt.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -512,4 +512,13 @@ export const nlNL = {
   'Assign to worker tags': 'Wijs toe aan werknemerslabels',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Dit verwijdert het bord en de bijbehorende {{count}} gebeurtenissen permanent. Dit kan niet ongedaan worden gemaakt.',
   'This and following (incl. completed)': 'Dit en het volgende (inclusief voltooid)',
+  'Payroll rules': 'Regels voor de loonadministratie',
+  'Pay Rule Set': 'Regels voor de betaling',
+  'Select the pay rule set for this worker': 'Selecteer de loonregelset voor deze werknemer.',
+  'View pay rule set': 'Bekijk de regels voor salarisbetalingen',
+  None: 'Geen',
+  'Advanced settings': 'Geavanceerde instellingen',
+  'Use 1-minute intervals': 'Gebruik intervallen van 1 minuut.',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Schakel de mogelijkheid in om tijdsintervallen van 1 minuut in te voeren. De standaardintervallen zijn 5 of 15 minuten.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Eenmaal ingeschakeld, kunnen intervallen van 1 minuut niet meer worden uitgeschakeld.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -512,4 +512,13 @@ export const noNO = {
   'Assign to worker tags': 'Tildel til arbeider-tagger',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Dette vil slette brettet og dets {{count}} hendelser permanent. Dette kan ikke angres.',
   'This and following (incl. completed)': 'Dette og følgende (inkl. fullført)',
+  'Payroll rules': 'Lønnsregler',
+  'Pay Rule Set': 'Sett med lønnsregler',
+  'Select the pay rule set for this worker': 'Velg lønnsregelsettet for denne arbeideren',
+  'View pay rule set': 'Vis sett med lønnsregler',
+  None: 'Ingen',
+  'Advanced settings': 'Avanserte innstillinger',
+  'Use 1-minute intervals': 'Bruk intervaller på 1 minutt',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Aktiver 1-minutts granularitet for tidsregistrering. Standardintervaller er 5 eller 15 minutter.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Når intervaller på 1 minutt er aktivert, kan de ikke slås av',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -512,4 +512,13 @@ export const plPL = {
   'Assign to worker tags': 'Przypisz do tagów pracownika',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Spowoduje to trwałe usunięcie tablicy i {{count}} jej zdarzeń. Tej czynności nie można cofnąć.',
   'This and following (incl. completed)': 'To i następne (w tym ukończone)',
+  'Payroll rules': 'Zasady dotyczące płac',
+  'Pay Rule Set': 'Zestaw zasad płatności',
+  'Select the pay rule set for this worker': 'Wybierz zestaw zasad płatności dla tego pracownika',
+  'View pay rule set': 'Wyświetl zestaw zasad dotyczących płatności',
+  None: 'Nic',
+  'Advanced settings': 'Ustawienia zaawansowane',
+  'Use 1-minute intervals': 'Używaj interwałów 1-minutowych',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Włącz dokładność wprowadzania czasu co 1 minutę. Domyślne wartości to 5 lub 15 minut.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Po włączeniu nie można wyłączyć interwałów 1-minutowych',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -512,4 +512,13 @@ export const ptBR = {
   'Assign to worker tags': 'Atribuir às etiquetas do trabalhador',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Isso excluirá permanentemente o quadro e seus {{count}} eventos. Essa ação não pode ser desfeita.',
   'This and following (incl. completed)': 'Isto e o seguinte (incluindo o já concluído)',
+  'Payroll rules': 'Regras de folha de pagamento',
+  'Pay Rule Set': 'Conjunto de regras de pagamento',
+  'Select the pay rule set for this worker': 'Selecione o conjunto de regras de pagamento para este funcionário.',
+  'View pay rule set': 'Visualizar conjunto de regras de pagamento',
+  None: 'Nenhum',
+  'Advanced settings': 'Configurações avançadas',
+  'Use 1-minute intervals': 'Use intervalos de 1 minuto.',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Ative a granularidade de 1 minuto para a entrada de tempo. Os incrementos padrão são de 5 ou 15 minutos.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Uma vez ativado, o intervalo de 1 minuto não pode ser desativado.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -512,4 +512,13 @@ export const ptPT = {
   'Assign to worker tags': 'Atribuir às etiquetas do trabalhador',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Isso excluirá permanentemente o quadro e seus {{count}} eventos. Essa ação não pode ser desfeita.',
   'This and following (incl. completed)': 'Isto e o seguinte (incluindo o já concluído)',
+  'Payroll rules': 'Regras de folha de pagamento',
+  'Pay Rule Set': 'Conjunto de regras de pagamento',
+  'Select the pay rule set for this worker': 'Selecione o conjunto de regras de pagamento para este funcionário.',
+  'View pay rule set': 'Visualizar conjunto de regras de pagamento',
+  None: 'Nenhum',
+  'Advanced settings': 'Configurações avançadas',
+  'Use 1-minute intervals': 'Use intervalos de 1 minuto.',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Ative a granularidade de 1 minuto para a entrada de tempo. Os incrementos padrão são de 5 ou 15 minutos.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Uma vez ativado, o intervalo de 1 minuto não pode ser desativado.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -512,4 +512,13 @@ export const roRO = {
   'Assign to worker tags': 'Atribuiți etichetelor lucrătorilor',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Aceasta acțiune va șterge definitiv forumul și {{count}} evenimentele sale. Această acțiune nu poate fi anulată.',
   'This and following (incl. completed)': 'Aceasta și următoarele (inclusiv finalizate)',
+  'Payroll rules': 'Reguli de salarizare',
+  'Pay Rule Set': 'Set de reguli de plată',
+  'Select the pay rule set for this worker': 'Selectați regula de plată setată pentru acest lucrător',
+  'View pay rule set': 'Vizualizați setul de reguli de plată',
+  None: 'Nici unul',
+  'Advanced settings': 'Setări avansate',
+  'Use 1-minute intervals': 'Folosește intervale de 1 minut',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Activați granularitatea de 1 minut pentru introducerea timpului. Incrementele implicite sunt de 5 sau 15 minute.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Odată activate, intervalele de 1 minut nu pot fi dezactivate',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -512,4 +512,13 @@ export const skSK = {
   'Assign to worker tags': 'Priradiť k značkám pracovníka',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Týmto sa natrvalo vymaže nástenka a jej {{count}} udalostí. Túto akciu nie je možné vrátiť späť.',
   'This and following (incl. completed)': 'Toto a nasledujúce (vrátane dokončených)',
+  'Payroll rules': 'Pravidlá pre výplaty miezd',
+  'Pay Rule Set': 'Sada pravidiel pre platby',
+  'Select the pay rule set for this worker': 'Vyberte pravidlo odmeňovania nastavené pre tohto pracovníka',
+  'View pay rule set': 'Zobraziť sadu pravidiel platieb',
+  None: 'Žiadne',
+  'Advanced settings': 'Rozšírené nastavenia',
+  'Use 1-minute intervals': 'Používajte 1-minútové intervaly',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Povoľte 1-minútovú granularitu pre zadávanie času. Predvolené prírastky sú 5 alebo 15 minút.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Po zapnutí nie je možné minútové intervaly vypnúť.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -512,4 +512,13 @@ export const slSL = {
   'Assign to worker tags': 'Dodeli oznakam delavcev',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'S tem boste trajno izbrisali tablo in {{count}} dogodkov na njej. Tega ni mogoče razveljaviti.',
   'This and following (incl. completed)': 'To in naslednje (vključno z dokončanim)',
+  'Payroll rules': 'Pravila za obračun plač',
+  'Pay Rule Set': 'Nabor pravil za plačilo',
+  'Select the pay rule set for this worker': 'Izberite nabor pravil plačila za tega delavca',
+  'View pay rule set': 'Ogled nabora pravil za plačilo',
+  None: 'Nobena',
+  'Advanced settings': 'Napredne nastavitve',
+  'Use 1-minute intervals': 'Uporabite 1-minutne intervale',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Omogočite 1-minutno natančnost za vnos časa. Privzeti koraki so 5 ali 15 minut.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Ko so omogočeni, 1-minutnih intervalov ni mogoče izklopiti.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -512,4 +512,13 @@ export const svSE = {
   'Assign to worker tags': 'Tilldela till arbetartaggar',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Detta kommer att permanent radera brädet och dess {{count}} händelser. Detta kan inte ångras.',
   'This and following (incl. completed)': 'Detta och följande (inkl. färdigställda)',
+  'Payroll rules': 'Löneregler',
+  'Pay Rule Set': 'Löneregeluppsättning',
+  'Select the pay rule set for this worker': 'Välj löneregeluppsättningen för den här arbetaren',
+  'View pay rule set': 'Visa uppsättning löneregler',
+  None: 'Ingen',
+  'Advanced settings': 'Avancerade inställningar',
+  'Use 1-minute intervals': 'Använd 1-minutsintervaller',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Aktivera 1-minuts granularitet för tidsinmatning. Standardintervallen är 5 eller 15 minuter.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'När 1-minutsintervaller är aktiverade kan de inte stängas av',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -512,4 +512,13 @@ export const ukUA = {
   'Assign to worker tags': 'Призначити тегам працівника',
   'This will permanently delete the board and its {{count}} events. This cannot be undone.': 'Це назавжди видалить дошку та її {{count}} подій. Цю дію неможливо скасувати.',
   'This and following (incl. completed)': 'Це та наступні (включно з завершеними)',
+  'Payroll rules': 'Правила нарахування заробітної плати',
+  'Pay Rule Set': 'Набір правил оплати',
+  'Select the pay rule set for this worker': 'Виберіть правило оплати праці, встановлене для цього працівника',
+  'View pay rule set': 'Переглянути набір правил оплати',
+  None: 'Жоден',
+  'Advanced settings': 'Розширені налаштування',
+  'Use 1-minute intervals': 'Використовуйте інтервали в 1 хвилину',
+  'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.': 'Увімкнути точність введення часу з кроком 1 хвилина. Крок за замовчуванням становить 5 або 15 хвилин.',
+  'Once enabled, 1-minute intervals cannot be turned off': 'Після ввімкнення інтервали в 1 хвилину не можна вимкнути',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.html
@@ -256,6 +256,35 @@
             <div class="modal-columns">
               <div class="d-flex flex-column" id="timeRegistrationColumn">
 
+                <!-- ========= Payroll rules ========= -->
+                <h3 class="section-header" *ngIf="!selectedDeviceUser.resigned && availablePayRuleSets.length > 0 && (selectAuthIsAdmin$ | async)">{{ 'Payroll rules' | translate }}</h3>
+
+                <div class="d-flex flex-row align-items-center pay-rule-set-row" *ngIf="!selectedDeviceUser.resigned && availablePayRuleSets.length > 0 && (selectAuthIsAdmin$ | async)">
+                  <mat-form-field class="p-1 flex-grow-1">
+                    <mat-label>{{ 'Pay Rule Set' | translate }}</mat-label>
+                    <mtx-select
+                      id="payRuleSetIdSelect"
+                      [items]="availablePayRuleSets"
+                      bindLabel="name"
+                      bindValue="id"
+                      [multiple]="false"
+                      [clearable]="true"
+                      [placeholder]="'None' | translate"
+                      formControlName="payRuleSetId">
+                    </mtx-select>
+                    <mat-hint>{{ 'Select the pay rule set for this worker' | translate }}</mat-hint>
+                  </mat-form-field>
+                  <button
+                    mat-icon-button
+                    type="button"
+                    id="viewPayRuleSetBtn"
+                    [disabled]="!form.get('payRuleSetId')?.value"
+                    matTooltip="{{ 'View pay rule set' | translate }}"
+                    (click)="openPayRuleSetView()">
+                    <mat-icon>visibility</mat-icon>
+                  </button>
+                </div>
+
                 <!-- ========= Break calculation ========= -->
                 <h3 class="section-header" *ngIf="!selectedDeviceUser.resigned">{{ 'Break calculation' | translate }}</h3>
 
@@ -403,6 +432,21 @@
                     </mtx-select>
                     <mat-hint>{{ 'Select tags that this manager is responsible for' | translate }}</mat-hint>
                   </mat-form-field>
+                </div>
+
+                <!-- ========= Advanced settings ========= -->
+                <h3 class="section-header" *ngIf="!selectedDeviceUser.resigned && (selectAuthIsAdmin$ | async)">{{ 'Advanced settings' | translate }}</h3>
+
+                <div class="d-flex flex-row" *ngIf="!selectedDeviceUser.resigned && (selectAuthIsAdmin$ | async)">
+                  <mat-checkbox class="p-1"
+                                id="useOneMinuteIntervals"
+                                formControlName="useOneMinuteIntervals">
+                    <div>
+                      <div>{{ 'Use 1-minute intervals' | translate }}</div>
+                      <small class="checkbox-description">{{ 'Enable 1-minute granularity for time entry. Default increments are 5 or 15 minutes.' | translate }}</small>
+                      <small class="checkbox-description">{{ 'Once enabled, 1-minute intervals cannot be turned off' | translate }}</small>
+                    </div>
+                  </mat-checkbox>
                 </div>
               </div>
             </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.scss
@@ -118,3 +118,12 @@
   vertical-align: middle;
 }
 
+.pay-rule-set-row {
+  // Outranks the theme cap "body.theme-workspace .mat-mdc-form-field.mat-mdc-form-field-type-mtx-select { max-width: 320px }"
+  mat-form-field.mat-mdc-form-field-type-mtx-select {
+    flex: 1 1 auto;
+    width: 100%;
+    max-width: none;
+  }
+}
+

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.ts
@@ -11,12 +11,12 @@ import {CommonDictionaryModel, LanguagesModel} from 'src/app/common/models';
 import {PropertyAssignmentWorkerModel, DeviceUserModel} from '../../../../models';
 import {BackendConfigurationPnPropertiesService} from '../../../../services';
 import {AuthStateService} from 'src/app/common/store';
-import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {MtxGridColumn} from '@ng-matero/extensions/grid';
 import {TranslateService} from '@ngx-translate/core';
 import {debounceTime, filter, first, startWith, switchMap, tap} from 'rxjs/operators';
 import {AppSettingsStateService} from 'src/app/modules/application-settings/components/store';
-import {TimePlanningPnSettingsService} from 'src/app/plugins/modules/time-planning-pn/services';
+import {TimePlanningPnSettingsService, TimePlanningPnPayRuleSetsService} from 'src/app/plugins/modules/time-planning-pn/services';
 import {
   AbstractControl,
   FormBuilder,
@@ -27,9 +27,10 @@ import {
   Validators
 } from '@angular/forms';
 import validator from 'validator';
-import {AssignedSiteModel, GlobalAutoBreakSettingsModel} from 'src/app/plugins/modules/time-planning-pn/models';
+import {AssignedSiteModel, GlobalAutoBreakSettingsModel, PayRuleSetSimpleModel} from 'src/app/plugins/modules/time-planning-pn/models';
 import {Store} from '@ngrx/store';
 import {selectAuthIsAdmin} from 'src/app/state';
+import {PayRuleSetsViewModalComponent} from 'src/app/plugins/modules/time-planning-pn/modules/pay-rule-sets/components/pay-rule-sets-view-modal/pay-rule-sets-view-modal.component';
 
 @AutoUnsubscribe()
 @Component({
@@ -47,6 +48,8 @@ export class PropertyWorkerCreateEditModalComponent implements OnInit, OnDestroy
   public dialogRef = inject(MatDialogRef<PropertyWorkerCreateEditModalComponent>);
   private appSettingsStateService = inject(AppSettingsStateService);
   private timePlanningPnSettingsService = inject(TimePlanningPnSettingsService);
+  private dialog = inject(MatDialog);
+  private payRuleSetsService = inject(TimePlanningPnPayRuleSetsService);
   private model = inject<{
     deviceUser: DeviceUserModel,
     assignments: PropertyAssignmentWorkerModel[],
@@ -67,6 +70,7 @@ export class PropertyWorkerCreateEditModalComponent implements OnInit, OnDestroy
   timeRegistrationEnabled: boolean = false;
   availableTags: CommonDictionaryModel[] = [];
   alreadyUsedEmails: string[] = [];
+  availablePayRuleSets: PayRuleSetSimpleModel[] = [];
   @Output() userUpdated: EventEmitter<void> = new EventEmitter<void>();
   tableHeaders: MtxGridColumn[] = [
     {
@@ -115,6 +119,10 @@ export class PropertyWorkerCreateEditModalComponent implements OnInit, OnDestroy
         }
       }
     });
+    // One-way: a saved 1-minute-intervals=true can never be re-enabled for editing
+    if (this.selectedAssignedSite.useOneMinuteIntervals) {
+      this.form.get('useOneMinuteIntervals')?.disable({emitEvent: false});
+    }
   }
 
   get languages() {
@@ -238,7 +246,9 @@ export class PropertyWorkerCreateEditModalComponent implements OnInit, OnDestroy
       fourthShiftActive: false,
       fifthShiftActive: false,
       isManager: false,
-      managingTagIds: []
+      managingTagIds: [],
+      payRuleSetId: [null as number | null],
+      useOneMinuteIntervals: [false],
     });
 
     // Build autoBreakSettings form group
@@ -258,6 +268,7 @@ export class PropertyWorkerCreateEditModalComponent implements OnInit, OnDestroy
     // here — the form is fully constructed, so even a synchronously-replayed
     // cached store value inside the tap callback can call `form.patchValue`.
     this.getEnabledLanguages();
+    this.loadPayRuleSets();
 
     // Fetch global auto break calculation settings
     this.timePlanningPnSettingsService.getGlobalAutoBreakCalculationSettings().subscribe(result => {
@@ -286,7 +297,13 @@ export class PropertyWorkerCreateEditModalComponent implements OnInit, OnDestroy
               fifthShiftActive: this.selectedAssignedSite.fifthShiftActive || false,
               isManager: this.selectedAssignedSite.isManager || false,
               managingTagIds: this.selectedAssignedSite.managingTagIds || [],
+              payRuleSetId: this.selectedAssignedSite.payRuleSetId ?? null,
+              useOneMinuteIntervals: this.selectedAssignedSite.useOneMinuteIntervals || false,
             });
+
+            if (this.selectedAssignedSite.useOneMinuteIntervals) {
+              this.form.get('useOneMinuteIntervals')?.disable({emitEvent: false});
+            }
 
             // Patch auto break settings from assigned site
             const autoBreakFg = this.form.get('autoBreakSettings') as FormGroup;
@@ -619,6 +636,31 @@ export class PropertyWorkerCreateEditModalComponent implements OnInit, OnDestroy
         this.languagesLoaded$.complete();
       }))
       .subscribe();
+  }
+
+  loadPayRuleSets(): void {
+    this.payRuleSetsService.getPayRuleSets({offset: 0, pageSize: 1000}).subscribe({
+      next: (result) => {
+        if (result && result.success) {
+          this.availablePayRuleSets = result.model?.payRuleSets || [];
+        }
+      },
+      error: () => {
+        this.availablePayRuleSets = [];
+      }
+    });
+  }
+
+  openPayRuleSetView(): void {
+    const payRuleSetId = this.form.get('payRuleSetId')?.value;
+    if (!payRuleSetId) {
+      return;
+    }
+    this.dialog.open(PayRuleSetsViewModalComponent, {
+      data: { payRuleSetId },
+      minWidth: 800,
+      maxWidth: 1000,
+    });
   }
 
   generateRandomEmail(): void {


### PR DESCRIPTION
## Summary
- The property-worker create/edit modal (Time registration tab) gains a **Payroll rules** section: a full-width pay-rule-set dropdown (scoped override of the global 320px `mtx-select` form-field cap) plus a view (eye) button opening TimePlanning's read-only rule-set modal, reused cross-plugin.
- New **Advanced settings** section with the **Use 1-minute intervals** checkbox (with its description plus a warning that it cannot be turned off once enabled).
- **Edit path** persists both values through the modal's existing TimePlanning `updateAssignedSite` PUT. **Create path**: `DeviceUserModel` gains nullable `PayRuleSetId`/`UseOneMinuteIntervals`, consumed by both `AssignedSite` creation blocks in `BackendConfigurationAssignmentWorkerServiceHelper`.
- ⚠️ **Behavior change:** those creation blocks previously hardcoded `UseOneMinuteIntervals = true` — newly created workers now default to standard 5/15-minute intervals unless the box is ticked. Operators relying on new workers getting exact-minute punch by default must now tick the box.
- One-way UI lock: the checkbox is disabled whenever the stored value is already true (including after the resigned-toggle's blanket enable loop). The authoritative one-way enforcement (API OR) ships in the companion PR microting/eform-angular-timeplanning-plugin#1635.
- i18n: 9 keys added to all locales; Danish aligned byte-for-byte with time-planning-pn's translations.

## Test plan
- Verified live in dev: full-width dropdown (910px of 952px row), eye opens the view modal from the BC context (cross-plugin injector verified), tick + save → reopen shows checked **and disabled**; API PUT with `false` on an already-true site leaves it true; TimePlanning assigned-site dialog shows the same locked state.
- Existing Playwright suites select these surfaces by unchanged ids; new controls use fresh ids (`payRuleSetIdSelect`, `viewPayRuleSetBtn`, `useOneMinuteIntervals`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)