### PR TITLE
fix(compliance-view): long lists were clipped and unscrollable

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-compliance-view/calendar-compliance-view.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-compliance-view/calendar-compliance-view.component.scss
@@ -4,7 +4,11 @@
   gap: 12px;
   padding: 12px 16px;
   overflow-y: auto;
-  height: 100%;
+  // Bounded by the flex host (see app-calendar-compliance-view rule in
+  // calendar-container.component.scss); min-height: 0 is what actually
+  // allows this flex child to shrink below content height and scroll.
+  flex: 1;
+  min-height: 0;
 }
 
 .compliance-filters {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.scss
@@ -39,5 +39,13 @@
       min-height: 0;
       overflow: hidden;
     }
+
+    app-calendar-compliance-view {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      overflow: hidden;
+    }
   }
 }


### PR DESCRIPTION
## Problem

With a long report (e.g. "Vis alle" on ~400 rows), the Compliance view's list was cropped at the viewport and could not be scrolled to the end.

## Root cause

`.calendar-main` is a flex column with `overflow: hidden`, and its view children need `flex: 1; min-height: 0` to be bounded — `app-calendar-week-grid` and `app-calendar-schedule-view` have exactly that child rule, but `app-calendar-compliance-view` was never added. Its host grew to content height (25k px measured), `.compliance-view`'s `height: 100%` resolved against that grown host (max scroll = 0), and `.calendar-main` clipped the rest.

## Fix

- Add the same `app-calendar-compliance-view` child rule as the sibling views in `calendar-container.component.scss`
- `.compliance-view`: `height: 100%` → `flex: 1; min-height: 0` (it already had `overflow-y: auto`)

Verified in-browser: 417-row "Vis alle" list scrolls fully (last row + pagination reachable); paged mode and the week/day/schedule views unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)