### PR TITLE
feat: sort property and calendar lists per the user's language (da: a…zæøå)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/UserNameComparerHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/UserNameComparerHelper.cs
@@ -1,0 +1,59 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+*/
+
+namespace BackendConfiguration.Pn.Infrastructure.Helpers;
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microting.eFormApi.BasePn.Abstractions;
+
+public static class UserNameComparerHelper
+{
+    /// <summary>
+    /// Case-insensitive name comparer for the CURRENT user's UI language, so
+    /// alphabetical lists collate per that language's rules — Danish ('da')
+    /// puts æ/ø/å after z (a…zæøå) while English keeps plain a–z order.
+    /// Falls back to ordinal for unauthenticated callers (gRPC/background)
+    /// or when the user's language cannot be resolved.
+    /// </summary>
+    public static async Task<StringComparer> GetForCurrentUser(IUserService userService, ILogger logger)
+    {
+        try
+        {
+            if (userService.UserId < 1)
+            {
+                // No authenticated user (gRPC/background callers) — skip the
+                // lookup entirely; GetCurrentUserLanguage would throw.
+                return StringComparer.OrdinalIgnoreCase;
+            }
+
+            var languageCode = (await userService.GetCurrentUserLanguage())?.LanguageCode;
+            if (!string.IsNullOrWhiteSpace(languageCode))
+            {
+                return StringComparer.Create(CultureInfo.GetCultureInfo(languageCode), true);
+            }
+        }
+        catch (Exception e)
+        {
+            logger.LogDebug(e,
+                "Could not resolve the current user's language for name sorting; falling back to ordinal");
+        }
+
+        return StringComparer.OrdinalIgnoreCase;
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using BackendConfigurationLocalizationService;
 using BackendConfigurationTaskWizardService;
+using Infrastructure.Helpers;
 using CalendarAssignmentReconciliation;
 using EventDeployService;
 using Infrastructure.Models.Calendar;
@@ -3473,6 +3474,14 @@ public class BackendConfigurationCalendarService(
                     PropertyId = defaultBoard.PropertyId,
                 });
             }
+
+            // Alphabetical in the CALLER'S language — a Danish user must see
+            // æ/ø/å sorted after z (a…zæøå), not interleaved among a/o as the
+            // default comparer does; an English user keeps plain a–z order.
+            // The frontend picks the DEFAULT board by lowest id, not by list
+            // position, so reordering here is display-only.
+            var nameComparer = await UserNameComparerHelper.GetForCurrentUser(userService, logger);
+            boards = boards.OrderBy(x => x.Name, nameComparer).ToList();
 
             return new OperationDataResult<List<CalendarBoardModel>>(true, boards);
         }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationPropertiesService/BackendConfigurationPropertiesService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationPropertiesService/BackendConfigurationPropertiesService.cs
@@ -492,13 +492,17 @@ public class BackendConfigurationPropertiesService(
                     x.CHR,
                     x.Name
                 }).ToListAsync().ConfigureAwait(false);
+            // Alphabetical in the CALLER'S language — a Danish user must see
+            // æ/ø/å sorted after z (a…zæøå), not interleaved among a/o as the
+            // default comparer does; an English user keeps plain a–z order.
+            var nameComparer = await UserNameComparerHelper.GetForCurrentUser(userService, logger);
             var result = properties
                 .Select(x => new CommonDictionaryModel
                 {
                     Id = x.Id,
                     Name = fullNames ? $"{x.CVR} - {x.CHR} - {x.Name}" : x.Name,
                     Description = ""
-                }).OrderBy(x => x.Name).ToList();
+                }).OrderBy(x => x.Name, nameComparer).ToList();
             return new OperationDataResult<List<CommonDictionaryModel>>(true, result);
         }
         catch (Exception ex)


### PR DESCRIPTION
## What

The calendar sidebar's property list and calendar list, and the create/edit modal's calendar picker, now sort alphabetically **per the current user's language**: Danish users get æ/ø/å collated after z (`a…z æ ø å`), English users keep standard a–z, and every other language gets its own locale's collation.

## How

- `BackendConfigurationPropertiesService.GetCommonDictionary` and `BackendConfigurationCalendarService.GetBoards` order names with `StringComparer.Create(CultureInfo.GetCultureInfo(<user's LanguageCode>), ignoreCase: true)` via a new shared `UserNameComparerHelper` (in-memory sort — the lists are small, and this avoids per-request `COLLATE` switching in MySQL).
- Unauthenticated callers (the gRPC paths, guarded cheaply via `UserId < 1`) and unresolvable languages fall back to ordinal, with a debug log on the exceptional path.
- Reordering `GetBoards` is display-only: both frontend consumers (`calendar-container`, `task-create-edit-modal`) pick the default calendar by **lowest id**, not list position. No e2e spec asserts positions in either list (they match by name).

## Verification

Seeded boards `Beta, Zebra, Ærø, Østre, Ålborg` and a property `Æblegård-test`, then verified via API and the live Danish UI:
- da: properties end `…Tids tester org, Æblegård-test`; calendars order `Beta, Default, Zebra, Ærø, Østre, Ålborg` — in the sidebar **and** the create/edit modal picker.
- en-US (locale flipped for the same user): `Ærø, Ålborg, Beta, Default, Østre, Zebra` — standard English collation.
- Test data cleaned up afterwards.

Note: Danish collation intentionally treats a leading "Aa" as Å (e.g. "Aabenraa…" sorts last for Danish users) — that is correct Danish orthography.

Known adjacent inconsistency (out of scope here): the task-wizard page's property dropdown sorts via a SQL `ORDER BY` (MySQL collation) in `BackendConfigurationTaskWizardService.GetProperties`, so it won't match Danish collation. Can be aligned in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)