### PR TITLE
feat(compliance-view): restrict Compliance view mode to admins

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.html
@@ -33,6 +33,7 @@
       [viewMode]="viewMode"
       [sidebarOpen]="sidebarOpen"
       [propertyName]="selectedPropertyName"
+      [isAdmin]="isAdmin"
       (navigate)="onNavigate($event)"
       (goToToday)="onGoToToday()"
       (viewModeChange)="onViewModeChange($event)"
@@ -85,16 +86,18 @@
         (toggleCompleteRequested)="onToggleCompleteRequested($event)"
       ></app-calendar-schedule-view>
 
-      <app-calendar-compliance-view
-        *ngSwitchCase="'compliance'"
-        #complianceView
-        [properties]="properties"
-        [boards]="boards"
-        [tags]="tags"
-        [employees]="employees"
-        [currentPropertyId]="currentPropertyId"
-        (completeRequested)="onComplianceRowCompleteRequested($event)"
-      ></app-calendar-compliance-view>
+      <ng-container *ngSwitchCase="'compliance'">
+        <app-calendar-compliance-view
+          *ngIf="isAdmin"
+          #complianceView
+          [properties]="properties"
+          [boards]="boards"
+          [tags]="tags"
+          [employees]="employees"
+          [currentPropertyId]="currentPropertyId"
+          (completeRequested)="onComplianceRowCompleteRequested($event)"
+        ></app-calendar-compliance-view>
+      </ng-container>
     </ng-container>
   </div>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -100,7 +100,17 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
     private router: Router,
   ) {
     this.store.select(selectCurrentUserIsAdmin).pipe(takeUntil(this.destroy$))
-      .subscribe(isAdmin => this.isAdmin = isAdmin);
+      .subscribe(isAdmin => {
+        this.isAdmin = isAdmin;
+        // isAdmin resolves async from the store after init — if it turns out
+        // the user is not an admin while compliance view is still active
+        // (e.g. deep link, or a stale admin session), force back to week
+        // view so a non-admin can never remain in the admin-only mode.
+        if (!isAdmin && this.viewMode === 'compliance') {
+          this.stateService.updateViewMode('week');
+          this.loadTasks();
+        }
+      });
   }
 
   ngOnInit(): void {
@@ -113,6 +123,19 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       this.activeTeamIds = filters.activeTeamIds;
       this.activeTagNames = filters.activeTagNames;
       this.sidebarOpen = filters.sidebarOpen;
+
+      // Defense in depth (mirrors the constructor's isAdmin-subscription
+      // guard): NgRx calendar state persists across in-app navigations, so
+      // a non-admin can land on this component with a stale 'compliance'
+      // viewMode inherited from a previous admin session, with no admin
+      // check ever having run. Force back to week — the updateViewMode
+      // dispatch re-emits filters$ with 'week', which this same
+      // subscription then processes normally, so no extra loadTasks() call
+      // is needed here.
+      if (this.viewMode === 'compliance' && !this.isAdmin) {
+        this.stateService.updateViewMode('week');
+        return;
+      }
     });
 
     this.loadProperties();

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
 import {TranslateService} from '@ngx-translate/core';
 import {getCurrentLocale} from '../../services/calendar-locale.helper';
 
@@ -8,11 +8,12 @@ import {getCurrentLocale} from '../../services/calendar-locale.helper';
   templateUrl: './calendar-header.component.html',
   styleUrls: ['./calendar-header.component.scss'],
 })
-export class CalendarHeaderComponent implements OnInit {
+export class CalendarHeaderComponent implements OnInit, OnChanges {
   @Input() currentDate: string = '';
   @Input() viewMode: 'week' | 'day' | 'schedule' | 'compliance' = 'week';
   @Input() sidebarOpen = true;
   @Input() propertyName: string = '';
+  @Input() isAdmin = false;
 
   viewModeOptions: {value: string; label: string}[] = [];
 
@@ -25,11 +26,24 @@ export class CalendarHeaderComponent implements OnInit {
   constructor(private translate: TranslateService) {}
 
   ngOnInit() {
+    this.buildViewModeOptions();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    // isAdmin arrives asynchronously from the store after this component has
+    // already initialised, so the option list must be rebuilt whenever it
+    // changes (not just once in ngOnInit).
+    if (changes['isAdmin']) {
+      this.buildViewModeOptions();
+    }
+  }
+
+  private buildViewModeOptions() {
     this.viewModeOptions = [
       {value: 'day', label: this.translate.instant('Day')},
       {value: 'week', label: this.translate.instant('Week')},
       {value: 'schedule', label: this.translate.instant('List')},
-      {value: 'compliance', label: this.translate.instant('Compliance')},
+      ...(this.isAdmin ? [{value: 'compliance', label: this.translate.instant('Compliance')}] : []),
     ];
   }
 


### PR DESCRIPTION
## What

The calendar's **Compliance** view mode is now admin-only, using the plugin's established frontend gating pattern (`selectCurrentUserIsAdmin` → `[isAdmin]` input, as the week grid already does):

- `calendar-header` takes `[isAdmin]` and only includes the Compliance dropdown option for admins (options rebuilt via `ngOnChanges` since the flag resolves async)
- Defense in depth against NgRx-persisted `viewMode` state (it survives in-app navigations): the `*ngSwitchCase="'compliance'"` renders the view only when `isAdmin`, and both the admin-selector subscription and the `filters$` subscription reset a non-admin back to week view

## Verified

- Admin: dropdown shows Dag/Uge/Tidsplan/Compliance and the view works as before
- Non-admin path (exercised via the component's real `ngOnChanges`/render path): option absent; with `viewMode` forced to `'compliance'` and `isAdmin=false` the view does not render
- No dispatch loop from the reset (guard re-entry sees `'week'`)

## Scope note

Gating is frontend-only, matching every other admin-gated feature in this plugin (no controller in BackendConfiguration.Pn uses role policies). The `compliance-report` endpoint stays `[Authorize]` like its siblings — flagging explicitly in case backend role enforcement is wanted later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)