### PR TITLE
feat(calendar): combined complete-event modal (worker + date + eForm in one)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarPrepareCompleteTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarPrepareCompleteTests.cs
@@ -1,0 +1,559 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+*/
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+using System.Globalization;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eForm.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.eFormApi.BasePn.Infrastructure.Models.API;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+
+/// <summary>
+/// DB-backed integration coverage for
+/// <see cref="BackendConfigurationCalendarService.PrepareComplete"/> — the
+/// combined-complete-modal's "resolve, but do NOT complete" step. It
+/// deliberately duplicates <c>ToggleComplete</c>'s resolution logic (existing
+/// Compliance lookup, on-demand materialisation via
+/// <see cref="IEventDeployService.EnsureComplianceForOccurrenceAsync"/>, and
+/// the EventStart triple: Compliance.Deadline day + CalendarOccurrenceException
+/// StartHour override ?? CalendarConfiguration.StartHour ?? 9.0), so this file
+/// pins the same shapes WITHOUT ever touching Case.Status or removing the
+/// Compliance row.
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarPrepareCompleteTests : TestBaseSetup
+{
+    // A minimal real eForm — content is irrelevant to PrepareComplete (it
+    // never inspects mandatory fields), we just need a real CheckListId to
+    // back the SDK Case. Copied from EventDeployServiceTest.CommentTemplateXml.
+    private const string CommentTemplateXml = @"
+<?xml version='1.0' encoding='UTF-8'?>
+<Main>
+    <Id>9060</Id>
+    <Repeated>0</Repeated>
+    <Label>CommentMain</Label>
+    <StartDate>2017-07-07</StartDate>
+    <EndDate>2027-07-07</EndDate>
+    <Language>da</Language>
+    <MultiApproval>false</MultiApproval>
+    <FastNavigation>false</FastNavigation>
+    <Review>false</Review>
+    <Summary>false</Summary>
+    <DisplayOrder>0</DisplayOrder>
+    <ElementList>
+        <Element type='DataElement'>
+            <Id>9060</Id>
+            <Label>CommentDataElement</Label>
+            <Description><![CDATA[CommentDataElementDescription]]></Description>
+            <DisplayOrder>0</DisplayOrder>
+            <ReviewEnabled>false</ReviewEnabled>
+            <ManualSync>false</ManualSync>
+            <ExtraFieldsEnabled>false</ExtraFieldsEnabled>
+            <DoneButtonDisabled>false</DoneButtonDisabled>
+            <ApprovalEnabled>false</ApprovalEnabled>
+            <DataItemList>
+                <DataItem type='Comment'>
+                    <Id>73660</Id>
+                    <Label>CommentField</Label>
+                    <Description><![CDATA[CommentFieldDescription]]></Description>
+                    <DisplayOrder>0</DisplayOrder>
+                    <Multi>1</Multi>
+                    <GeolocationEnabled>false</GeolocationEnabled>
+                    <Split>false</Split>
+                    <Value />
+                    <ReadOnly>false</ReadOnly>
+                    <Mandatory>false</Mandatory>
+                    <Color>e8eaf6</Color>
+                </DataItem>
+            </DataItemList>
+        </Element>
+    </ElementList>
+</Main>";
+
+    private static string ExpectedIso(DateTime deadlineDate, double hour)
+    {
+        var whole = (int)Math.Floor(hour);
+        var minute = (int)Math.Round((hour - whole) * 60);
+        return DateTime.SpecifyKind(deadlineDate.Date, DateTimeKind.Utc)
+            .AddHours(whole).AddMinutes(minute)
+            .ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+    }
+
+    private sealed class Scenario
+    {
+        public BackendConfigurationCalendarService Service = null!;
+        public AreaRulePlanning Arp = null!;
+        public Property Property = null!;
+        public Area Area = null!;
+        public Planning Planning = null!;
+        public Site SdkSite = null!;
+        public int TemplateId;
+        public eFormCore.Core Core = null!;
+    }
+
+    /// <summary>
+    /// Seeds a full Area → Property → AreaRule → Planning → AreaRulePlanning
+    /// graph plus a real SDK site/language/eForm template, and builds a
+    /// <see cref="BackendConfigurationCalendarService"/> against it. The
+    /// deployed site is wired both as a (BC) PlanningSite of the ARP — the
+    /// source PrepareComplete's on-demand branch reads
+    /// (<c>arp.PlanningSites.FirstOrDefault</c>) — and as an active
+    /// PropertyWorker, so the deploy pipeline's leak guard
+    /// (EventDeployService.cs:497-547) never blocks materialisation.
+    ///
+    /// When <paramref name="useRealEventDeployService"/> is true the service
+    /// is wired to a REAL <see cref="EventDeployService"/> (needed for the
+    /// on-demand-materialisation scenarios); otherwise it gets a mock that is
+    /// never expected to be reached (existing-compliance / early-failure
+    /// scenarios).
+    /// </summary>
+    private async Task<Scenario> SeedGraphAsync(
+        string tag,
+        int microtingUid,
+        DateTime arpStartDate,
+        bool useRealEventDeployService,
+        int? areaRuleEformIdOverride = null)
+    {
+        var core = await GetCore();
+        var language = await MicrotingDbContext!.Languages.FirstAsync();
+
+        // The per-test SQL fixture reset predates the calendar tables: it
+        // drops/recreates AreaRulePlannings (auto-increment restarts at 1)
+        // but never mentions CalendarConfigurations / CalendarOccurrenceExceptions,
+        // so those tables SURVIVE across tests within this fixture. A StartHour
+        // row created by an earlier test would silently attach to this test's
+        // freshly-seeded ARP (which reuses the same id). Clear them explicitly.
+        await BackendConfigurationPnDbContext!.Database
+            .ExecuteSqlRawAsync("DELETE FROM CalendarConfigurations");
+        await BackendConfigurationPnDbContext.Database
+            .ExecuteSqlRawAsync("DELETE FROM CalendarOccurrenceExceptions");
+
+        var template = await core.TemplateFromXml(CommentTemplateXml);
+        var templateId = await core.TemplateCreate(template);
+
+        var sdkSite = new Site
+        {
+            Name = $"prepare-complete-{tag}",
+            MicrotingUid = microtingUid,
+            LanguageId = language.Id,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext.Sites.AddAsync(sdkSite);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1, ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.Areas.AddAsync(area);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var property = new Property
+        {
+            Name = $"PrepareComplete-{tag}-{Guid.NewGuid()}", ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var areaRule = new AreaRule
+        {
+            AreaId = area.Id, PropertyId = property.Id,
+            EformId = areaRuleEformIdOverride ?? templateId,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planning = new Planning
+        {
+            Enabled = true, RepeatEvery = 1, RepeatType = RepeatType.Week, StartDate = arpStartDate,
+            RelatedEFormId = templateId, WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id, PropertyId = property.Id, AreaId = area.Id,
+            ItemPlanningId = planning.Id, StartDate = arpStartDate, Status = true,
+            RepeatType = 1, RepeatEvery = 1, DayOfWeek = 1,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(arp);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var planningSite = new Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities.PlanningSite
+        {
+            AreaRulePlanningsId = arp.Id, SiteId = sdkSite.Id,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.PlanningSites.AddAsync(planningSite);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        await BackendConfigurationPnDbContext.PropertyWorkers.AddAsync(new PropertyWorker
+        {
+            PropertyId = property.Id, WorkerId = sdkSite.Id,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        });
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        // Reload with the Includes PrepareComplete itself requires.
+        arp = await BackendConfigurationPnDbContext.AreaRulePlannings
+            .Include(x => x.AreaRule)
+            .Include(x => x.PlanningSites)
+            .FirstAsync(x => x.Id == arp.Id);
+
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        userService.GetCurrentUserLanguage().Returns(Task.FromResult(language));
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+        var taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        taskWizardService.DeleteTask(Arg.Any<int>()).Returns(Task.FromResult(new OperationResult(true)));
+
+        IEventDeployService eventDeployService;
+        if (useRealEventDeployService)
+        {
+            var calendarMock = Substitute.For<IBackendConfigurationCalendarService>();
+            var services = new ServiceCollection();
+            services.AddSingleton(calendarMock);
+            var sp = services.BuildServiceProvider();
+            eventDeployService = new EventDeployService(
+                BackendConfigurationPnDbContext, ItemsPlanningPnDbContext, coreHelper, sp,
+                NullLogger<EventDeployService>.Instance);
+        }
+        else
+        {
+            eventDeployService = Substitute.For<IEventDeployService>();
+        }
+
+        var service = new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(), userService,
+            BackendConfigurationPnDbContext, coreHelper, eventDeployService,
+            ItemsPlanningPnDbContext, taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
+            NullLogger<BackendConfigurationCalendarService>.Instance);
+
+        return new Scenario
+        {
+            Service = service, Arp = arp, Property = property, Area = area,
+            Planning = planning, SdkSite = sdkSite, TemplateId = templateId, Core = core
+        };
+    }
+
+    /// <summary>Creates and persists a live Compliance row backed by a real SDK Case.</summary>
+    private async Task<(Compliance Compliance, Case SdkCase)> SeedComplianceAsync(
+        Scenario s, DateTime deadlineDate, int caseStatus = 66)
+    {
+        var sdkCase = new Case
+        {
+            SiteId = s.SdkSite.Id,
+            CheckListId = s.TemplateId,
+            Status = caseStatus,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await MicrotingDbContext!.Cases.AddAsync(sdkCase);
+        await MicrotingDbContext.SaveChangesAsync();
+
+        var compliance = new Compliance
+        {
+            PlanningId = s.Planning.Id, PropertyId = s.Property.Id, AreaId = s.Area.Id,
+            Deadline = deadlineDate.Date, StartDate = deadlineDate.Date.AddDays(-7),
+            MicrotingSdkCaseId = sdkCase.Id, MicrotingSdkeFormId = s.TemplateId,
+            WorkflowState = Constants.WorkflowStates.Created
+        };
+        await BackendConfigurationPnDbContext!.Compliances.AddAsync(compliance);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        return (compliance, sdkCase);
+    }
+
+    // ------------------------------------------------------------------
+    // 1. Existing Compliance row → resolves it without any side effects.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task PrepareComplete_ExistingCompliance_ReturnsIdsAndDoesNotComplete()
+    {
+        var deadline = DateTime.UtcNow.Date.AddDays(5);
+        var s = await SeedGraphAsync("existing", 5001, deadline.AddDays(-14), useRealEventDeployService: false);
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = s.Arp.Id, StartHour = 9.0, Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var (compliance, sdkCase) = await SeedComplianceAsync(s, deadline);
+
+        var result = await s.Service.PrepareComplete(
+            s.Arp.Id, compliance.Id, deadline.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Model!.SdkCaseId, Is.EqualTo(sdkCase.Id));
+            Assert.That(result.Model.TemplateId, Is.EqualTo(s.TemplateId));
+            Assert.That(result.Model.ComplianceId, Is.EqualTo(compliance.Id));
+            Assert.That(result.Model.PropertyId, Is.EqualTo(s.Property.Id));
+            Assert.That(result.Model.AssignedSiteId, Is.EqualTo(sdkCase.SiteId));
+            Assert.That(result.Model.Deadline, Is.EqualTo(ExpectedIso(deadline, 0.0)));
+            Assert.That(result.Model.EventStart, Is.EqualTo(ExpectedIso(deadline, 9.0)));
+        });
+
+        // CRITICAL invariant — nothing was completed.
+        var reloadedCase = await MicrotingDbContext!.Cases.AsNoTracking().FirstAsync(x => x.Id == sdkCase.Id);
+        var reloadedCompliance = await BackendConfigurationPnDbContext.Compliances
+            .AsNoTracking().FirstAsync(x => x.Id == compliance.Id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(reloadedCase.Status, Is.EqualTo(66), "SDK case Status must be untouched (not completed)");
+            Assert.That(reloadedCompliance.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created),
+                "Compliance row must remain live (not removed)");
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // 2. No Compliance row → materialises on demand; nothing completed.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task PrepareComplete_NoCompliance_MaterialisesOnDemand()
+    {
+        var deadline = DateTime.UtcNow.Date.AddDays(3);
+        var s = await SeedGraphAsync("ondemand", 5002, deadline.AddDays(-14), useRealEventDeployService: true);
+
+        var beforeCount = await BackendConfigurationPnDbContext!.Compliances.CountAsync();
+
+        var result = await s.Service.PrepareComplete(
+            s.Arp.Id, null, deadline.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Model!.SdkCaseId, Is.GreaterThan(0));
+            Assert.That(result.Model.ComplianceId, Is.GreaterThan(0));
+            Assert.That(result.Model.TemplateId, Is.Not.Null.And.GreaterThan(0));
+            Assert.That(result.Model.PropertyId, Is.EqualTo(s.Property.Id));
+            Assert.That(result.Model.EventStart, Is.EqualTo(ExpectedIso(deadline, 9.0)));
+        });
+
+        var afterCount = await BackendConfigurationPnDbContext.Compliances.CountAsync();
+        Assert.That(afterCount, Is.EqualTo(beforeCount + 1), "exactly one Compliance row must be materialised");
+
+        // Nothing completed: the freshly materialised case/compliance are untouched.
+        var newCase = await MicrotingDbContext!.Cases.AsNoTracking().FirstAsync(x => x.Id == result.Model!.SdkCaseId);
+        var newCompliance = await BackendConfigurationPnDbContext.Compliances
+            .AsNoTracking().FirstAsync(x => x.Id == result.Model!.ComplianceId);
+        Assert.Multiple(() =>
+        {
+            Assert.That(newCase.Status, Is.Not.EqualTo(100), "newly materialised case must not be completed");
+            Assert.That(newCompliance.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created),
+                "newly materialised Compliance row must remain live");
+            Assert.That(result.Model!.AssignedSiteId, Is.EqualTo(newCase.SiteId));
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // 3. EventStart honors CalendarConfiguration.StartHour (13.5 -> 13:30).
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task PrepareComplete_EventStart_HonorsCalendarConfigurationStartHour()
+    {
+        var deadline = DateTime.UtcNow.Date.AddDays(6);
+        var s = await SeedGraphAsync("cfgstarthour", 5003, deadline.AddDays(-14), useRealEventDeployService: false);
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = s.Arp.Id, StartHour = 13.5, Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var (compliance, _) = await SeedComplianceAsync(s, deadline);
+
+        var result = await s.Service.PrepareComplete(
+            s.Arp.Id, compliance.Id, deadline.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model!.EventStart, Is.EqualTo(ExpectedIso(deadline, 13.5)));
+        Assert.That(result.Model.EventStart, Does.Contain("T13:30:00.000Z"));
+    }
+
+    // ------------------------------------------------------------------
+    // 4. EventStart honors a CalendarOccurrenceException StartHour override.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task PrepareComplete_EventStart_HonorsOccurrenceExceptionStartHour()
+    {
+        var deadline = DateTime.UtcNow.Date.AddDays(7);
+        var s = await SeedGraphAsync("exceptionstarthour", 5004, deadline.AddDays(-14), useRealEventDeployService: false);
+
+        var calConfig = new CalendarConfiguration
+        {
+            AreaRulePlanningId = s.Arp.Id, StartHour = 9.0, Duration = 1.0,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext!.CalendarConfigurations.AddAsync(calConfig);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var exception = new CalendarOccurrenceException
+        {
+            AreaRulePlanningId = s.Arp.Id, OriginalDate = deadline.Date, NewDate = null,
+            IsDeleted = false, StartHour = 15.25,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await BackendConfigurationPnDbContext.CalendarOccurrenceExceptions.AddAsync(exception);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var (compliance, _) = await SeedComplianceAsync(s, deadline);
+
+        var result = await s.Service.PrepareComplete(
+            s.Arp.Id, compliance.Id, deadline.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model!.EventStart, Is.EqualTo(ExpectedIso(deadline, 15.25)));
+        Assert.That(result.Model.EventStart, Does.Contain("T15:15:00.000Z"),
+            "the occurrence exception's StartHour (15:15) must win over the CalendarConfiguration default (09:00)");
+    }
+
+    // ------------------------------------------------------------------
+    // 5. EventStart defaults to 09:00 when no CalendarConfiguration exists.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task PrepareComplete_EventStart_DefaultsTo9AM_WhenNoCalendarConfiguration()
+    {
+        var deadline = DateTime.UtcNow.Date.AddDays(8);
+        var s = await SeedGraphAsync("nocfg", 5005, deadline.AddDays(-14), useRealEventDeployService: false);
+
+        // Deliberately no CalendarConfiguration row for this ARP.
+        var (compliance, _) = await SeedComplianceAsync(s, deadline);
+
+        var result = await s.Service.PrepareComplete(
+            s.Arp.Id, compliance.Id, deadline.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(result.Model!.EventStart, Is.EqualTo(ExpectedIso(deadline, 9.0)));
+        Assert.That(result.Model.EventStart, Does.Contain("T09:00:00.000Z"));
+    }
+
+    // ------------------------------------------------------------------
+    // 6. Missing/removed ARP id -> failure result.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task PrepareComplete_RemovedAreaRulePlanning_ReturnsFailure()
+    {
+        var deadline = DateTime.UtcNow.Date.AddDays(4);
+        var s = await SeedGraphAsync("removedarp", 5006, deadline.AddDays(-14), useRealEventDeployService: false);
+
+        // Soft-remove the ARP after seeding — mirrors the WorkflowState filter
+        // PrepareComplete applies (`WorkflowState != Removed`).
+        var trackedArp = await BackendConfigurationPnDbContext!.AreaRulePlannings.FirstAsync(x => x.Id == s.Arp.Id);
+        trackedArp.WorkflowState = Constants.WorkflowStates.Removed;
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        var result = await s.Service.PrepareComplete(
+            s.Arp.Id, null, deadline.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+
+        Assert.That(result.Success, Is.False, "a removed AreaRulePlanning must not resolve");
+
+        var complianceCount = await BackendConfigurationPnDbContext.Compliances.CountAsync();
+        Assert.That(complianceCount, Is.EqualTo(0), "no Compliance row may be written for a removed ARP");
+    }
+
+    // ------------------------------------------------------------------
+    // 7. No Compliance row + ARP whose AreaRule has no EformId -> failure.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task PrepareComplete_NoCompliance_AreaRuleMissingEformId_ReturnsFailure()
+    {
+        var deadline = DateTime.UtcNow.Date.AddDays(4);
+        var s = await SeedGraphAsync(
+            "noeform", 5007, deadline.AddDays(-14), useRealEventDeployService: false, areaRuleEformIdOverride: 0);
+
+        var result = await s.Service.PrepareComplete(
+            s.Arp.Id, null, deadline.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+
+        Assert.That(result.Success, Is.False, "an AreaRule with no EformId has nothing to materialise");
+
+        var complianceCount = await BackendConfigurationPnDbContext!.Compliances.CountAsync();
+        Assert.That(complianceCount, Is.EqualTo(0));
+    }
+
+    // ------------------------------------------------------------------
+    // 8. No Compliance row + invalid occurrenceDate format -> failure.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task PrepareComplete_NoCompliance_InvalidOccurrenceDateFormat_ReturnsFailure()
+    {
+        var deadline = DateTime.UtcNow.Date.AddDays(4);
+        var s = await SeedGraphAsync("badformat", 5008, deadline.AddDays(-14), useRealEventDeployService: false);
+
+        var result = await s.Service.PrepareComplete(s.Arp.Id, null, "13-07-2026");
+
+        Assert.That(result.Success, Is.False, "a non-yyyy-MM-dd occurrenceDate must be rejected");
+
+        var complianceCount = await BackendConfigurationPnDbContext!.Compliances.CountAsync();
+        Assert.That(complianceCount, Is.EqualTo(0));
+    }
+
+    // ------------------------------------------------------------------
+    // 9. Calling PrepareComplete twice for the same occurrence is idempotent.
+    // ------------------------------------------------------------------
+    [Test]
+    public async Task PrepareComplete_CalledTwice_SameOccurrence_IsIdempotent()
+    {
+        var deadline = DateTime.UtcNow.Date.AddDays(9);
+        var s = await SeedGraphAsync("idempotent", 5009, deadline.AddDays(-14), useRealEventDeployService: true);
+        var occurrenceDate = deadline.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        var first = await s.Service.PrepareComplete(s.Arp.Id, null, occurrenceDate);
+        Assert.That(first.Success, Is.True, first.Message);
+
+        var second = await s.Service.PrepareComplete(s.Arp.Id, null, occurrenceDate);
+        Assert.That(second.Success, Is.True, second.Message);
+
+        Assert.That(second.Model!.ComplianceId, Is.EqualTo(first.Model!.ComplianceId),
+            "repeated resolution of the same occurrence must return the same Compliance row");
+        Assert.That(second.Model.SdkCaseId, Is.EqualTo(first.Model.SdkCaseId));
+
+        var complianceCount = await BackendConfigurationPnDbContext!.Compliances
+            .CountAsync(c => c.PlanningId == s.Planning.Id && c.Deadline.Date == deadline.Date);
+        Assert.That(complianceCount, Is.EqualTo(1), "no duplicate Compliance row may be created");
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/CalendarController.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/CalendarController.cs
@@ -111,6 +111,14 @@ public class CalendarController : Controller
             id, model.Completed, model.ComplianceId, model.OccurrenceDate, model.WorkerId);
     }
 
+    [HttpPost("tasks/{id:int}/prepare-complete")]
+    public async Task<OperationDataResult<CalendarPrepareCompleteResult>> PrepareComplete(
+        int id, [FromBody] CalendarPrepareCompleteModel model)
+    {
+        return await _backendConfigurationCalendarService.PrepareComplete(
+            id, model.ComplianceId, model.OccurrenceDate);
+    }
+
     [HttpPost("tasks/{id:int}/files")]
     [RequestSizeLimit(26_214_400)]
     public async Task<OperationDataResult<CalendarTaskAttachmentDto>> UploadFile(int id, IFormFile file)

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/CompliancesController.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/CompliancesController.cs
@@ -100,4 +100,11 @@ public class CompliancesController : Controller
 
         return Ok(await _backendConfigurationCompliancesService.Update(model).ConfigureAwait(false));
     }
+
+    [HttpPut]
+    [Route("cases/calendar")]
+    public async Task<OperationResult> UpdateFromCalendar([FromBody] ReplyRequest model)
+    {
+        return await _backendConfigurationCompliancesService.UpdateFromCalendar(model);
+    }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarPrepareCompleteModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarPrepareCompleteModel.cs
@@ -1,0 +1,8 @@
+namespace BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+
+public class CalendarPrepareCompleteModel
+{
+    public int? ComplianceId { get; set; }
+    /// <summary>Occurrence date, yyyy-MM-dd — required when the compliance row must be materialised on demand.</summary>
+    public string OccurrenceDate { get; set; }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarPrepareCompleteResult.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarPrepareCompleteResult.cs
@@ -1,0 +1,15 @@
+namespace BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+
+public class CalendarPrepareCompleteResult
+{
+    public int SdkCaseId { get; set; }
+    public int? TemplateId { get; set; }
+    public int PropertyId { get; set; }
+    public int ComplianceId { get; set; }
+    /// <summary>The SDK site the case is currently deployed to — the modal's default worker preselect fallback.</summary>
+    public int? AssignedSiteId { get; set; }
+    /// <summary>ISO 8601 UTC (same format as CalendarToggleCompleteResult.Deadline).</summary>
+    public string Deadline { get; set; }
+    /// <summary>ISO 8601 UTC event start (Deadline day + effective StartHour).</summary>
+    public string EventStart { get; set; }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -3379,6 +3379,147 @@ public class BackendConfigurationCalendarService(
     }
 
     /// <summary>
+    /// Materialises/resolves the occurrence the combined complete modal is about
+    /// to fill, WITHOUT completing anything and WITHOUT a worker (the worker is
+    /// committed on save via PUT compliances/cases). Deliberately duplicates
+    /// <see cref="ToggleComplete"/>'s resolution steps rather than refactoring
+    /// them out — <see cref="ToggleComplete"/> backs mobile/gRPC and must stay
+    /// byte-identical.
+    /// </summary>
+    public async Task<OperationDataResult<CalendarPrepareCompleteResult>> PrepareComplete(
+        int id, int? complianceId, string occurrenceDate)
+    {
+        try
+        {
+            var arp = await backendConfigurationPnDbContext.AreaRulePlannings
+                .Include(x => x.AreaRule)
+                .Include(x => x.PlanningSites)
+                .Where(x => x.Id == id)
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .FirstOrDefaultAsync();
+
+            if (arp == null)
+            {
+                return new OperationDataResult<CalendarPrepareCompleteResult>(false,
+                    localizationService.GetString("AreaRulePlanningNotFound"));
+            }
+
+            Compliance? compliance = null;
+            if (complianceId is > 0)
+            {
+                compliance = await backendConfigurationPnDbContext.Compliances
+                    .Where(c => c.Id == complianceId.Value
+                             && c.PlanningId == arp.ItemPlanningId
+                             && c.WorkflowState != Constants.WorkflowStates.Removed
+                             && c.MicrotingSdkCaseId > 0)
+                    .FirstOrDefaultAsync();
+            }
+
+            if (compliance == null)
+            {
+                if (arp.AreaRule == null
+                    || arp.AreaRule.EformId == null
+                    || arp.AreaRule.EformId == 0)
+                {
+                    return new OperationDataResult<CalendarPrepareCompleteResult>(false,
+                        localizationService.GetString("TaskHasNoComplianceCase"));
+                }
+
+                var planningSite = arp.PlanningSites?.FirstOrDefault(s =>
+                    s.WorkflowState != Constants.WorkflowStates.Removed);
+                if (planningSite == null)
+                {
+                    return new OperationDataResult<CalendarPrepareCompleteResult>(false,
+                        localizationService.GetString("NoAssignedWorker"));
+                }
+                var targetSiteId = planningSite.SiteId;
+
+                if (string.IsNullOrWhiteSpace(occurrenceDate))
+                {
+                    return new OperationDataResult<CalendarPrepareCompleteResult>(false,
+                        localizationService.GetString("TaskHasNoComplianceCase"));
+                }
+
+                if (!DateTime.TryParseExact(occurrenceDate, "yyyy-MM-dd",
+                        CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate))
+                {
+                    return new OperationDataResult<CalendarPrepareCompleteResult>(false,
+                        localizationService.GetString("TaskHasNoComplianceCase"));
+                }
+                var deadline = parsedDate.Date;
+
+                var ensure = await eventDeployService
+                    .EnsureComplianceForOccurrenceAsync(arp, deadline, targetSiteId)
+                    .ConfigureAwait(false);
+                if (ensure == null || ensure.ComplianceId <= 0)
+                {
+                    return new OperationDataResult<CalendarPrepareCompleteResult>(false,
+                        localizationService.GetString("TaskHasNoComplianceCase"));
+                }
+
+                compliance = await backendConfigurationPnDbContext.Compliances
+                    .FirstOrDefaultAsync(c => c.Id == ensure.ComplianceId
+                                           && c.WorkflowState != Constants.WorkflowStates.Removed
+                                           && c.MicrotingSdkCaseId > 0);
+
+                if (compliance == null)
+                {
+                    return new OperationDataResult<CalendarPrepareCompleteResult>(false,
+                        localizationService.GetString("TaskHasNoComplianceCase"));
+                }
+            }
+
+            var sdkCore = await coreHelper.GetCore().ConfigureAwait(false);
+            await using var sdkDbContext = sdkCore.DbContextHelper.GetDbContext();
+
+            var sdkCase = await sdkDbContext.Cases
+                .FirstOrDefaultAsync(c => c.Id == compliance.MicrotingSdkCaseId);
+
+            if (sdkCase == null || sdkCase.CheckListId == null)
+            {
+                return new OperationDataResult<CalendarPrepareCompleteResult>(false,
+                    localizationService.GetString("SdkCaseNotFound"));
+            }
+
+            // Canonical event start — same triple as ToggleComplete (~line 3237).
+            var calConfig = await backendConfigurationPnDbContext.CalendarConfigurations
+                .Where(x => x.AreaRulePlanningId == arp.Id)
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .FirstOrDefaultAsync();
+            var complianceException = await backendConfigurationPnDbContext.CalendarOccurrenceExceptions
+                .Where(x => x.AreaRulePlanningId == arp.Id)
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Where(x => x.OriginalDate.Date == compliance.Deadline.Date)
+                .FirstOrDefaultAsync();
+            var effectiveStartHour = complianceException?.StartHour ?? calConfig?.StartHour ?? 9.0;
+            var startHourWhole = (int)Math.Floor(effectiveStartHour);
+            var startMinuteWhole = (int)Math.Round((effectiveStartHour - startHourWhole) * 60);
+            var deadlineDayUtc = DateTime.SpecifyKind(compliance.Deadline.Date, DateTimeKind.Utc);
+            var eventStart = deadlineDayUtc.AddHours(startHourWhole).AddMinutes(startMinuteWhole);
+
+            return new OperationDataResult<CalendarPrepareCompleteResult>(true,
+                new CalendarPrepareCompleteResult
+                {
+                    SdkCaseId = sdkCase.Id,
+                    TemplateId = sdkCase.CheckListId,
+                    PropertyId = compliance.PropertyId,
+                    ComplianceId = compliance.Id,
+                    AssignedSiteId = sdkCase.SiteId,
+                    Deadline = DateTime.SpecifyKind(compliance.Deadline, DateTimeKind.Utc)
+                        .ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture),
+                    EventStart = eventStart.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture)
+                });
+        }
+        catch (Exception e)
+        {
+            SentrySdk.CaptureException(e);
+            logger.LogError(e, "BackendConfigurationCalendarService.PrepareComplete: {Message}", e.Message);
+            return new OperationDataResult<CalendarPrepareCompleteResult>(false,
+                $"{localizationService.GetString("ErrorWhileGettingCalendarTasks")}: {e.Message}");
+        }
+    }
+
+    /// <summary>
     /// Returns true iff the eForm template referenced by <paramref name="checkListId"/>
     /// contains at least one mandatory <see cref="Field"/>. Recurses through
     /// <see cref="FieldContainer"/> so grouped/container-nested fields are inspected too.

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/IBackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/IBackendConfigurationCalendarService.cs
@@ -48,6 +48,8 @@ public interface IBackendConfigurationCalendarService
     Task<OperationResult> ResizeTask(CalendarTaskResizeRequestModel resizeModel);
     Task<OperationDataResult<CalendarToggleCompleteResult>> ToggleComplete(
         int id, bool completed, int? complianceId, string? occurrenceDate, int? workerId = null);
+    Task<OperationDataResult<CalendarPrepareCompleteResult>> PrepareComplete(
+        int id, int? complianceId, string occurrenceDate);
     Task<OperationDataResult<List<CalendarBoardModel>>> GetBoards(int propertyId);
     Task<OperationResult> CreateBoard(CalendarBoardCreateModel model);
     Task<OperationResult> UpdateBoard(CalendarBoardUpdateModel model);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCompliancesService/BackendConfigurationCompliancesService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCompliancesService/BackendConfigurationCompliancesService.cs
@@ -410,6 +410,194 @@ public class BackendConfigurationCompliancesService : IBackendConfigurationCompl
         }
     }
 
+    // Calendar-specific variant of Update: identical behaviour except the
+    // device retraction (core.CaseDelete) is resolved synchronously but
+    // executed fire-and-forget, since it is an external platform call that
+    // can block for minutes in dev. Retraction was already best-effort in
+    // Update (failures are swallowed), so this changes latency, not
+    // guarantees.
+    public async Task<OperationResult> UpdateFromCalendar(ReplyRequest model)
+    {
+        var checkListValueList = new List<string>();
+        var fieldValueList = new List<string>();
+        var core = await _coreHelper.GetCore().ConfigureAwait(false);
+        var language = await _userService.GetCurrentUserLanguage().ConfigureAwait(false);
+        var currentUser = await _userService.GetCurrentUserAsync().ConfigureAwait(false);
+        try
+        {
+            model.ElementList.ForEach(element =>
+            {
+                checkListValueList.AddRange(CaseUpdateHelper.GetCheckList(element));
+                fieldValueList.AddRange(CaseUpdateHelper.GetFieldList(element));
+            });
+        }
+        catch (Exception ex)
+        {
+            Log.LogException(ex.Message);
+            Log.LogException(ex.StackTrace);
+            return new OperationResult(false, $"{_localizationService.GetString("CaseCouldNotBeUpdated")} Exception: {ex.Message}");
+        }
+
+        try
+        {
+            var compliance = await _backendConfigurationPnDbContext.Compliances.SingleOrDefaultAsync(x => x.Id == model.ExtraId).ConfigureAwait(false);
+            if (compliance != null)
+            {
+                await compliance.Delete(_backendConfigurationPnDbContext).ConfigureAwait(false);
+            }
+            else
+            {
+                return new OperationResult(false, $"{_localizationService.GetString("CaseCouldNotBeUpdated")}");
+            }
+
+
+            await core.CaseUpdate(model.Id, fieldValueList, checkListValueList).ConfigureAwait(false);
+            await core.CaseUpdateFieldValues(model.Id, language).ConfigureAwait(false);
+
+            var sdkDbContext = core.DbContextHelper.GetDbContext();
+
+            var foundCase = await sdkDbContext.Cases
+                .Where(x => x.Id == model.Id)
+                .FirstOrDefaultAsync().ConfigureAwait(false);
+
+            if(foundCase != null) {
+                // Preserve the caller-supplied time-of-day so calendar
+                // event.start (Deadline day + CalendarConfiguration.StartHour)
+                // survives the round-trip. Existing consumers (task-tracker,
+                // compliance-list) keep submitting their previous values —
+                // task-tracker uses `task.deadlineTask.toISOString()` and
+                // Compliance.Deadline is stored as midnight UTC, so their
+                // observable behaviour is unchanged. SpecifyKind re-tags
+                // without shifting (model.DoneAt arrives as Unspecified-kind
+                // from the JSON binder).
+                var newDoneAt = DateTime.SpecifyKind(model.DoneAt, DateTimeKind.Utc);
+                foundCase.DoneAtUserModifiable = newDoneAt;
+                foundCase.DoneAt = newDoneAt;
+
+                var site = await sdkDbContext.Sites
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .FirstOrDefaultAsync(x => x.Id == model.SiteId).ConfigureAwait(false);
+
+                foundCase.SiteId = model.SiteId;
+                foundCase.Status = 100;
+                foundCase.WorkflowState = Constants.WorkflowStates.Created;
+                await foundCase.Update(sdkDbContext).ConfigureAwait(false);
+
+                if (CaseUpdateDelegates.CaseUpdateDelegate != null)
+                {
+                    var invocationList = CaseUpdateDelegates.CaseUpdateDelegate
+                        .GetInvocationList();
+                    foreach (var func in invocationList)
+                    {
+                        func.DynamicInvoke(model.Id);
+                    }
+                }
+                var planningCaseSite = await _itemsPlanningPnDbContext.PlanningCaseSites
+                    .FirstOrDefaultAsync(x => x.CreatedAt.Date == compliance.StartDate.Date && x.PlanningId == compliance.PlanningId).ConfigureAwait(false);
+                if (planningCaseSite != null)
+                {
+                    planningCaseSite.Status = 100;
+                    planningCaseSite = await SetFieldValue(planningCaseSite, foundCase.Id, language).ConfigureAwait(false);
+
+                    planningCaseSite.MicrotingSdkCaseId = foundCase.Id;
+                    planningCaseSite.MicrotingSdkCaseDoneAt = foundCase.DoneAt;
+                    planningCaseSite.DoneByUserId = (int)foundCase.SiteId;
+                    planningCaseSite.DoneByUserName = site.Name;
+                    await planningCaseSite.Update(_itemsPlanningPnDbContext).ConfigureAwait(false);
+
+                    var planningCase = await _itemsPlanningPnDbContext.PlanningCases
+                        .SingleAsync(x => x.Id == planningCaseSite.PlanningCaseId).ConfigureAwait(false);
+                    if (planningCase.Status != 100)
+                    {
+                        planningCase.Status = 100;
+                        planningCase.MicrotingSdkCaseDoneAt = foundCase.DoneAt;
+                        planningCase.MicrotingSdkCaseId = foundCase.Id;
+                        planningCase.DoneByUserId = (int)foundCase.SiteId;
+                        planningCase.DoneByUserName = planningCaseSite.DoneByUserName;
+                        planningCase.WorkflowState = Constants.WorkflowStates.Processed;
+
+                        planningCase = await SetFieldValue(planningCase, foundCase.Id, language).ConfigureAwait(false);
+                        await planningCase.Update(_itemsPlanningPnDbContext).ConfigureAwait(false);
+                    }
+                    planningCaseSite.PlanningCaseId = planningCase.Id;
+                    await planningCaseSite.Update(_itemsPlanningPnDbContext).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                return new OperationResult(false, _localizationService.GetString("CaseNotFound"));
+            }
+
+            var property = await _backendConfigurationPnDbContext.Properties.SingleAsync(x => x.Id == compliance.PropertyId).ConfigureAwait(false);
+
+            if (_backendConfigurationPnDbContext.Compliances.AsNoTracking().Any(x =>
+                    x.Deadline < DateTime.UtcNow && x.PropertyId == property.Id &&
+                    x.WorkflowState != Constants.WorkflowStates.Removed))
+            {
+                property.ComplianceStatus = 2;
+                property.ComplianceStatusThirty = 2;
+                await property.Update(_backendConfigurationPnDbContext).ConfigureAwait(false);
+            }
+            else
+            {
+                if (!_backendConfigurationPnDbContext.Compliances.AsNoTracking().Any(x =>
+                        x.Deadline < DateTime.UtcNow.AddDays(30) && x.PropertyId == property.Id &&
+                        x.WorkflowState != Constants.WorkflowStates.Removed))
+                {
+                    property.ComplianceStatusThirty = 0;
+                    await property.Update(_backendConfigurationPnDbContext).ConfigureAwait(false);
+                }
+
+                if (!_backendConfigurationPnDbContext.Compliances.AsNoTracking().Any(x =>
+                        x.Deadline < DateTime.UtcNow && x.PropertyId == property.Id &&
+                        x.WorkflowState != Constants.WorkflowStates.Removed))
+                {
+                    property.ComplianceStatus = 0;
+                    await property.Update(_backendConfigurationPnDbContext).ConfigureAwait(false);
+                }
+            }
+
+            // Resolve the uid to retract BEFORE returning; the actual CaseDelete is an
+            // external platform call that can block for minutes (dev) — run it
+            // fire-and-forget. Retraction is best-effort today as well (the shared
+            // Update swallows its failures), so guarantees are unchanged.
+            int? microtingUidToRetract = foundCase.MicrotingUid;
+            if (microtingUidToRetract == null)
+            {
+                var checkListSite = await sdkDbContext.CheckListSites
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(x => x.Id == model.Id)
+                    .ConfigureAwait(false);
+                microtingUidToRetract = checkListSite?.MicrotingUid;
+            }
+            if (microtingUidToRetract != null)
+            {
+                var uidToRetract = (int)microtingUidToRetract;
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        var retractionCore = await _coreHelper.GetCore().ConfigureAwait(false);
+                        await retractionCore.CaseDelete(uidToRetract).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.LogException(ex.Message);
+                        Log.LogException(ex.StackTrace);
+                    }
+                });
+            }
+
+            return new OperationResult(true, _localizationService.GetString("CaseHasBeenUpdated"));
+        }
+        catch (Exception ex)
+        {
+            Log.LogException(ex.Message);
+            Log.LogException(ex.StackTrace);
+            return new OperationResult(false, _localizationService.GetString("CaseCouldNotBeUpdated") + $" Exception: {ex.Message}");
+        }
+    }
+
     public async Task<OperationResult> Delete(int id)
     {
         var compliance = await _backendConfigurationPnDbContext.Compliances.FirstOrDefaultAsync(x => x.Id == id).ConfigureAwait(false);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCompliancesService/IBackendConfigurationCompliancesService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCompliancesService/IBackendConfigurationCompliancesService.cs
@@ -39,6 +39,7 @@ public interface IBackendConfigurationCompliancesService
     Task<OperationDataResult<int>> ComplianceStatus(int propertyId);
     Task<OperationDataResult<ReplyElement>> Read(int id);
     Task<OperationResult> Update(ReplyRequest model);
+    Task<OperationResult> UpdateFromCalendar(ReplyRequest model);
     Task<OperationResult> Delete(int id);
     Task<OperationDataResult<CompliancesStatsModel>> Stats();
 }

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/p/calendar-complete.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/p/calendar-complete.spec.ts
@@ -15,52 +15,69 @@ import {
  * Calendar task-completion paths suite for GitHub issue #894.
  *
  * Exercises the completion indicator end-to-end: clicking the `.completion-btn`
- * fires PUT /tasks/{id}/complete; the backend (ToggleComplete in
- * BackendConfigurationCalendarService) then either
+ * fires POST /tasks/{id}/prepare-complete and opens ONE combined modal,
+ * `app-calendar-complete-event-modal` (CalendarCompleteEventModalComponent),
+ * with stable ids `#completeWorkerSelect` / `#completeDoneAt` /
+ * `#completeSaveBtn` / `#completeCancelBtn`. Server-side, `PrepareComplete`
+ * (BackendConfigurationCalendarService) then either
  *   (a) errors "TaskHasNoComplianceCase" when the AreaRule has no EformId, or
- *   (b) returns RequiresForm=true and the UI opens the compliance-case eForm
- *       submission dialog (mat-dialog-container / app-compliance-case-modal), or
- *   (c) completes the SDK case in place (DoneAt = event-start) when the
- *       template has NO mandatory fields.
+ *   (b) resolves (materialising the Compliance row on demand via
+ *       `EnsureComplianceForOccurrenceAsync` if it doesn't exist yet) and the
+ *       modal opens with the case's eForm embedded inline (`app-case-edit-element`
+ *       elements inside the same dialog — there is no separate submission
+ *       dialog anymore).
+ * Saving (`#completeSaveBtn`, gated on a selected worker + doneAt) PUTs the
+ * full reply — including the embedded eForm fields — to
+ * `api/backend-configuration-pn/compliances/cases/calendar`
+ * (`updateCaseFromCalendar`), which both marks the SDK case done and (async,
+ * server-side) retracts the case.
  *
  * REALITY CHECK (drives which rows are real vs. test.fixme):
  *
  *  1. Every event created through the calendar create modal must select an
  *     eForm (`#calendarEventEform` is required and auto-/non-clearable in the
  *     fillAndSaveEvent helper). So a "no-eForm / no-compliance" task (the
- *     TaskHasNoComplianceCase branch — server lines ~2100-2128) CANNOT be
- *     produced via the UI. → X01, X11 are test.fixme.
+ *     TaskHasNoComplianceCase branch) CANNOT be produced via the UI.
+ *     → X01, X11 are test.fixme.
  *
- *  2. The compliance dialog opens ONLY when the backend returns
- *     RequiresForm=true, and that flag is set EXCLUSIVELY when
- *     HasMandatoryFields(template) is true (server lines 2198-2231). In other
- *     words: whenever the dialog appears in e2e, its embedded eForm
- *     (`app-case-edit-element`) by definition contains mandatory fields. The
- *     Save button (`#submit_form`) is gated only on `replyElement.doneAt`
- *     (which is pre-filled), so it is *clickable* — but `saveCase()` submits
- *     the nested eForm reply via `updateCase`, and reliably satisfying
- *     arbitrary mandatory field types (text, picture, signature, …) by
- *     driving the embedded reply UI is impractical and flaky in e2e. So a
- *     FULL completion (form submit → task flips to `completed`) is not
- *     automatable here. → X03, X07, X09, X10 are test.fixme; the reachable
- *     core is "PUT fires + dialog opens" (X06/X04) and the same from the
- *     schedule view (X05).
+ *  2. The combined modal now opens UNCONDITIONALLY on every completion click
+ *     — there is no more "opens a dialog only for mandatory-field templates,
+ *     else completes silently in place" branch in the UI (that used to gate
+ *     on the old ToggleComplete's RequiresForm flag). Every modal opened in
+ *     e2e embeds the seeded task's eForm (`app-case-edit-element`), which
+ *     carries mandatory fields (see calendar-compliance-view.spec.ts's seed
+ *     comment). `#completeSaveBtn` is gated only on
+ *     `selectedWorkerId != null && !!replyElement.doneAt` (both auto-filled
+ *     for a single-worker seed), so it is *clickable* — but `saveCase()`
+ *     submits the nested eForm reply via `updateCaseFromCalendar`, and
+ *     reliably satisfying arbitrary mandatory field types (text, picture,
+ *     signature, …) by driving the embedded reply UI is impractical and
+ *     flaky in e2e. So a FULL completion (save → task flips to `completed`)
+ *     is not automatable here. → X03, X07, X09, X10 are test.fixme; the
+ *     reachable core is "prepare-complete fires + the combined modal opens"
+ *     (X06/X04) and the same from the schedule view (X05).
  *
  *     The in-place no-mandatory-fields completion branch (X02) is likewise
- *     unreachable from the default seed: an eForm with NO mandatory fields
- *     would never set RequiresForm=true, so to hit it the seed would need a
- *     dedicated compliance-enabled, no-mandatory-field template — which the
- *     property/worker seed below does not provision. → X02 is test.fixme.
+ *     unreachable from the default seed: reaching it needs a dedicated
+ *     compliance-enabled, no-mandatory-field template — which the
+ *     property/worker seed below does not provision (and, per the point
+ *     above, wouldn't skip the modal even if it existed — only Save's
+ *     mandatory-field burden would disappear, which still isn't automated
+ *     here). → X02 is test.fixme.
  *
  * Server-side coverage for the branches we cannot reach in e2e lives in
  * BackendConfiguration.Pn.Integration.Test/CalendarCompleteOccurrenceTests.cs
- * (notably GetTasksForWeek_MultiDaySeries_CompleteOneDay_KeepsOtherDays — the
- * X07 dedup-by-(planning,date) regression guard) and CalendarActionableOnlyTests.cs.
+ * and CalendarPrepareCompleteTests.cs (notably
+ * GetTasksForWeek_MultiDaySeries_CompleteOneDay_KeepsOtherDays — the X07
+ * dedup-by-(planning,date) regression guard) and CalendarActionableOnlyTests.cs.
  *
- * The exact PUT matcher used throughout (mirrors L6 in
- * calendar-event-card-layout.spec.ts and the toggleComplete service URL
- * `${Tasks}/${taskId}/complete`):
- *   /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/complete/  (method PUT)
+ * The exact matchers used throughout (mirrors L6 in
+ * calendar-event-card-layout.spec.ts):
+ *   prepare-complete (fires when the modal opens):
+ *     /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/prepare-complete/  (method POST)
+ *   save (fires only on a full #completeSaveBtn submit — not exercised by the
+ *   reachable tests here, see point 2 above):
+ *     /\/api\/backend-configuration-pn\/compliances\/cases\/calendar/  (method PUT)
  *
  * Lives in `r/` to share the matrix slot with the resize / move / edit-scope /
  * copy suites; reuses CalendarUiEnhancementsPage and the same property/worker
@@ -70,14 +87,14 @@ import {
  *   X01 — no-eForm task → TaskHasNoComplianceCase.        [fixme — not creatable via modal]
  *   X02 — non-mandatory eForm completes in place,
  *         DoneAt = event-start.                            [fixme — branch unreachable from seed]
- *   X03 — full completion submits the compliance dialog.   [fixme — eForm submit not automatable]
- *   X04 — completing fires the complete PUT.               [here — folded into X06]
- *   X05 — completion from the schedule view fires the PUT. [here]
- *   X06 — completing a compliance event opens the eForm dialog. [here]
- *   X07 — weekly Mon–Fri series, complete Monday only.     [fixme — needs form submit; server-covered]
- *   X08 — compliance dialog doneAt picker default ≠ blank/now. [here]
+ *   X03 — full completion saves the combined modal.        [fixme — eForm submit not automatable]
+ *   X04 — completing fires the prepare-complete POST.      [here — folded into X06]
+ *   X05 — completion from the schedule view fires the POST. [here]
+ *   X06 — completing a compliance event opens the combined modal. [here]
+ *   X07 — weekly Mon–Fri series, complete Monday only.     [fixme — needs full save; server-covered]
+ *   X08 — combined modal doneAt picker default ≠ blank/now. [here]
  *   X09 — uncomplete not supported.                        [fixme — needs a completed task first]
- *   X10 — future-occurrence materialize on completion.     [fixme — needs form submit]
+ *   X10 — future-occurrence materialize on completion.     [fixme — needs full save]
  *   X11 — complianceId present + EformId=0.                [fixme — not creatable via modal]
  */
 
@@ -98,50 +115,56 @@ const worker: PropertyWorker = {
 
 let seeded = false;
 
-// The completion backend call (PUT .../calendar/tasks/{id}/complete). This is
-// the single canonical matcher used by every test in this suite.
-function isCompletePut(r: import('@playwright/test').Response): boolean {
+// The completion backend call (POST .../calendar/tasks/{id}/prepare-complete)
+// that fires when the combined complete modal opens. This is the single
+// canonical matcher used by every test in this suite.
+function isPrepareComplete(r: import('@playwright/test').Response): boolean {
   return (
-    /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/complete/.test(r.url()) &&
-    r.request().method() === 'PUT'
+    /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/prepare-complete/.test(r.url()) &&
+    r.request().method() === 'POST'
   );
 }
 
-// Close the compliance-case eForm dialog (mat-dialog-container) without
-// submitting — clicks its Cancel/Annuller button, falling back to Escape.
+// Cancel the combined complete-event modal (app-calendar-complete-event-modal)
+// without saving — clicks `#completeCancelBtn`, falling back to Escape.
 async function closeComplianceDialog(page: import('@playwright/test').Page): Promise<void> {
-  const dialog = page.locator('mat-dialog-container').first();
-  if ((await dialog.count()) === 0) return;
-  const cancelBtn = page
-    .locator('mat-dialog-container button')
-    .filter({ hasText: /Annuller|Cancel/i })
-    .first();
+  const modal = page.locator('app-calendar-complete-event-modal').first();
+  if ((await modal.count()) === 0) return;
+  const cancelBtn = page.locator('#completeCancelBtn');
   if ((await cancelBtn.count()) > 0) {
     await cancelBtn.click();
   } else {
     await page.keyboard.press('Escape');
   }
-  await page
-    .locator('mat-dialog-container')
-    .waitFor({ state: 'detached', timeout: 5000 })
-    .catch(() => undefined);
+  await modal.waitFor({ state: 'detached', timeout: 5000 }).catch(() => undefined);
 }
 
-// Confirm the worker-selection modal that ALWAYS appears when completing an
-// event. It lists every worker assigned to the event's property; with exactly
-// one worker (this seed) it opens preselected, otherwise nothing is selected
-// and the confirm button is disabled — in that case explicitly pick the
-// seeded property worker (falling back to the first option) before confirming.
+// Ensure the combined complete-event modal that ALWAYS appears when
+// completing an event has a worker selected. `#completeWorkerSelect` lists
+// every worker assigned to the event's property; with exactly one worker
+// (this seed) it preselects automatically, otherwise nothing is selected and
+// `#completeSaveBtn` stays disabled — in that case explicitly pick the
+// seeded property worker (falling back to the first option).
 async function handleWorkerSelectModal(page: import('@playwright/test').Page): Promise<void> {
-  const workerModal = page.locator('app-calendar-select-worker-modal');
+  const modal = page.locator('app-calendar-complete-event-modal');
   // The modal is part of the completion contract now — fail loudly if it
-  // does not appear instead of silently letting the PUT fire without it.
-  await workerModal.waitFor({ state: 'visible', timeout: 10000 });
-  const confirmBtn = page.locator('app-calendar-select-worker-modal button.btn-primary');
-  if (await confirmBtn.isDisabled()) {
+  // does not appear instead of silently letting the flow proceed without it.
+  await modal.waitFor({ state: 'visible', timeout: 10000 });
+  const workerSelect = page.locator('#completeWorkerSelect');
+  await workerSelect.waitFor({ state: 'visible', timeout: 10000 });
+  // The preselect (single-assignee seed) applies asynchronously once the
+  // linked-sites call resolves — give it a moment before falling back to an
+  // explicit pick.
+  const preselected = await workerSelect
+    .locator('.ng-value-label')
+    .first()
+    .waitFor({ state: 'attached', timeout: 3000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!preselected) {
     // The mtx-select dropdown appends to body, so the options live outside
     // the modal element.
-    await workerModal.locator('mtx-select').click();
+    await workerSelect.click();
     const seededOption = page
       .locator('.ng-dropdown-panel .ng-option')
       .filter({ hasText: `${worker.name} ${worker.surname}` })
@@ -152,8 +175,6 @@ async function handleWorkerSelectModal(page: import('@playwright/test').Page): P
       await page.locator('.ng-dropdown-panel .ng-option').first().click();
     }
   }
-  await confirmBtn.click();
-  await workerModal.waitFor({ state: 'detached', timeout: 5000 }).catch(() => undefined);
 }
 
 test.describe.serial('Calendar task completion (#894)', () => {
@@ -222,17 +243,17 @@ test.describe.serial('Calendar task completion (#894)', () => {
   });
 
   // =======================================================================
-  // X06 / X04 — completing a compliance event fires the complete PUT and
-  //   opens the eForm submission dialog.
+  // X06 / X04 — completing a compliance event fires the prepare-complete
+  //   POST and opens the combined complete modal.
   //
   //   This is the reachable CORE of #894: it proves the completion indicator
-  //   is wired to PUT /tasks/{id}/complete and that a RequiresForm=true
-  //   response opens app-compliance-case-modal. X04 (the PUT fires) is folded
-  //   in — the same waitForResponse asserts it. We do NOT submit the form
-  //   (its mandatory fields make submission impractical — see file header);
-  //   we close the dialog so it does not leak into the next test.
+  //   is wired to POST /tasks/{id}/prepare-complete and opens
+  //   app-calendar-complete-event-modal. X04 (the POST fires) is folded
+  //   in — the same waitForResponse asserts it. We do NOT save the modal
+  //   (its embedded eForm's mandatory fields make submission impractical —
+  //   see file header); we cancel it so it does not leak into the next test.
   // =======================================================================
-  test('X06/X04: completing a compliance event fires the complete PUT and opens the eForm dialog', async ({ page }) => {
+  test('X06/X04: completing a compliance event fires the prepare-complete POST and opens the combined modal', async ({ page }) => {
     const calendarPage = new CalendarUiEnhancementsPage(page);
     const title = `X06-${generateRandmString(5)}`;
 
@@ -243,35 +264,36 @@ test.describe.serial('Calendar task completion (#894)', () => {
     const block = calendarPage.findEventBlock(title);
     await expect(block).toBeVisible();
 
-    const completionWait = page.waitForResponse(isCompletePut, { timeout: 30000 });
+    const completionWait = page.waitForResponse(isPrepareComplete, { timeout: 30000 });
     await block.locator('.completion-btn').click();
-    await handleWorkerSelectModal(page);
     const resp = await completionWait;
+    await handleWorkerSelectModal(page);
 
-    // X04: the PUT fired and was accepted.
-    expect(resp.request().method()).toBe('PUT');
-    expect(resp.url()).toMatch(/\/calendar\/tasks\/\d+\/complete$/);
+    // X04: the POST fired and was accepted.
+    expect(resp.request().method()).toBe('POST');
+    expect(resp.url()).toMatch(/\/calendar\/tasks\/\d+\/prepare-complete$/);
 
-    // X06: the compliance-case eForm dialog opens in response (the seeded
-    // task carries an eForm template WITH mandatory fields → RequiresForm=true).
-    await expect(page.locator('mat-dialog-container').first())
+    // X06: the combined complete modal opens in response (the seeded task
+    // carries an eForm template WITH mandatory fields).
+    await expect(page.locator('app-calendar-complete-event-modal').first())
       .toBeVisible({ timeout: 10000 });
-    await expect(page.locator('app-compliance-case-modal')).toHaveCount(1);
+    await expect(page.locator('#completeSaveBtn')).toHaveCount(1);
 
     await closeComplianceDialog(page);
   });
 
   // =======================================================================
-  // X05 — completion from the SCHEDULE (list) view fires the same complete
-  //   PUT and opens the same dialog.
+  // X05 — completion from the SCHEDULE (list) view fires the same
+  //   prepare-complete POST and opens the same combined modal.
   //
-  //   The schedule row's `.completion-btn` calls onCompletionClick →
-  //   toggleComplete → the SAME PUT /tasks/{id}/complete, and emits
-  //   completeRequiresForm to open app-compliance-case-modal (identical to the
-  //   week-grid path — see calendar-container.html lines 84-85). This proves
-  //   the list view shares the completion plumbing.
+  //   The schedule row's `.completion-btn` emits toggleCompleteRequested →
+  //   onToggleCompleteRequested, which opens the SAME
+  //   app-calendar-complete-event-modal as the week-grid path (identical to
+  //   calendar-container.component.html — both grid and schedule bind
+  //   `(toggleCompleteRequested)="onToggleCompleteRequested($event)"`). This
+  //   proves the list view shares the completion plumbing.
   // =======================================================================
-  test('X05: completion from the schedule view fires the same complete PUT', async ({ page }) => {
+  test('X05: completion from the schedule view fires the same prepare-complete POST', async ({ page }) => {
     const calendarPage = new CalendarUiEnhancementsPage(page);
     const title = `X05-${generateRandmString(5)}`;
 
@@ -284,32 +306,32 @@ test.describe.serial('Calendar task completion (#894)', () => {
     const row = calendarPage.findScheduleItem(title);
     await expect(row).toBeVisible({ timeout: 10000 });
 
-    const completionWait = page.waitForResponse(isCompletePut, { timeout: 30000 });
+    const completionWait = page.waitForResponse(isPrepareComplete, { timeout: 30000 });
     await row.locator('.completion-btn').click();
-    await handleWorkerSelectModal(page);
     const resp = await completionWait;
+    await handleWorkerSelectModal(page);
 
-    // Same PUT as the week-grid path.
-    expect(resp.request().method()).toBe('PUT');
-    expect(resp.url()).toMatch(/\/calendar\/tasks\/\d+\/complete$/);
+    // Same POST as the week-grid path.
+    expect(resp.request().method()).toBe('POST');
+    expect(resp.url()).toMatch(/\/calendar\/tasks\/\d+\/prepare-complete$/);
 
-    // Same dialog opens.
-    await expect(page.locator('mat-dialog-container').first())
+    // Same combined modal opens.
+    await expect(page.locator('app-calendar-complete-event-modal').first())
       .toBeVisible({ timeout: 10000 });
-    await expect(page.locator('app-compliance-case-modal')).toHaveCount(1);
+    await expect(page.locator('#completeSaveBtn')).toHaveCount(1);
 
     await closeComplianceDialog(page);
   });
 
   // =======================================================================
-  // X08 — the compliance dialog's doneAt picker defaults to the event-start,
+  // X08 — the combined modal's doneAt picker defaults to the event-start,
   //   NOT a blank value and NOT the current wall-clock date.
   //
-  //   ComplianceCaseModalComponent.loadCase() sets
+  //   CalendarCompleteEventModalComponent.loadCase() sets
   //     replyElement.doneAt = eventStart ?? deadline ?? new Date()
-  //   and the picker input binds `[value]="replyElement.doneAt"`. The event is
-  //   created on NEXT week (openCreateModalAtSlot advances one week), so the
-  //   scheduled date differs from today — letting us distinguish the
+  //   and `#completeDoneAt` binds `[value]="replyElement.doneAt"`. The event
+  //   is created on NEXT week (openCreateModalAtSlot advances one week), so
+  //   the scheduled date differs from today — letting us distinguish the
   //   event-start default from a naive "now" fallback. The picker is a
   //   mat-datepicker (date-only), so we assert the input is (a) non-empty and
   //   (b) does NOT render today's date — proving doneAt was seeded from the
@@ -322,7 +344,7 @@ test.describe.serial('Calendar task completion (#894)', () => {
   //   server-side in CalendarCompleteOccurrenceTests. Left as a documented
   //   placeholder.
   // =======================================================================
-  test.fixme('X08: compliance dialog doneAt picker defaults to the event date, not blank/now', async ({ page }) => {
+  test.fixme('X08: combined modal doneAt picker defaults to the event date, not blank/now', async ({ page }) => {
     const calendarPage = new CalendarUiEnhancementsPage(page);
     const title = `X08-${generateRandmString(5)}`;
 
@@ -331,23 +353,22 @@ test.describe.serial('Calendar task completion (#894)', () => {
     await calendarPage.fillAndSaveEvent(title);
 
     const block = calendarPage.findEventBlock(title);
-    const completionWait = page.waitForResponse(isCompletePut, { timeout: 30000 });
+    const completionWait = page.waitForResponse(isPrepareComplete, { timeout: 30000 });
     await block.locator('.completion-btn').click();
     await completionWait;
 
-    await expect(page.locator('mat-dialog-container').first())
+    await expect(page.locator('app-calendar-complete-event-modal').first())
       .toBeVisible({ timeout: 10000 });
 
-    // The doneAt picker is the first matInput bound to a matDatepicker inside
-    // the dialog (compliance-case-modal.component.html lines 15-22).
-    const doneAtInput = page
-      .locator('mat-dialog-container input[matInput]')
-      .first();
+    // The doneAt picker is `#completeDoneAt` (calendar-complete-event-modal.
+    // component.html lines 31-40).
+    const doneAtInput = page.locator('#completeDoneAt');
     await expect(doneAtInput).toBeVisible({ timeout: 5000 });
     const value = (await doneAtInput.inputValue()).trim();
 
-    // (a) Not blank — doneAt was pre-filled (Save is `[disabled]="!doneAt"`,
-    //     so a blank value would also block submission).
+    // (a) Not blank — doneAt was pre-filled (`#completeSaveBtn` requires
+    //     `canSave`, which needs `!!replyElement.doneAt`, so a blank value
+    //     would also block submission).
     expect(value.length).toBeGreaterThan(0);
 
     // (b) Not today's wall-clock date. The event lives on next week, so a
@@ -377,21 +398,20 @@ test.describe.serial('Calendar task completion (#894)', () => {
   });
 
   // =======================================================================
-  // X03 — full completion: submit the compliance dialog so the SDK case is
+  // X03 — full completion: save the combined modal so the SDK case is
   //   marked done and the task flips to `completed`.
   //
-  //   fixme rationale: the compliance dialog opens ONLY when the backend
-  //   returns RequiresForm=true, which it does EXCLUSIVELY when the template
-  //   HasMandatoryFields (BackendConfigurationCalendarService lines 2198-2231).
-  //   Therefore every dialog reachable in e2e contains mandatory eForm fields.
-  //   Save (`#submit_form`) is clickable (gated only on the pre-filled doneAt),
-  //   but `saveCase()` submits the nested `app-case-edit-element` reply via
-  //   updateCase; satisfying arbitrary mandatory field types (text, picture,
-  //   signature, dropdown, …) by driving the embedded reply UI is impractical
-  //   and flaky. Full eForm submission is therefore not automatable here.
+  //   fixme rationale: the combined modal now opens on EVERY completion
+  //   click, and the seeded task's template carries mandatory eForm fields
+  //   (see file header point 2). `#completeSaveBtn` is clickable (gated only
+  //   on a selected worker + the pre-filled doneAt), but `saveCase()` submits
+  //   the nested `app-case-edit-element` reply via `updateCaseFromCalendar`;
+  //   satisfying arbitrary mandatory field types (text, picture, signature,
+  //   dropdown, …) by driving the embedded reply UI is impractical and
+  //   flaky. Full eForm submission is therefore not automatable here.
   //   Covered server-side by CalendarCompleteOccurrenceTests.cs.
   // =======================================================================
-  test.fixme('X03: submitting the compliance dialog fully completes the task', async ({ page }) => {
+  test.fixme('X03: saving the combined modal fully completes the task', async ({ page }) => {
     const calendarPage = new CalendarUiEnhancementsPage(page);
     const title = `X03-${generateRandmString(5)}`;
 
@@ -399,17 +419,18 @@ test.describe.serial('Calendar task completion (#894)', () => {
     await calendarPage.fillAndSaveEvent(title);
 
     const block = calendarPage.findEventBlock(title);
-    const completionWait = page.waitForResponse(isCompletePut, { timeout: 30000 });
+    const completionWait = page.waitForResponse(isPrepareComplete, { timeout: 30000 });
     await block.locator('.completion-btn').click();
     await completionWait;
+    await handleWorkerSelectModal(page);
 
-    await expect(page.locator('app-compliance-case-modal')).toHaveCount(1);
+    await expect(page.locator('app-calendar-complete-event-modal')).toHaveCount(1);
 
-    // Intended: fill all mandatory eForm fields, then click Save and await the
-    // updateCase PUT; then assert the block flips to `.completed`.
-    // Not implementable: mandatory field types vary per template and the
-    // embedded reply UI is not reliably drivable in e2e.
-    await page.locator('mat-dialog-container button#submit_form').click();
+    // Intended: fill all mandatory eForm fields, then click #completeSaveBtn
+    // and await the updateCaseFromCalendar PUT; then assert the block flips
+    // to `.completed`. Not implementable: mandatory field types vary per
+    // template and the embedded reply UI is not reliably drivable in e2e.
+    await page.locator('#completeSaveBtn').click();
     await expect(block).toHaveClass(/(^|\s)completed(\s|$)/, { timeout: 10000 });
   });
 
@@ -419,8 +440,8 @@ test.describe.serial('Calendar task completion (#894)', () => {
   //   navigate +1 week and all five present/fresh (dedup-by-(planning,date)
   //   regression guard).
   //
-  //   fixme rationale: completing the Monday occurrence requires SUBMITTING
-  //   the compliance dialog (RequiresForm=true → mandatory fields), which is
+  //   fixme rationale: completing the Monday occurrence requires SAVING the
+  //   combined complete modal (mandatory eForm fields embedded in it), which is
   //   not automatable in e2e (see X03). Without a committed completion the
   //   per-occurrence completed/open state cannot be asserted. This exact
   //   regression — completing ONE day of a multi-day series keeps the other
@@ -454,13 +475,14 @@ test.describe.serial('Calendar task completion (#894)', () => {
     await page.locator('#calendarEventSaveBtn').click();
     await page.waitForTimeout(1500);
 
-    // Intended: complete ONLY the Monday occurrence (submit the dialog), then
+    // Intended: complete ONLY the Monday occurrence (save the combined
+    //   modal), then
     //   - assert Mon shows `.completed` and Tue–Fri the same week stay open,
     //   - navigate +1 week and assert all five weekdays render fresh/open
     //     (no duplicate, no dropped occurrence — the dedup-by-(planning,date)
     //     regression guard).
-    // Not implementable: completing the Monday occurrence requires submitting
-    // the mandatory-field compliance dialog (see X03). Covered server-side by
+    // Not implementable: completing the Monday occurrence requires saving
+    // the mandatory-field combined complete modal (see X03). Covered server-side by
     // CalendarCompleteOccurrenceTests.GetTasksForWeek_MultiDaySeries_CompleteOneDay_KeepsOtherDays.
   });
 
@@ -477,9 +499,10 @@ test.describe.serial('Calendar task completion (#894)', () => {
   // =======================================================================
   test.fixme('X01: completing a no-eForm task returns TaskHasNoComplianceCase', async () => {
     // Intended: create a task whose AreaRule.EformId is null, click complete,
-    // assert the PUT returns success=false with the TaskHasNoComplianceCase
-    // message and NO dialog opens. Not reachable: the create modal force-
-    // selects an eForm, so a no-eForm task cannot exist via the UI.
+    // assert the prepare-complete POST returns success=false with the
+    // TaskHasNoComplianceCase message and the combined modal does NOT open.
+    // Not reachable: the create modal force-selects an eForm, so a no-eForm
+    // task cannot exist via the UI.
   });
 
   // =======================================================================
@@ -495,23 +518,26 @@ test.describe.serial('Calendar task completion (#894)', () => {
   });
 
   // =======================================================================
-  // X02 — a NON-mandatory eForm completes IN PLACE (no dialog), and the SDK
-  //   case DoneAt is set to the event-start (server lines 2233-2243).
+  // X02 — a NON-mandatory eForm's SDK case DoneAt is set to the event-start
+  //   on save (server lines 2233-2243).
   //
-  //   fixme rationale: this branch fires only when HasMandatoryFields is false
-  //   — but in that case the backend NEVER sets RequiresForm=true, so no
-  //   dialog opens and the task completes silently. Reaching it needs a
-  //   compliance-enabled eForm template with NO mandatory fields; the default
-  //   property/worker seed used by this suite provisions no such template (the
-  //   eForms surfaced in `#calendarEventEform` open the dialog, i.e. they HAVE
-  //   mandatory fields), so the requiresForm=false branch is unreachable here.
-  //   Covered server-side by CalendarCompleteOccurrenceTests.cs.
+  //   fixme rationale: the combined complete modal now opens
+  //   UNCONDITIONALLY (see file header point 2), so there is no longer a
+  //   "silent in-place, no dialog" branch to distinguish in the UI — a
+  //   no-mandatory-field template would just make `#completeSaveBtn`
+  //   trivially automatable (no embedded fields to fill). But the default
+  //   property/worker seed used by this suite provisions no such template
+  //   (the eForms surfaced in `#calendarEventEform` all carry mandatory
+  //   fields — see X06/X03), so this remains unreachable from the seed, not
+  //   because of a UI branch. Covered server-side by
+  //   CalendarCompleteOccurrenceTests.cs.
   // =======================================================================
-  test.fixme('X02: a non-mandatory eForm completes in place with DoneAt = event-start', async () => {
-    // Intended: with a no-mandatory-field compliance template, click complete,
-    // assert NO dialog opens, the block flips to `.completed`, and the SDK
-    // case DoneAt equals the scheduled event-start. Not reachable from the
-    // default seed (its templates carry mandatory fields → dialog path).
+  test.fixme('X02: a non-mandatory eForm completes with DoneAt = event-start', async () => {
+    // Intended: with a no-mandatory-field compliance template, click
+    // complete, save the combined modal (trivial — no embedded fields), and
+    // assert the block flips to `.completed` and the SDK case DoneAt equals
+    // the scheduled event-start. Not reachable from the default seed (its
+    // templates all carry mandatory fields).
   });
 
   // =======================================================================
@@ -522,27 +548,32 @@ test.describe.serial('Calendar task completion (#894)', () => {
   //   calendar-task-block.component.html `*ngIf="!task.completed"`), and the
   //   schedule view's onCompletionClick early-returns when `task.completed`.
   //   So uncomplete has no UI affordance — and we cannot even reach a
-  //   completed state without submitting the compliance dialog (see X03).
+  //   completed state without saving the combined complete modal (see X03).
   //   Covered server-side.
   // =======================================================================
   test.fixme('X09: a completed task cannot be un-completed from the calendar', async () => {
     // Intended: fully complete a task (X03 path), then assert there is no
     // enabled completion control to toggle it back open. Not feasible: we
-    // cannot produce a completed task in e2e (form submit, see X03).
+    // cannot produce a completed task in e2e (modal save, see X03).
   });
 
   // =======================================================================
   // X10 — completing a FUTURE occurrence materializes its Compliance row.
   //
-  //   fixme rationale: materialization happens on the completion submit path;
-  //   reaching it requires submitting the compliance dialog for a future
-  //   occurrence (see X03). Not automatable in e2e. Covered server-side
-  //   (the EnsureComplianceForOccurrence path exercised by the calendar
-  //   service tests).
+  //   fixme rationale: materialization now actually happens as soon as the
+  //   combined modal opens — `PrepareComplete` calls
+  //   `EnsureComplianceForOccurrenceAsync` synchronously inside the
+  //   prepare-complete POST (see calendar-compliance-view.spec.ts's seed,
+  //   which already exercises this on-demand-materialize-then-cancel path).
+  //   What remains unautomatable here is asserting the row PERSISTS through
+  //   a full completion (block flips to `.completed`), which needs saving
+  //   the modal — not automatable (see X03). Covered server-side (the
+  //   EnsureComplianceForOccurrence path exercised by the calendar service
+  //   tests).
   // =======================================================================
   test.fixme('X10: completing a future occurrence materializes its compliance row', async () => {
-    // Intended: navigate forward, complete a future occurrence (submit the
-    // dialog), assert the row materialises and persists. Not feasible without
-    // automatable form submission (see X03).
+    // Intended: navigate forward, complete a future occurrence (save the
+    // combined modal), assert the row materialises and persists. Not
+    // feasible without automatable modal-save (see X03).
   });
 });

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-resize-scope.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-resize-scope.spec.ts
@@ -411,13 +411,14 @@ test.describe.serial('Calendar resize scope (#889)', () => {
     // no-op and no /tasks/resize round-trip fires.
     //
     // fixme — same rationale as calendar-move.spec.ts M08: fully completing
-    // an event in e2e requires submitting the eForm dialog (the seeded task's
-    // template opens one); merely opening and closing it leaves the task NOT
-    // completed, so the resize handle stays enabled and the gesture would
-    // succeed. Left as a documented placeholder encoding the intended
-    // behaviour; the completed-occurrence resize rejection is covered
-    // server-side (CalendarResizeTests) and by the handle-hidden /
-    // [cdkDragDisabled] binding for completed tasks.
+    // an event in e2e requires filling + submitting the combined complete
+    // modal's embedded eForm (the seeded task's template opens one); merely
+    // opening and cancelling it leaves the task NOT completed, so the resize
+    // handle stays enabled and the gesture would succeed. Left as a
+    // documented placeholder encoding the intended behaviour; the
+    // completed-occurrence resize rejection is covered server-side
+    // (CalendarResizeTests) and by the handle-hidden / [cdkDragDisabled]
+    // binding for completed tasks.
     // ---------------------------------------------------------------------
     test.fixme('R09: a completed occurrence cannot be resized', async ({ page }) => {
       test.setTimeout(180000);
@@ -431,14 +432,14 @@ test.describe.serial('Calendar resize scope (#889)', () => {
       expect(pre).toContain('09:00');
       expect(pre).toContain('10:00');
 
-      // Trigger the completion flow. The PUT fires and the eForm submission
-      // dialog opens (mirrors M08 in calendar-move.spec.ts). We close the
-      // dialog without submitting — which, as documented above, does NOT
-      // actually complete the task, hence the test.fixme.
+      // Trigger the completion flow. The combined complete modal opens
+      // (mirrors M08 in calendar-move.spec.ts). We cancel it without saving —
+      // which, as documented above, does NOT actually complete the task,
+      // hence the test.fixme.
       const block = calendarPage.findEventBlock(title);
       const completionWait = page.waitForResponse(
-        r => /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/complete/.test(r.url())
-          && r.request().method() === 'PUT',
+        r => /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/prepare-complete/.test(r.url())
+          && r.request().method() === 'POST',
         { timeout: 30000 }
       ).catch(() => undefined);
       const completionBtn = block.locator('.completion-btn');
@@ -446,17 +447,13 @@ test.describe.serial('Calendar resize scope (#889)', () => {
         await completionBtn.click();
         await completionWait;
 
-        const dialog = page.locator('mat-dialog-container').first();
-        if ((await dialog.count()) > 0) {
-          await dialog.waitFor({ state: 'visible', timeout: 10000 }).catch(() => undefined);
-          const cancelBtn = page
-            .locator('mat-dialog-container button')
-            .filter({ hasText: /Annuller|Cancel/i })
-            .first();
+        const modal = page.locator('app-calendar-complete-event-modal').first();
+        if ((await modal.count()) > 0) {
+          await modal.waitFor({ state: 'visible', timeout: 10000 }).catch(() => undefined);
+          const cancelBtn = page.locator('#completeCancelBtn');
           if ((await cancelBtn.count()) > 0) {
             await cancelBtn.click();
-            await page
-              .locator('mat-dialog-container')
+            await modal
               .waitFor({ state: 'detached', timeout: 5000 })
               .catch(() => undefined);
           } else {

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-compliance-view.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-compliance-view.spec.ts
@@ -21,14 +21,15 @@ import {
  * Self-seeded: creates its own property + worker + a single one-off task
  * next week, then MATERIALISES an open Compliance row by clicking the task's
  * `.completion-btn` — the same on-demand path exercised by
- * `p/calendar-complete.spec.ts` (X06/X04): `ToggleComplete` calls
+ * `p/calendar-complete.spec.ts` (X06/X04): `PrepareComplete` calls
  * `IEventDeployService.EnsureComplianceForOccurrenceAsync` synchronously
- * inside the PUT `/tasks/{id}/complete` request whenever no Compliance row
- * exists yet for the occurrence, regardless of how far in the future the
- * date is (BackendConfigurationCalendarService.cs ToggleComplete, ~line
- * 3117-3206). We never submit the compliance-case eForm dialog that pops
- * afterwards (its mandatory fields make submission impractical in e2e, see
- * calendar-complete.spec.ts file header) — cancelling it leaves the
+ * inside the POST `/tasks/{id}/prepare-complete` request that opens the
+ * combined complete modal (`app-calendar-complete-event-modal`) whenever no
+ * Compliance row exists yet for the occurrence, regardless of how far in the
+ * future the date is (BackendConfigurationCalendarService.cs PrepareComplete,
+ * ~line 3389-3512). We never save the modal's embedded eForm (its mandatory
+ * fields make submission impractical in e2e, see calendar-complete.spec.ts
+ * file header) — cancelling it via `#completeCancelBtn` leaves the
  * materialised Compliance row in the OPEN (not completed) state, which is
  * exactly the fixture this suite needs.
  *
@@ -188,14 +189,25 @@ function complianceRowByTitle(page: Page, title: string) {
   return page.locator('.compliance-row').filter({ hasText: title });
 }
 
-// Confirm the worker-selection modal that appears when completing an event
-// (mirrors handleWorkerSelectModal in p/calendar-complete.spec.ts).
+// Ensure the combined complete-event modal (app-calendar-complete-event-modal)
+// that appears when completing an event has a worker selected — mirrors
+// handleWorkerSelectModal in p/calendar-complete.spec.ts.
 async function handleWorkerSelectModal(page: Page): Promise<void> {
-  const workerModal = page.locator('app-calendar-select-worker-modal');
-  await workerModal.waitFor({ state: 'visible', timeout: 10000 });
-  const confirmBtn = page.locator('app-calendar-select-worker-modal button.btn-primary');
-  if (await confirmBtn.isDisabled()) {
-    await workerModal.locator('mtx-select').click();
+  const modal = page.locator('app-calendar-complete-event-modal');
+  await modal.waitFor({ state: 'visible', timeout: 10000 });
+  const workerSelect = page.locator('#completeWorkerSelect');
+  await workerSelect.waitFor({ state: 'visible', timeout: 10000 });
+  // The preselect (single-assignee seed) applies asynchronously once the
+  // linked-sites call resolves — give it a moment before falling back to an
+  // explicit pick.
+  const preselected = await workerSelect
+    .locator('.ng-value-label')
+    .first()
+    .waitFor({ state: 'attached', timeout: 3000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!preselected) {
+    await workerSelect.click();
     const seededOption = page
       .locator('.ng-dropdown-panel .ng-option')
       .filter({ hasText: `${worker.name} ${worker.surname}` })
@@ -206,28 +218,21 @@ async function handleWorkerSelectModal(page: Page): Promise<void> {
       await page.locator('.ng-dropdown-panel .ng-option').first().click();
     }
   }
-  await confirmBtn.click();
-  await workerModal.waitFor({ state: 'detached', timeout: 5000 }).catch(() => undefined);
 }
 
-// Close the compliance-case eForm dialog (mat-dialog-container) without
-// submitting it — mirrors closeComplianceDialog in p/calendar-complete.spec.ts.
+// Cancel the combined complete-event modal without saving — mirrors
+// cancelCompleteModal in p/calendar-complete.spec.ts. Leaves the
+// materialised Compliance row in the OPEN (not completed) state.
 async function closeComplianceCaseDialog(page: Page): Promise<void> {
-  const dialog = page.locator('mat-dialog-container').first();
-  if ((await dialog.count()) === 0) return;
-  const cancelBtn = page
-    .locator('mat-dialog-container button')
-    .filter({ hasText: /Annuller|Cancel/i })
-    .first();
+  const modal = page.locator('app-calendar-complete-event-modal').first();
+  if ((await modal.count()) === 0) return;
+  const cancelBtn = page.locator('#completeCancelBtn');
   if ((await cancelBtn.count()) > 0) {
     await cancelBtn.click();
   } else {
     await page.keyboard.press('Escape');
   }
-  await page
-    .locator('mat-dialog-container')
-    .waitFor({ state: 'detached', timeout: 5000 })
-    .catch(() => undefined);
+  await modal.waitFor({ state: 'detached', timeout: 5000 }).catch(() => undefined);
 }
 
 /**
@@ -357,17 +362,16 @@ test.describe.serial('Calendar Compliance view', () => {
   // Seed 2 — a one-off task next week, materialised into an OPEN Compliance
   // row via the completion-indicator on-demand deploy path.
   //
-  // Whether clicking .completion-btn opens the compliance-case eForm dialog
-  // (RequiresForm=true → row stays OPEN when cancelled) or completes the SDK
-  // case in place (no mandatory fields on the picked template → row is
-  // immediately DONE) depends entirely on which eForm template the
-  // environment's data happens to put first in the #calendarEventEform list
-  // (ToggleComplete → HasMandatoryFields, BackendConfigurationCalendarService.cs
-  // ~line 3253). This is environment seed data, not app behaviour under test,
-  // so rather than hardcode "the first eForm has mandatory fields" (true in
-  // the CI fixture per p/calendar-complete.spec.ts's file header, but not
-  // guaranteed everywhere) we try eForm options in order — one per weekday of
-  // next week — until one actually produces an open row.
+  // Clicking .completion-btn now ALWAYS opens the combined complete modal
+  // (app-calendar-complete-event-modal) — the modal's own POST
+  // /tasks/{id}/prepare-complete materialises the Compliance row server-side
+  // (EnsureComplianceForOccurrenceAsync) unconditionally, regardless of
+  // whether the picked eForm template has mandatory fields. Cancelling the
+  // modal (never saving it) therefore always leaves the row in the OPEN
+  // state — the fixture this suite needs. The eForm-index retry loop below
+  // predates this (it used to matter which eForm produced the RequiresForm
+  // dialog vs. an in-place auto-complete); it is kept as a harmless no-op
+  // safety net since the first attempt now always succeeds.
   // =========================================================================
   test('seed: create a next-week task and materialise an open compliance row', async ({ page }) => {
     test.setTimeout(180000);
@@ -389,30 +393,30 @@ test.describe.serial('Calendar Compliance view', () => {
       await expect(block).toBeVisible();
 
       const completionWait = page.waitForResponse(
-        r => /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/complete/.test(r.url())
-          && r.request().method() === 'PUT',
+        r => /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/prepare-complete/.test(r.url())
+          && r.request().method() === 'POST',
         { timeout: 30000 }
       );
       await block.locator('.completion-btn').click();
-      await handleWorkerSelectModal(page);
       await completionWait;
+      await handleWorkerSelectModal(page);
 
       const opened = await page
-        .locator('app-compliance-case-modal')
+        .locator('app-calendar-complete-event-modal')
         .waitFor({ state: 'visible', timeout: 4000 })
         .then(() => true)
         .catch(() => false);
 
       if (opened) {
-        // RequiresForm=true — cancel WITHOUT submitting so the Compliance row
-        // materialised server-side (EnsureComplianceForOccurrenceAsync) stays
-        // in the OPEN state, which is what this suite needs as its fixture.
+        // Cancel WITHOUT saving so the Compliance row materialised
+        // server-side (EnsureComplianceForOccurrenceAsync) stays in the
+        // OPEN state, which is what this suite needs as its fixture.
         await closeComplianceCaseDialog(page);
         openTitle = title;
         break;
       }
-      // No mandatory fields on this eForm → the task auto-completed in place.
-      // Discard it (harmless leftover DONE row) and try the next eForm option.
+      // Not expected to happen now that the modal always opens, but kept as
+      // a defensive fallback — try the next eForm option.
     }
 
     expect(

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/s/calendar-move.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/s/calendar-move.spec.ts
@@ -552,27 +552,29 @@ test.describe.serial('Calendar drag-move scope (#887)', () => {
     // cdkDrag handle is inert — a mouse-drag on its body produces no move.
     //
     // WEAKENED — read before changing the assertion:
-    // Fully completing an event in e2e opens the eForm submission dialog
-    // (the seeded task carries an eForm template — see L6 in
-    // calendar-event-card-layout.spec.ts) and submitting that form is
-    // impractical/flaky here. So we do NOT drive a full completion. Instead
-    // we trigger the completion button (PUT /tasks/{id}/complete fires and
-    // the eForm dialog opens — same as L6), close the dialog, then attempt a
-    // drag and assert the robust invariant: NO /tasks/move POST fires and
-    // the block stays on its original slot. If the optimistic UI does not
-    // flip the block to completed before the form is submitted (so cdkDrag
-    // is still enabled), the drag could still succeed; to keep the test
-    // deterministic and non-flaky we treat the "no move POST" + "still on
-    // original slot" as the asserted invariant and DOCUMENT that a fully
-    // committed-completed move-block is covered server-side
-    // (CalendarMoveTests.cs rejects a move on a completed occurrence).
+    // Fully completing an event in e2e opens the combined complete modal
+    // (app-calendar-complete-event-modal, the seeded task carries an eForm
+    // template — see L6 in calendar-event-card-layout.spec.ts) and filling +
+    // submitting its embedded eForm is impractical/flaky here. So we do NOT
+    // drive a full completion. Instead we trigger the completion button (the
+    // prepare-complete POST fires and the modal opens — same as L6), cancel
+    // it, then attempt a drag and assert the robust invariant: NO
+    // /tasks/move POST fires and the block stays on its original slot. If
+    // the optimistic UI does not flip the block to completed before the form
+    // is submitted (so cdkDrag is still enabled), the drag could still
+    // succeed; to keep the test deterministic and non-flaky we treat the "no
+    // move POST" + "still on original slot" as the asserted invariant and
+    // DOCUMENT that a fully committed-completed move-block is covered
+    // server-side (CalendarMoveTests.cs rejects a move on a completed
+    // occurrence).
     // ---------------------------------------------------------------------
-    // fixme: fully completing an event in e2e requires submitting the eForm
-    // dialog (the seeded task's template opens one — see L6); merely opening
-    // and closing it leaves the task NOT completed, so cdkDrag stays enabled
-    // and the drag would succeed. Left as a documented placeholder; the
-    // completed-occurrence move rejection is covered server-side
-    // (CalendarMoveTests) and by the [cdkDragDisabled]="task.completed" binding.
+    // fixme: fully completing an event in e2e requires filling + submitting
+    // the combined complete modal's embedded eForm (the seeded task's
+    // template opens one — see L6); merely opening and cancelling it leaves
+    // the task NOT completed, so cdkDrag stays enabled and the drag would
+    // succeed. Left as a documented placeholder; the completed-occurrence
+    // move rejection is covered server-side (CalendarMoveTests) and by the
+    // [cdkDragDisabled]="task.completed" binding.
     test.fixme('M08: a completed occurrence cannot be dragged (best-effort)', async ({ page }) => {
       test.setTimeout(180000);
       const calendarPage = new CalendarUiEnhancementsPage(page);
@@ -583,12 +585,13 @@ test.describe.serial('Calendar drag-move scope (#887)', () => {
       await createSimpleEvent(page, calendarPage, title, dayX, 9);
       expect(await calendarPage.getEventDayIndex(title)).toBe(dayX);
 
-      // Trigger the completion flow. The PUT fires and the eForm submission
-      // dialog opens (mirrors L6). We close the dialog without submitting.
+      // Trigger the completion flow. The prepare-complete POST fires and the
+      // combined complete modal opens (mirrors L6). We cancel it without
+      // saving.
       const block = calendarPage.findEventBlock(title);
       const completionWait = page.waitForResponse(
-        r => /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/complete/.test(r.url())
-          && r.request().method() === 'PUT',
+        r => /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/prepare-complete/.test(r.url())
+          && r.request().method() === 'POST',
         { timeout: 30000 }
       ).catch(() => undefined);
       const completionBtn = block.locator('.completion-btn');
@@ -596,18 +599,14 @@ test.describe.serial('Calendar drag-move scope (#887)', () => {
         await completionBtn.click();
         await completionWait;
 
-        // Close any eForm submission dialog so it doesn't intercept the drag.
-        const dialog = page.locator('mat-dialog-container').first();
-        if ((await dialog.count()) > 0) {
-          await dialog.waitFor({ state: 'visible', timeout: 10000 }).catch(() => undefined);
-          const cancelBtn = page
-            .locator('mat-dialog-container button')
-            .filter({ hasText: /Annuller|Cancel/i })
-            .first();
+        // Cancel the complete modal so it doesn't intercept the drag.
+        const modal = page.locator('app-calendar-complete-event-modal').first();
+        if ((await modal.count()) > 0) {
+          await modal.waitFor({ state: 'visible', timeout: 10000 }).catch(() => undefined);
+          const cancelBtn = page.locator('#completeCancelBtn');
           if ((await cancelBtn.count()) > 0) {
             await cancelBtn.click();
-            await page
-              .locator('mat-dialog-container')
+            await modal
               .waitFor({ state: 'detached', timeout: 5000 })
               .catch(() => undefined);
           } else {

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-event-card-layout.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-event-card-layout.spec.ts
@@ -39,21 +39,31 @@ const worker: PropertyWorker = {
 
 let seeded = false;
 
-// Confirm the worker-selection modal that ALWAYS appears when completing an
-// event. It lists every worker assigned to the event's property; with exactly
-// one worker (this seed) it opens preselected, otherwise nothing is selected
-// and the confirm button is disabled — in that case explicitly pick the
-// seeded property worker (falling back to the first option) before confirming.
+// Ensure the combined complete-event modal (app-calendar-complete-event-modal)
+// that ALWAYS appears when completing an event has a worker selected. With
+// exactly one worker assigned (this seed) `#completeWorkerSelect` preselects
+// it automatically; otherwise explicitly pick the seeded property worker
+// (falling back to the first option) so `#completeSaveBtn` can become enabled.
 async function handleWorkerSelectModal(page: import('@playwright/test').Page): Promise<void> {
-  const workerModal = page.locator('app-calendar-select-worker-modal');
+  const modal = page.locator('app-calendar-complete-event-modal');
   // The modal is part of the completion contract now — fail loudly if it
-  // does not appear instead of silently letting the PUT fire without it.
-  await workerModal.waitFor({ state: 'visible', timeout: 10000 });
-  const confirmBtn = page.locator('app-calendar-select-worker-modal button.btn-primary');
-  if (await confirmBtn.isDisabled()) {
+  // does not appear instead of silently letting completion proceed without it.
+  await modal.waitFor({ state: 'visible', timeout: 10000 });
+  const workerSelect = page.locator('#completeWorkerSelect');
+  await workerSelect.waitFor({ state: 'visible', timeout: 10000 });
+  // The preselect (single-assignee seed) applies asynchronously once the
+  // linked-sites call resolves — give it a moment before falling back to an
+  // explicit pick.
+  const preselected = await workerSelect
+    .locator('.ng-value-label')
+    .first()
+    .waitFor({ state: 'attached', timeout: 3000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!preselected) {
     // The mtx-select dropdown appends to body, so the options live outside
     // the modal element.
-    await workerModal.locator('mtx-select').click();
+    await workerSelect.click();
     const seededOption = page
       .locator('.ng-dropdown-panel .ng-option')
       .filter({ hasText: `${worker.name} ${worker.surname}` })
@@ -64,8 +74,6 @@ async function handleWorkerSelectModal(page: import('@playwright/test').Page): P
       await page.locator('.ng-dropdown-panel .ng-option').first().click();
     }
   }
-  await confirmBtn.click();
-  await workerModal.waitFor({ state: 'detached', timeout: 5000 }).catch(() => undefined);
 }
 
 test.describe.serial('Calendar event card — adaptive layout', () => {
@@ -292,11 +300,12 @@ test.describe.serial('Calendar event card — adaptive layout', () => {
   // =======================================================================
   // L6. The 12-px completion circle on a compact card is still a reachable
   //     click target. We assert the click triggers the completion flow —
-  //     PUT /tasks/{id}/complete fires and the eForm submission dialog
-  //     opens. The actual `completed` class transition requires submitting
-  //     that form (the seeded task has an associated eForm template),
-  //     which is out of scope for the layout suite — what matters here is
-  //     that the shrunken hit target still receives the click.
+  //     the prepare-complete POST fires and the combined complete modal
+  //     (app-calendar-complete-event-modal, with its embedded eForm) opens.
+  //     The actual `completed` class transition requires saving that modal
+  //     (the seeded task has an associated eForm template), which is out of
+  //     scope for the layout suite — what matters here is that the shrunken
+  //     hit target still receives the click.
   // =======================================================================
   test('L6: completion button is clickable on compact card', async ({ page }) => {
     const calendarPage = new CalendarUiEnhancementsPage(page);
@@ -311,30 +320,27 @@ test.describe.serial('Calendar event card — adaptive layout', () => {
     await expect(block).toHaveClass(/(^|\s)compact(\s|$)/);
 
     const completionWait = page.waitForResponse(
-      r => /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/complete/.test(r.url())
-        && r.request().method() === 'PUT',
+      r => /\/api\/backend-configuration-pn\/calendar\/tasks\/\d+\/prepare-complete/.test(r.url())
+        && r.request().method() === 'POST',
       { timeout: 30000 }
     );
     await block.locator('.completion-btn').click();
-    await handleWorkerSelectModal(page);
     await completionWait;
+    await handleWorkerSelectModal(page);
 
-    // The eForm submission dialog opens in response to the PUT (the seeded
-    // task carries an eForm template). The dialog's mere appearance proves
+    // The combined complete modal opens in response to the click (the seeded
+    // task carries an eForm template). The modal's mere appearance proves
     // the click landed and the completion workflow kicked off; we don't
-    // need to submit the form here.
-    await expect(page.locator('mat-dialog-container').first())
+    // need to save it here.
+    await expect(page.locator('app-calendar-complete-event-modal').first())
       .toBeVisible({ timeout: 10000 });
 
-    // Cancel so the dialog doesn't leak into the next test.
-    const cancelBtn = page
-      .locator('mat-dialog-container button')
-      .filter({ hasText: /Annuller|Cancel/i })
-      .first();
+    // Cancel so the modal doesn't leak into the next test.
+    const cancelBtn = page.locator('#completeCancelBtn');
     if ((await cancelBtn.count()) > 0) {
       await cancelBtn.click();
       await page
-        .locator('mat-dialog-container')
+        .locator('app-calendar-complete-event-modal')
         .waitFor({ state: 'detached', timeout: 5000 })
         .catch(() => undefined);
     }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -547,4 +547,5 @@ export const bgBG = {
   Employees: 'Служители',
   At: 'В',
   'Time of day': 'Време на деня',
+  'Done date': 'Дата на завършване',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -547,4 +547,5 @@ export const csCZ = {
   Employees: 'Zaměstnanci',
   At: 'Na',
   'Time of day': 'Denní doba',
+  'Done date': 'Datum dokončení',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -548,4 +548,5 @@ export const da = {
   Employees: 'Medarbejdere',
   At: 'Kl.',
   'Time of day': 'Tidspunkt',
+  'Done date': 'Udført dato',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -596,4 +596,5 @@ export const deDE = {
   Employees: 'Mitarbeiter',
   At: 'Bei',
   'Time of day': 'Uhrzeit',
+  'Done date': 'Fertigstellungsdatum',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -547,4 +547,5 @@ export const elGR = {
   Employees: 'Υπάλληλοι',
   At: 'Στο',
   'Time of day': 'Ώρα της ημέρας',
+  'Done date': 'Ημερομηνία ολοκλήρωσης',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -513,6 +513,7 @@ export const enUS= {
   Confirm: 'Confirm',
   'Save changes': 'Save changes',
   'Complete task': 'Complete task',
+  'Done date': 'Done date',
   'Only this': 'Only this',
   'This and following': 'This and following',
   'This and following (incl. completed)': 'This and following (incl. completed)',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -547,4 +547,5 @@ export const esES = {
   Employees: 'Empleados',
   At: 'En',
   'Time of day': 'Hora del día',
+  'Done date': 'Fecha de finalización',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -547,4 +547,5 @@ export const etET = {
   Employees: 'Töötajad',
   At: 'Kell',
   'Time of day': 'Kellaaeg',
+  'Done date': 'Valmis kuupäev',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -547,4 +547,5 @@ export const fiFI = {
   Employees: 'Työntekijät',
   At: 'Klo',
   'Time of day': 'Kellonaika',
+  'Done date': 'Valmistumispäivämäärä',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -546,4 +546,5 @@ export const frFR = {
   Employees: 'Employés',
   At: 'À',
   'Time of day': 'Heure de la journée',
+  'Done date': 'Date de réalisation',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -547,4 +547,5 @@ export const hrHR = {
   Employees: 'Zaposlenici',
   At: 'Na',
   'Time of day': 'Doba dana',
+  'Done date': 'Datum završetka',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -547,4 +547,5 @@ export const huHU = {
   Employees: 'Alkalmazottak',
   At: 'At',
   'Time of day': 'Napszak',
+  'Done date': 'Kész dátum',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -547,4 +547,5 @@ export const isIS = {
   Employees: 'Starfsmenn',
   At: 'Á',
   'Time of day': 'Tími dags',
+  'Done date': 'Lokadagur',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -547,4 +547,5 @@ export const itIT = {
   Employees: 'Dipendenti',
   At: 'A',
   'Time of day': 'ora del giorno',
+  'Done date': 'Data di completamento',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -547,4 +547,5 @@ export const ltLT = {
   Employees: 'Darbuotojai',
   At: 'Prie',
   'Time of day': 'Paros laikas',
+  'Done date': 'Atlikimo data',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -547,4 +547,5 @@ export const lvLV = {
   Employees: 'Darbinieki',
   At: 'Plkst.',
   'Time of day': 'Dienas laiks',
+  'Done date': 'Pabeigšanas datums',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -547,4 +547,5 @@ export const nlNL = {
   Employees: 'Medewerkers',
   At: 'Bij',
   'Time of day': 'Tijdstip van de dag',
+  'Done date': 'Voltooiingsdatum',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -547,4 +547,5 @@ export const noNO = {
   Employees: 'Ansatte',
   At: 'På',
   'Time of day': 'Tid på dagen',
+  'Done date': 'Ferdigdato',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -547,4 +547,5 @@ export const plPL = {
   Employees: 'Pracownicy',
   At: 'Na ',
   'Time of day': 'Pora dnia',
+  'Done date': 'Data wykonania',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -547,4 +547,5 @@ export const ptBR = {
   Employees: 'Funcionários',
   At: 'No',
   'Time of day': 'Hora do dia',
+  'Done date': 'Data de conclusão',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -547,4 +547,5 @@ export const ptPT = {
   Employees: 'Funcionários',
   At: 'No',
   'Time of day': 'Hora do dia',
+  'Done date': 'Data de conclusão',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -547,4 +547,5 @@ export const roRO = {
   Employees: 'Angajați',
   At: 'La',
   'Time of day': 'Momentul zilei',
+  'Done date': 'Data finalizării',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -547,4 +547,5 @@ export const skSK = {
   Employees: 'Zamestnanci',
   At: 'O',
   'Time of day': 'Denný čas',
+  'Done date': 'Dátum dokončenia',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -547,4 +547,5 @@ export const slSL = {
   Employees: 'Zaposleni',
   At: 'Ob',
   'Time of day': 'Čas dneva',
+  'Done date': 'Datum zaključka',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -547,4 +547,5 @@ export const svSE = {
   Employees: 'Anställda',
   At: 'På',
   'Time of day': 'Tid på dagen',
+  'Done date': 'Klardatum',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -547,4 +547,5 @@ export const ukUA = {
   Employees: 'Співробітники',
   At: 'О',
   'Time of day': 'Час доби',
+  'Done date': 'Дата виконання',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-prepare-complete.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-prepare-complete.model.ts
@@ -1,0 +1,9 @@
+export interface CalendarPrepareCompleteResult {
+  sdkCaseId: number;
+  templateId: number | null;
+  propertyId: number;
+  complianceId: number;
+  assignedSiteId: number | null;
+  deadline: string;
+  eventStart: string;
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/index.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/index.ts
@@ -4,3 +4,4 @@ export * from './repeat-rule.model';
 export * from './calendar-task-request.model';
 export * from './google-drive-status.model';
 export * from './calendar-compliance-report.model';
+export * from './calendar-prepare-complete.model';

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/calendar.module.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/calendar.module.ts
@@ -58,6 +58,7 @@ import {
   BoardDeleteModalComponent,
   ComplianceCaseModalComponent,
   CalendarSelectWorkerModalComponent,
+  CalendarCompleteEventModalComponent,
 } from './modals';
 
 // Re-export modal components for barrel
@@ -71,6 +72,7 @@ export {
   BoardDeleteModalComponent,
   ComplianceCaseModalComponent,
   CalendarSelectWorkerModalComponent,
+  CalendarCompleteEventModalComponent,
 };
 
 @NgModule({
@@ -95,6 +97,7 @@ export {
     BoardDeleteModalComponent,
     ComplianceCaseModalComponent,
     CalendarSelectWorkerModalComponent,
+    CalendarCompleteEventModalComponent,
     TeamCreateDialogComponent,
     TeamDeleteDialogComponent,
     TagCreateDialogComponent,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -36,6 +36,7 @@ import {CalendarSelectWorkerModalComponent} from '../../modals';
 import {dialogConfigHelper} from 'src/app/common/helpers';
 import {RepeatEditScope} from '../../../../models/calendar';
 import {CalendarComplianceViewComponent} from '../calendar-compliance-view/calendar-compliance-view.component';
+import {CalendarCompleteEventModalComponent, CalendarCompleteEventModalData} from '../../modals/calendar-complete-event-modal/calendar-complete-event-modal.component';
 
 @Component({
   standalone: false,
@@ -650,6 +651,7 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       complianceId: row.complianceId,
       taskDate: row.taskDate,
       propertyId: row.propertyId,
+      assigneeIds: [],
     } as CalendarTaskLayoutModel);
   }
 
@@ -662,50 +664,24 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
   }
 
   async onToggleCompleteRequested(task: CalendarTaskLayoutModel) {
-    // ALWAYS ask who completed the event — even when the task has a single
-    // assignee or none at all — so the completion is explicitly attributed.
-    // The list is ALL workers assigned to the event's PROPERTY (not just the
-    // task-assigned subset), sorted alphabetically by name.
-    // getLinkedSites(propertyId, false) returns exactly the property's
-    // non-removed PropertyWorkers as CommonDictionaryModel ({id, name,
-    // languageId}) — the shape the modal's `sites` input expects. compliance
-    // must be FALSE here: true appends the calling user's own SDK site, which
-    // EventDeployService's leak guard (#932/#1377) rejects on the on-demand
-    // completion path when that user is not a property worker. Locale-aware
-    // 'da' sort so Danish characters (æ/ø/å) order correctly; copy the array
-    // first (no in-place mutation of the service response).
-    const linked = await firstValueFrom(
-      this.propertiesService.getLinkedSites(task.propertyId, false),
-    );
-    if (!linked?.success || !linked.model) return;
-    const sites: CommonDictionaryModel[] =
-      [...linked.model].sort((a, b) => a.name.localeCompare(b.name, 'da'));
-
-    const ref = this.dialog.open(CalendarSelectWorkerModalComponent, {
-      minWidth: '400px',
+    if (task.completed) { return; }
+    const ref = this.dialog.open(CalendarCompleteEventModalComponent, {
+      data: {
+        taskId: task.id,
+        complianceId: task.complianceId ?? null,
+        occurrenceDate: task.taskDate,
+        propertyId: task.propertyId,
+        assigneeIds: task.assigneeIds ?? [],
+      } as CalendarCompleteEventModalData,
+      width: 'min(90vw, 1080px)',
+      maxWidth: '95vw',
       autoFocus: false,
+      restoreFocus: false,
     });
-    const instance = ref.componentInstance;
-    instance.sites = sites;
-    if (sites.length === 1) {
-      instance.selectedSite = sites[0];
+    const result = await firstValueFrom(ref.afterClosed());
+    if (result?.saved) {
+      this.reloadAfterCompletion();
     }
-
-    const selected: CommonDictionaryModel | null = await firstValueFrom(ref.afterClosed());
-    if (!selected) return;
-
-    const selectedWorkerId = selected.id;
-
-    this.calendarService
-      .toggleComplete(task.id, !task.completed, task.complianceId, task.taskDate, selectedWorkerId)
-      .subscribe(res => {
-        if (!res?.success) return;
-        if (res.model?.requiresForm) {
-          this.onCompleteRequiresForm(res.model);
-          return;
-        }
-        this.reloadAfterCompletion();
-      });
   }
 
   onTaskClickedFromGrid(event: {task: CalendarTaskLayoutModel; cellLeft: number; cellRight: number; slotTop: number}) {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-complete-event-modal/calendar-complete-event-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-complete-event-modal/calendar-complete-event-modal.component.html
@@ -1,0 +1,85 @@
+<h2 mat-dialog-title>{{ replyElement?.label || ('Complete task' | translate) }}</h2>
+
+<mat-dialog-content class="calendar-complete-event-modal__content">
+  <div class="d-flex flex-row justify-content-between">
+    <div class="flex-grow-1 mr-4 d-flex flex-column">
+      <mat-card class="mb-4">
+        <mat-card-title>{{ 'Select worker' | translate }}</mat-card-title>
+        <mat-card-content>
+          <div class="text-field--rounded">
+            <mat-form-field>
+              <mtx-select
+                [items]="sites"
+                bindValue="id"
+                bindLabel="name"
+                [(ngModel)]="selectedWorkerId"
+                [clearable]="false"
+                [placeholder]="'Select worker' | translate"
+                id="completeWorkerSelect"
+              ></mtx-select>
+            </mat-form-field>
+          </div>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card class="mb-4">
+        <mat-card-title>{{ 'Done date' | translate }}</mat-card-title>
+        <mat-card-content>
+          <mat-form-field>
+            <mat-label>{{ 'Select date' | translate }}</mat-label>
+            <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+            <input
+              required
+              matInput
+              [matDatepicker]="picker"
+              [max]="maxDate"
+              [value]="replyElement.doneAt"
+              (dateChange)="replyElement.doneAt = $event.value"
+              (click)="picker.open()"
+              id="completeDoneAt"
+            >
+            <mat-datepicker #picker></mat-datepicker>
+            <mat-error class="text-warn" *ngIf="!replyElement.doneAt">
+              {{ 'Date is required' | translate }}*
+            </mat-error>
+          </mat-form-field>
+        </mat-card-content>
+      </mat-card>
+
+      <app-case-edit-element
+        [element]="elem"
+        *ngFor="let elem of replyElement.elementList"
+        (needUpdate)="partialLoadCase()"
+      ></app-case-edit-element>
+    </div>
+
+    <div class="calendar-complete-event-modal__nav" *ngIf="replyElement?.elementList?.length">
+      <mat-card>
+        <mat-card-content style="max-height: 50vh; overflow: auto;">
+          <div *ngFor="let element of replyElement.elementList" style="cursor: pointer">
+            <a mat-button (click)="goToSection('#section' + element.id)" class="d-flex w-100">
+              {{ element.label }}
+            </a>
+            <ng-container *ngIf="element.elementList">
+              <app-case-edit-nav [element]="element"></app-case-edit-nav>
+            </ng-container>
+          </div>
+        </mat-card-content>
+      </mat-card>
+    </div>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()" [disabled]="isSaving" id="completeCancelBtn">
+    {{ 'Cancel' | translate }}
+  </button>
+  <button
+    class="btn-primary btn-primary--icon-left"
+    (click)="saveCase()"
+    [disabled]="!canSave"
+    id="completeSaveBtn"
+  >
+    {{ 'Save' | translate }}
+  </button>
+</mat-dialog-actions>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-complete-event-modal/calendar-complete-event-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-complete-event-modal/calendar-complete-event-modal.component.scss
@@ -1,0 +1,11 @@
+.calendar-complete-event-modal {
+  &__content {
+    min-width: min(90vw, 960px);
+    max-height: 75vh;
+  }
+
+  &__nav {
+    flex-shrink: 0;
+    width: 240px;
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-complete-event-modal/calendar-complete-event-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-complete-event-modal/calendar-complete-event-modal.component.ts
@@ -1,0 +1,212 @@
+import {
+  Component, Inject, OnInit, QueryList, ViewChildren, inject,
+} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {EFormService} from 'src/app/common/services';
+import {
+  TemplateDto, CaseEditRequest, ReplyElementDto, ReplyRequest,
+  ElementDto, DataItemDto, CommonDictionaryModel,
+} from 'src/app/common/models';
+import {CaseEditElementComponent} from 'src/app/common/modules/eform-cases/components';
+import {
+  BackendConfigurationPnCompliancesService,
+  BackendConfigurationPnCalendarService,
+  BackendConfigurationPnPropertiesService,
+} from '../../../../services';
+import {CalendarPrepareCompleteResult} from '../../../../models';
+import {parseISO} from 'date-fns';
+import * as R from 'ramda';
+
+export interface CalendarCompleteEventModalData {
+  taskId: number;
+  complianceId: number | null;
+  occurrenceDate: string;
+  propertyId: number;
+  assigneeIds: number[];
+}
+
+@Component({
+  selector: 'app-calendar-complete-event-modal',
+  templateUrl: './calendar-complete-event-modal.component.html',
+  styleUrls: ['./calendar-complete-event-modal.component.scss'],
+  standalone: false,
+})
+export class CalendarCompleteEventModalComponent implements OnInit {
+  private dialogRef = inject(MatDialogRef<CalendarCompleteEventModalComponent>);
+  private compliancesService = inject(BackendConfigurationPnCompliancesService);
+  private calendarService = inject(BackendConfigurationPnCalendarService);
+  private propertiesService = inject(BackendConfigurationPnPropertiesService);
+  private eFormService = inject(EFormService);
+
+  @ViewChildren(CaseEditElementComponent)
+  editElements: QueryList<CaseEditElementComponent>;
+
+  sites: CommonDictionaryModel[] = [];
+  selectedWorkerId: number | null = null;
+
+  prepared: CalendarPrepareCompleteResult | null = null;
+  currenteForm: TemplateDto = new TemplateDto();
+  replyElement: ReplyElementDto = new ReplyElementDto();
+  maxDate = new Date();
+  loading = true;
+  isSaving = false;
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: CalendarCompleteEventModalData) {}
+
+  ngOnInit() {
+    // Workers and prepare run in parallel; the case loads once prepare returns.
+    this.propertiesService.getLinkedSites(this.data.propertyId, false).subscribe(res => {
+      if (!res?.success || !res.model) { return; }
+      this.sites = [...res.model].sort((a, b) => a.name.localeCompare(b.name, 'da'));
+      this.applyPreselect();
+    });
+    this.calendarService
+      .prepareComplete(this.data.taskId, this.data.complianceId, this.data.occurrenceDate)
+      .subscribe({
+        next: res => {
+          if (!res?.success || !res.model) { this.dialogRef.close({saved: false}); return; }
+          this.prepared = res.model;
+          this.applyPreselect();
+          this.loadTemplateInfo();
+        },
+        error: () => this.dialogRef.close({saved: false}),
+      });
+  }
+
+  // Preselect: the event's single assigned worker when there is exactly one,
+  // else the site the case is deployed to — but only when that site is in the
+  // property-workers list. Multi-assignee events stay unselected (explicit pick).
+  private applyPreselect() {
+    if (this.selectedWorkerId != null || this.sites.length === 0) { return; }
+    if (this.data.assigneeIds?.length === 1
+        && this.sites.some(s => s.id === this.data.assigneeIds[0])) {
+      this.selectedWorkerId = this.data.assigneeIds[0];
+      return;
+    }
+    if (this.data.assigneeIds?.length > 1) { return; }
+    const assigned = this.prepared?.assignedSiteId;
+    if (assigned != null && this.sites.some(s => s.id === assigned)) {
+      this.selectedWorkerId = assigned;
+    }
+  }
+
+  get canSave(): boolean {
+    return !this.isSaving && !this.loading
+      && this.selectedWorkerId != null && !!this.replyElement.doneAt;
+  }
+
+  private loadTemplateInfo() {
+    const templateId = this.prepared?.templateId;
+    if (!templateId) { this.dialogRef.close({saved: false}); return; }
+    this.eFormService.getSingle(templateId).subscribe(op => {
+      if (op && op.success) {
+        this.currenteForm = op.model;
+        this.loadCase();
+      } else {
+        this.dialogRef.close({saved: false});
+      }
+    });
+  }
+
+  private loadCase() {
+    const id = this.prepared?.sdkCaseId;
+    if (!id) { this.dialogRef.close({saved: false}); return; }
+    this.compliancesService.getCase(id, this.currenteForm.id).subscribe(op => {
+      if (op && op.success) {
+        this.replyElement = op.model;
+        const defaultDoneAt =
+          this.toDate(this.prepared?.eventStart) ?? this.toDate(this.prepared?.deadline) ?? new Date();
+        // Completing a future occurrence early: clamp the default into the
+        // datepicker's allowed range (max = today) so the pre-filled value is valid.
+        this.replyElement.doneAt = defaultDoneAt > this.maxDate ? new Date() : defaultDoneAt;
+        this.loading = false;
+      } else {
+        this.dialogRef.close({saved: false});
+      }
+    });
+  }
+
+  private toDate(value: string | Date | undefined | null): Date | null {
+    if (value == null) { return null; }
+    if (value instanceof Date) { return value; }
+    if (typeof value === 'string' && value.length > 0) { return parseISO(value); }
+    return null;
+  }
+
+  saveCase() {
+    if (!this.canSave || !this.prepared) { return; }
+    const requestModels: Array<CaseEditRequest> = [];
+    this.editElements.forEach(x => {
+      x.extractData();
+      requestModels.push(x.requestModel);
+    });
+    const replyRequest = new ReplyRequest();
+    replyRequest.id = this.prepared.sdkCaseId;
+    replyRequest.label = this.replyElement.label;
+    replyRequest.elementList = requestModels;
+    replyRequest.doneAt = this.replyElement.doneAt;
+    replyRequest.extraId = this.prepared.complianceId;
+    replyRequest.siteId = this.selectedWorkerId;
+    this.isSaving = true;
+    this.compliancesService.updateCaseFromCalendar(replyRequest, this.currenteForm.id).subscribe({
+      next: op => {
+        this.isSaving = false;
+        if (op && op.success) { this.dialogRef.close({saved: true}); }
+      },
+      error: () => { this.isSaving = false; },
+    });
+  }
+
+  cancel() {
+    this.dialogRef.close({saved: false});
+  }
+
+  goToSection(location: string): void {
+    setTimeout(() => {
+      const target = document.querySelector(location) as HTMLElement | null;
+      target?.parentElement?.scrollIntoView({behavior: 'smooth'});
+    });
+  }
+
+  partialLoadCase() {
+    const id = this.prepared?.sdkCaseId;
+    if (!id) { return; }
+    this.compliancesService.getCase(id, this.currenteForm.id).subscribe(op => {
+      if (op && op.success) {
+        const fn = (pathForLens: Array<number | string>) => {
+          const lens = R.lensPath(pathForLens);
+          let dataItem: (ElementDto | DataItemDto) = R.view(lens, op.model);
+          // @ts-ignore
+          if (dataItem.elementList !== undefined || dataItem.dataItemList !== undefined) {
+            dataItem = dataItem as ElementDto;
+            if (dataItem.elementList) {
+              for (let i = 0; i < dataItem.elementList.length; i++) {
+                fn([...pathForLens, 'elementList', i]);
+              }
+            }
+            if (dataItem.dataItemList) {
+              for (let i = 0; i < dataItem.dataItemList.length; i++) {
+                fn([...pathForLens, 'dataItemList', i]);
+              }
+            }
+          } else { // @ts-ignore
+            if (dataItem.fieldType !== undefined) {
+              dataItem = dataItem as DataItemDto;
+              if (dataItem.fieldType === 'FieldContainer') {
+                for (let i = 0; i < dataItem.dataItemList.length; i++) {
+                  fn([...pathForLens, 'dataItemList', i]);
+                }
+              }
+              if (dataItem.fieldType === 'Picture') {
+                this.replyElement = R.set(lens, dataItem, this.replyElement);
+              }
+            }
+          }
+        };
+        for (let i = 0; i < op.model.elementList.length; i++) {
+          fn(['elementList', i]);
+        }
+      }
+    });
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/index.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/index.ts
@@ -7,3 +7,4 @@ export * from './board-create-modal/board-create-modal.component';
 export * from './board-delete-modal/board-delete-modal.component';
 export * from './compliance-case-modal/compliance-case-modal.component';
 export {CalendarSelectWorkerModalComponent} from './calendar-select-worker-modal/calendar-select-worker-modal.component';
+export * from './calendar-complete-event-modal/calendar-complete-event-modal.component';

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-calendar.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-calendar.service.ts
@@ -6,6 +6,7 @@ import {
   CalendarBoardModel,
   CalendarComplianceReportRequestModel,
   CalendarComplianceReportRowModel,
+  CalendarPrepareCompleteResult,
   CalendarTaskCreateModel,
   CalendarTaskIndexRequestModel,
   CalendarTaskModel,
@@ -103,6 +104,17 @@ export class BackendConfigurationPnCalendarService {
     return this.apiBaseService.put(
       `${BackendConfigurationPnCalendarMethods.Tasks}/${taskId}/complete`,
       {completed, complianceId: complianceId ?? null, occurrenceDate: occurrenceDate ?? null, workerId}
+    );
+  }
+
+  prepareComplete(
+    taskId: number,
+    complianceId: number | null | undefined,
+    occurrenceDate: string | null | undefined,
+  ): Observable<OperationDataResult<CalendarPrepareCompleteResult>> {
+    return this.apiBaseService.post(
+      `${BackendConfigurationPnCalendarMethods.Tasks}/${taskId}/prepare-complete`,
+      {complianceId: complianceId ?? null, occurrenceDate: occurrenceDate ?? null}
     );
   }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-compliances.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-compliances.service.ts
@@ -8,6 +8,7 @@ export let BackendConfigurationPnCompliancesMethods = {
   Compliances: 'api/backend-configuration-pn/compliances/index',
   ComplianceStatus: 'api/backend-configuration-pn/compliances/compliance',
   GetCases: 'api/backend-configuration-pn/compliances/cases',
+  UpdateCaseFromCalendar: 'api/backend-configuration-pn/compliances/cases/calendar',
   DeleteCompliance: 'api/backend-configuration-pn/compliances/delete',
 };
 
@@ -50,6 +51,16 @@ export class BackendConfigurationPnCompliancesService {
   ): Observable<OperationResult> {
     return this.apiBaseService.put<ReplyRequest>(
       BackendConfigurationPnCompliancesMethods.GetCases,
+      model
+    );
+  }
+
+  updateCaseFromCalendar(
+    model: ReplyRequest,
+    templateId: number
+  ): Observable<OperationResult> {
+    return this.apiBaseService.put<ReplyRequest>(
+      BackendConfigurationPnCompliancesMethods.UpdateCaseFromCalendar,
       model
     );
   }


### PR DESCRIPTION
## What

Replaces the calendar's two-step complete flow (worker-select modal → then, only when the eForm has mandatory fields, a separate fill-eForm modal) with **one combined modal** at every completion entry point (week/day grid circle, Tidsplan, Compliance view rows), per the approved mockup: **Vælg medarbejder** (property workers, event assignee preselected) + **Udført dato** (defaults to the event start, clamped to today) + the embedded eForm (shared case-edit components), saved with a single **Gem**.

Implemented as new code throughout — `ComplianceCaseModalComponent`, `CalendarSelectWorkerModalComponent`, backend `ToggleComplete`, and the shared `Update` are all untouched (their flows are used elsewhere).

## Backend

- `POST calendar/tasks/{id}/prepare-complete`: materialises/resolves the compliance occurrence (mirrors `ToggleComplete`'s resolution steps exactly; verified side-by-side in review) and returns `{sdkCaseId, templateId, complianceId, assignedSiteId, deadline, eventStart}` — **no completion side effects**, so the modal can render the case before any commitment.
- `PUT compliances/cases/calendar` → `UpdateFromCalendar`: a copy of the shared `Update` (mechanically audited: zero drift) with ONE change — the device retraction resolves the MicrotingUid synchronously but runs `core.CaseDelete` fire-and-forget. Reason: the synchronous external call blocked the response **12+ minutes in dev** and would freeze every Gem; retraction was already best-effort (failures swallowed), so guarantees are unchanged. Gem now returns in <1s.

## Behavior changes (deliberate)

- Every completion opens the modal — including eForms with no mandatory fields, which previously completed silently after the worker pick (users gain a visible done-date control and optional field/note/photo entry).
- Opening the modal materialises/deploys the occurrence even if the user cancels (required to render the form; idempotent via the per-site deploy lock; the eager-deploy path would deploy near-term occurrences anyway).
- Web "un-complete" via the completion circle is removed (completed tasks no-op; uncomplete was already rejected server-side).
- doneAt is user-editable on every completion, defaulting to the scheduled event start (clamped to today for future occurrences).

## Tests

- `CalendarPrepareCompleteTests` (9 scenarios): occurrence resolution (existing + on-demand materialisation), eventStart variants (config hour, exception override, 9.0 default), **no-completion invariant**, idempotence, failure paths. Runs in CI.
- Calendar e2e specs updated to the combined modal (`#completeWorkerSelect`/`#completeDoneAt`/`#completeSaveBtn`/`#completeCancelBtn`); network waits retargeted from `tasks/{id}/complete` to `prepare-complete` + `cases/calendar`.
- Manual browser walkthrough vs the mockup: modal layout, worker preselect, Annuller, Gem (~800ms) with correct DB completion state (Status=100, DoneAt=event start, worker attribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)