### PR TITLE
fix(compliance-view): open-task period presets extend into the future

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-compliance-view.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-compliance-view.spec.ts
@@ -32,10 +32,11 @@ import {
  * materialised Compliance row in the OPEN (not completed) state, which is
  * exactly the fixture this suite needs.
  *
- * The Compliance report's built-in period presets (1/3/6/12 months, YTD) are
- * all backward-looking from today (dateTo is hard-clamped to `new Date()` —
- * calendar-compliance-view.component.ts `get dateTo()`), so they can never
- * include a task dated next week. Every report-fetching test here uses the
+ * The Compliance report's built-in period presets are backward-looking from
+ * today only for the "done" status; for open/all statuses they span
+ * symmetrically into the future (calendar-compliance-view.component.ts
+ * `get dateTo()`). These tests predate that and need a deterministic window
+ * anyway, so every report-fetching test here uses the
  * "Set period" (custom) preset with an explicit range spanning
  * [today-2, nextMonday+8] (the whole retry week, see selectCompliancePeriodCustom)
  * instead.

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-compliance-view/calendar-compliance-view.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-compliance-view/calendar-compliance-view.component.ts
@@ -106,22 +106,38 @@ export class CalendarComplianceViewComponent implements OnInit {
       case 'ytd': return new Date(today.getFullYear(), 0, 1);
       case 'custom': return this.customFrom ?? today;
       default: {
-        const d = new Date(today);
         const months = parseInt(this.periodPreset, 10);
-        const targetMonthIndex = d.getMonth() - months;
-        d.setMonth(targetMonthIndex);
-        // setMonth overflows at month ends (May 31 − 3 → Mar 3); clamp back
-        // to the last day of the intended month.
-        if (d.getMonth() !== ((targetMonthIndex % 12) + 12) % 12) {
-          d.setDate(0);
-        }
-        return d;
+        return this.addClampedMonths(today, -months);
       }
     }
   }
 
   get dateTo(): Date {
-    return this.periodPreset === 'custom' && this.customTo ? this.customTo : new Date();
+    const today = new Date();
+    switch (this.periodPreset) {
+      case 'custom': return this.customTo ?? today;
+      case 'ytd':
+        // Open/all tasks can have future deadlines; only "done" stays
+        // retrospective (bounded by today).
+        return this.filterStatus === 'done' ? today : new Date(today.getFullYear(), 11, 31);
+      default: {
+        if (this.filterStatus === 'done') { return today; }
+        const months = parseInt(this.periodPreset, 10);
+        return this.addClampedMonths(today, months);
+      }
+    }
+  }
+
+  // setMonth overflows at month ends (May 31 + 3 → Sep 1); clamp back to the
+  // last day of the intended month. `months` may be negative.
+  private addClampedMonths(date: Date, months: number): Date {
+    const d = new Date(date);
+    const targetMonthIndex = d.getMonth() + months;
+    d.setMonth(targetMonthIndex);
+    if (d.getMonth() !== ((targetMonthIndex % 12) + 12) % 12) {
+      d.setDate(0);
+    }
+    return d;
   }
 
   get periodDisplay(): string {


### PR DESCRIPTION
## Problem

The Compliance view's period presets all ended at *today* (mockup semantics: retrospective report). On real data, open compliance tasks are almost entirely either overdue by more than a month or upcoming (future deadlines) — so the default view (Ikke udførte + 1 mdr.) rendered empty for every property, and upcoming open tasks could never be shown at all.

Evidence: of 402 open Compliance rows in the dev DB, only 2 fell inside the trailing-month window; 15 have future deadlines unreachable by any preset.

## Fix

Status-aware period getters in `calendar-compliance-view.component.ts`:
- **Ikke udførte / Alle opgaver**: month presets span symmetrically `[today − N, today + N]`; År til dato spans `[Jan 1, Dec 31]`
- **Udførte**: unchanged, retrospective (end = today)
- **Sæt periode**: unchanged (user controls both ends)

Month-end arithmetic clamped via a shared `addClampedMonths` helper (Jan 31 + 1 mo → Feb 28, not Mar 3). Also refreshes the e2e spec's now-stale header comment about preset semantics (tests themselves use the custom preset and are unaffected).

Verified in-browser: default filters on a property with an upcoming open task now show it (period display "10. juni 2026 – 10. august 2026").

🤖 Generated with [Claude Code](https://claude.com/claude-code)