### PR TITLE
Calendar task card: full field set + tense-aware preview (future edit / historical view)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
@@ -60,4 +60,12 @@ public class CalendarTaskResponseModel
     /// the GetTaskTrackerList and GetTasksForWeek service paths.
     /// </summary>
     public bool TaskIsExpired { get; set; }
+
+    /// <summary>
+    /// Completion metadata for completed compliance-backed rows: the site
+    /// (worker) name that checked the case and when it was done. Null for
+    /// uncompleted rows and recurrence-derived rows.
+    /// </summary>
+    public string? DoneByName { get; set; }
+    public DateTime? DoneAt { get; set; }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -1020,6 +1020,15 @@ public class BackendConfigurationCalendarService(
                     RepeatOrdinalWeek = arp?.RepeatOrdinalWeek,
                     RepeatWeekdaysCsv = arp?.RepeatWeekdaysCsv,
                     Completed = complianceCompleted,
+                    // Completion metadata for the task card — compSdkCase and
+                    // siteNamesById are already batch-loaded above, so this
+                    // adds no DB round-trips.
+                    DoneByName = complianceCompleted && compSdkCase?.SiteId != null
+                        ? siteNamesById.GetValueOrDefault(compSdkCase.SiteId.Value)
+                        : null,
+                    DoneAt = complianceCompleted
+                        ? compSdkCase?.DoneAtUserModifiable ?? compSdkCase?.DoneAt
+                        : null,
                     TaskIsExpired = compTaskIsExpired,
                     // Orphan compliance rows (no live ARP) render as dimmed
                     // inactive — visually distinct from a healthy active row.

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/calendar-ui-enhancements.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/calendar-ui-enhancements.page.ts
@@ -364,9 +364,10 @@ export class CalendarUiEnhancementsPage {
 
   /**
    * Click a task block's body to open the preview popover
-   * (`app-task-preview-modal`). The popover renders Edit / Duplicate /
-   * Delete actions. The click target is `.task-block-body` (carries the
-   * (click)=onBodyClick handler) rather than the resize handles.
+   * (`app-task-preview-modal`). The popover renders Edit (future tasks) or
+   * View (historical tasks) / Duplicate / Delete actions. The click target
+   * is `.task-block-body` (carries the (click)=onBodyClick handler) rather
+   * than the resize handles.
    */
   async openEventPreview(title: string): Promise<void> {
     const body = this.findEventBlock(title).locator('.task-block-body');
@@ -381,13 +382,23 @@ export class CalendarUiEnhancementsPage {
    * Click Edit in the preview popover and wait for the edit modal's title
    * input to appear and rehydrate. Mirrors clickEditInPreview in
    * l/calendar.page.ts.
+   *
+   * Tense-aware: the popover renders #calendarEventEditBtn for FUTURE tasks
+   * but #calendarEventViewBtn for HISTORICAL ones (completed, or
+   * taskDate+endTime in the past). Both open the same edit modal (readonly
+   * in the historical case), so this clicks whichever is present.
    */
   async clickEditInPreview(): Promise<void> {
-    await this.getPreviewEditButton().click();
+    await this.getPreviewEditOrViewButton().click();
     await this.page
       .locator('#calendarEventTitle')
       .waitFor({ state: 'visible', timeout: 15000 });
     await this.page.waitForTimeout(800);
+  }
+
+  /** Explicit alias for the tense-aware edit/view click. */
+  async clickEditOrViewInPreview(): Promise<void> {
+    await this.clickEditInPreview();
   }
 
   /**
@@ -493,62 +504,6 @@ export class CalendarUiEnhancementsPage {
     } else {
       await this.page.waitForTimeout(500);
     }
-  }
-
-  /**
-   * Create a single (non-recurring) event in the create-modal currently
-   * open, with the given title, start time, end time, and required dropdowns
-   * (first eForm + first planning tag + first assignee, mirroring
-   * createSimpleEvent in calendar-resize.spec.ts). Awaits the create POST
-   * and waits for the resulting `.task-block` to appear on the grid.
-   *
-   * The modal must already be open at the desired day slot — callers should
-   * pair this with `openCreateModalAtSlot(dayOffset, startHour)` first.
-   */
-  async fillAndSaveEvent(
-    title: string,
-    options: { endTime?: string; startTime?: string } = {},
-  ): Promise<void> {
-    await this.page.locator('#calendarEventTitle').fill(title);
-
-    if (options.startTime) {
-      await this.typeStartTime(options.startTime, 'Enter');
-    }
-    if (options.endTime) {
-      await this.typeEndTime(options.endTime, 'Enter');
-    }
-
-    const eform = this.page.locator('#calendarEventEform');
-    await eform.click();
-    await this.page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
-    await this.page.locator('.ng-dropdown-panel .ng-option').first().click();
-    await this.page.waitForTimeout(300);
-
-    const planningTag = this.page.locator('#calendarEventPlanningTag');
-    await planningTag.click();
-    await this.page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
-    await this.page.locator('.ng-dropdown-panel .ng-option').first().click();
-    await this.page.waitForTimeout(300);
-
-    const assignee = this.page.locator('#calendarEventAssignee');
-    await assignee.click();
-    await this.page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
-    await this.page.locator('.ng-dropdown-panel .ng-option').first().click();
-    await this.page.locator('#calendarEventTitle').click();
-    await this.page.waitForTimeout(300);
-
-    const createResp = this.page.waitForResponse(
-      r => r.url().includes('/api/backend-configuration-pn/calendar/tasks')
-        && !r.url().includes('/tasks/week')
-        && !r.url().includes('/tasks/move')
-        && !r.url().includes('/tasks/resize')
-        && r.request().method() === 'POST',
-      { timeout: 30000 }
-    );
-    await this.page.locator('#calendarEventSaveBtn').click();
-    await createResp;
-    await this.page.waitForTimeout(1500);
-    await this.findEventBlock(title).waitFor({ state: 'visible', timeout: 10000 });
   }
 
   /**
@@ -856,9 +811,30 @@ export class CalendarUiEnhancementsPage {
     ).trim();
   }
 
-  /** Edit button in the preview popover (week-grid + schedule both reuse it). */
+  /**
+   * Edit button in the preview popover (week-grid + schedule both reuse it).
+   * Rendered for FUTURE tasks only — historical tasks (completed, or
+   * taskDate+endTime in the past) render #calendarEventViewBtn instead.
+   */
   getPreviewEditButton(): Locator {
     return this.page.locator('#calendarEventEditBtn');
+  }
+
+  /**
+   * View (visibility) button in the preview popover — the historical-task
+   * replacement for the edit pencil. Opens the edit modal in readonly mode.
+   */
+  getPreviewViewButton(): Locator {
+    return this.page.locator('#calendarEventViewBtn');
+  }
+
+  /**
+   * Whichever of Edit/View the popover currently renders. Exactly one of
+   * the two exists at a time (*ngIf on isHistorical), so the combined
+   * locator never violates strict mode.
+   */
+  getPreviewEditOrViewButton(): Locator {
+    return this.page.locator('#calendarEventEditBtn, #calendarEventViewBtn');
   }
 
   /** Copy/Duplicate button in the preview popover. */

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/l/calendar.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/l/calendar.page.ts
@@ -272,9 +272,96 @@ export class CalendarPage {
   }
 
   // Click Edit in the preview popover to open the edit modal.
+  // Delegates to clickEditOrViewInPreview — the preview renders
+  // #calendarEventEditBtn for future tasks but #calendarEventViewBtn for
+  // historical ones (completed, or taskDate+endTime in the past), and both
+  // open the same edit modal (readonly in the historical case).
   async clickEditInPreview(): Promise<void> {
-    await this.page.locator('#calendarEventEditBtn').click();
+    await this.clickEditOrViewInPreview();
+  }
+
+  // Click whichever of Edit (#calendarEventEditBtn, future tasks) or View
+  // (#calendarEventViewBtn, historical tasks) the preview popover renders.
+  // Exactly one of the two exists at a time (*ngIf on isHistorical), so the
+  // combined locator never violates strict mode.
+  async clickEditOrViewInPreview(): Promise<void> {
+    await this.getPreviewEditOrViewButton().click();
     await this.page.locator('#calendarEventTitle').waitFor({ state: 'visible', timeout: 15000 });
     await this.page.waitForTimeout(800); // let form rehydrate
+  }
+
+  // Edit button in the preview popover — rendered for FUTURE tasks only.
+  getPreviewEditButton(): Locator {
+    return this.page.locator('#calendarEventEditBtn');
+  }
+
+  // View (visibility) button in the preview popover — rendered for
+  // HISTORICAL tasks (completed, or taskDate+endTime in the past). Opens
+  // the edit modal in readonly mode.
+  getPreviewViewButton(): Locator {
+    return this.page.locator('#calendarEventViewBtn');
+  }
+
+  // Whichever of Edit/View the popover currently renders (exactly one).
+  getPreviewEditOrViewButton(): Locator {
+    return this.page.locator('#calendarEventEditBtn, #calendarEventViewBtn');
+  }
+
+  // ----- Preview-card (task card) row helpers ------------------------------
+  // The preview popover body renders one `.preview-row` per populated field,
+  // each led by a `mat-icon.preview-icon` whose ligature text identifies the
+  // row: schedule, repeat, domain (property), calendar_today (board), group
+  // (assignees / "Completed by"), style (tags), stacks (report headline),
+  // checklist (eForm), attach_file, notes, add_to_drive, image,
+  // toggle_on/toggle_off (status), policy. Empty rows are not rendered.
+
+  // Locator for the preview row led by the given icon ligature (exact match,
+  // so e.g. "toggle_on" never matches "toggle_off").
+  getPreviewRowByIcon(icon: string): Locator {
+    return this.page
+      .locator('app-task-preview-modal .preview-row')
+      .filter({
+        has: this.page.locator('mat-icon.preview-icon', {
+          hasText: new RegExp(`^${icon}$`),
+        }),
+      });
+  }
+
+  // Trimmed visible text of the preview row led by the given icon (includes
+  // the icon ligature text itself — callers should assert with toContain).
+  async getPreviewRowText(icon: string): Promise<string> {
+    return ((await this.getPreviewRowByIcon(icon).textContent()) ?? '').trim();
+  }
+
+  // Chip texts of a chip-style preview row (group / style / attach_file).
+  async getPreviewChipTexts(icon: string): Promise<string[]> {
+    const chips = this.getPreviewRowByIcon(icon).locator('.preview-chip');
+    const count = await chips.count();
+    const out: string[] = [];
+    for (let i = 0; i < count; i++) {
+      out.push(((await chips.nth(i).textContent()) ?? '').trim());
+    }
+    return out;
+  }
+
+  // The preview card's title line.
+  async getPreviewTitleText(): Promise<string> {
+    return ((await this.page.locator('app-task-preview-modal .preview-title').textContent()) ?? '').trim();
+  }
+
+  // Close the preview popover via its X action button (the close button has
+  // no id — match it by the `close` mat-icon, same pattern as the delete
+  // button in calendar-ui-enhancements.page.ts).
+  async closePreviewPopover(): Promise<void> {
+    await this.page
+      .locator('app-task-preview-modal .preview-actions-row button')
+      .filter({ has: this.page.locator('mat-icon', { hasText: 'close' }) })
+      .first()
+      .click();
+    await this.page
+      .locator('app-task-preview-modal')
+      .waitFor({ state: 'detached', timeout: 5000 })
+      .catch(() => undefined);
+    await this.page.waitForTimeout(300);
   }
 }

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/m/calendar-task-card.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/m/calendar-task-card.spec.ts
@@ -1,0 +1,559 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../../Page objects/Login.page';
+import { generateRandmString } from '../../../helper-functions';
+import { CalendarPage } from '../l/calendar.page';
+import { CalendarUiEnhancementsPage } from '../calendar-ui-enhancements.page';
+import {
+  BackendConfigurationPropertiesPage,
+  PropertyCreateUpdate,
+} from '../BackendConfigurationProperties.page';
+import {
+  BackendConfigurationPropertyWorkersPage,
+  PropertyWorker,
+} from '../BackendConfigurationPropertyWorkers.page';
+
+/**
+ * Calendar task-card (opgavekort) preview popover suite — covers the
+ * extended preview card of 2026-07-14-calendar-task-card-design.md:
+ *
+ *   - Future card body rows in spec order, each led by a mat-icon ligature:
+ *     schedule, repeat (ALWAYS rendered — "Does not repeat" for one-offs),
+ *     domain (property), calendar_today (board + color dot), group
+ *     (assignee/team chips), style (tag chips), stacks (report headline),
+ *     checklist (eForm name), attach_file (attachment chips),
+ *     toggle_on/toggle_off (status), policy (only when complianceEnabled).
+ *     Rows with no value are HIDDEN (except repeat).
+ *   - Tense-aware action row: future tasks render the edit pencil
+ *     (#calendarEventEditBtn); HISTORICAL tasks (completed, or
+ *     taskDate+endTime in the past) render #calendarEventViewBtn instead,
+ *     which opens the same edit modal in readonly mode.
+ *   - Completed cards: group row becomes "Completed by"/"Udført af" +
+ *     completer name; toggle/policy rows omitted; Picture-field thumbnails
+ *     in an image row → CalendarImageLightboxComponent.
+ *   - Live refresh: after an edit-save the tile and a re-opened card show
+ *     fresh values WITHOUT a page reload (container loadTasks re-render).
+ *
+ * REALITY CHECK (drives which rows are real vs. test.fixme — mirrors the
+ * conventions established in p/calendar-complete.spec.ts and
+ * t/calendar-edit-fields.spec.ts E17):
+ *
+ *  1. An UNCOMPLETED PAST task cannot be produced through the UI:
+ *     - past grid slots are inert (v/calendar-create-validation.spec.ts V03
+ *       asserts the create modal never opens on a past slot);
+ *     - the create modal's datepicker has minDate = today, and the backend
+ *       CreateTask rejects past starts outright
+ *       ("CannotCreateTaskInThePast" guard in
+ *       BackendConfigurationCalendarService.CreateTask);
+ *     - edit-save is blocked for past dates (isInPast guard in onSave) and
+ *       the move/resize endpoints silently reject moves into the past.
+ *     → the past-card tests (KC05) are test.fixme, same as E17.
+ *
+ *  2. A COMPLETED task cannot be produced through the UI: completing an
+ *     event opens the combined complete modal
+ *     (app-calendar-complete-event-modal) whose embedded eForm carries
+ *     mandatory fields for every template the seed provisions — saving it
+ *     (#completeSaveBtn) is not automatable (see
+ *     p/calendar-complete.spec.ts header, X03/X07/X09). The completed-card
+ *     behaviors ("Udført af" group row, no toggle/policy rows, image
+ *     thumbnails + lightbox) are covered at component level; server-side
+ *     coverage lives in CalendarCompleteOccurrenceTests.cs.
+ *     → KC06 is test.fixme with the intended assertions documented.
+ *
+ *  3. Because neither a completed case nor Picture-field data is
+ *     producible in e2e, lightbox coverage (ids calendarLightbox,
+ *     calendarLightboxPrev / calendarLightboxNext / calendarLightboxClose,
+ *     calendarLightboxImage; wrap-around navigation; arrows hidden for a
+ *     single image) stays component-level. What IS asserted here: the
+ *     image row (icon `image`) is absent on every reachable card.
+ *
+ * Lives in `m/` — the lightest calendar matrix slot (shares with the
+ * fresh-property-worker and translation suites). Seeds its own property +
+ * worker like every calendar suite (only shard `a` seeds SQL).
+ */
+
+const property: PropertyCreateUpdate = {
+  name: generateRandmString(5),
+  chrNumber: generateRandmString(5),
+  address: generateRandmString(5),
+  cvrNumber: '1111111',
+};
+
+const worker: PropertyWorker = {
+  name: generateRandmString(5),
+  surname: generateRandmString(5),
+  language: 'Dansk',
+  properties: [property.name],
+  workerEmail: generateRandmString(5) + '@test.com',
+};
+
+// KC01 creates this event; KC04 edits it (serial suite state).
+const kc01Title = `KC01-${generateRandmString(5)}`;
+// Planning tag doubles as report headline (stacks row) AND set-tag chip
+// (style row) — calendar tags and planning tags share the same pool.
+const kc01Tag = `KCTag-${generateRandmString(5)}`;
+
+let seeded = false;
+let kc01EformLabel = '';
+
+test.describe.serial('Calendar task-card preview (task-card-preview-fields)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4200');
+    await new LoginPage(page).login();
+    await page.waitForTimeout(2000);
+
+    const uiPage = new CalendarUiEnhancementsPage(page);
+    await uiPage.goToCalendar();
+    await uiPage.ensureSidebarOpen();
+
+    if (seeded) {
+      const folderResp = page.waitForResponse(
+        r => r.url().includes('/api/backend-configuration-pn/properties/get-folder-dtos'),
+        { timeout: 60000 }
+      );
+      await uiPage.selectProperty(property.name);
+      await folderResp.catch(() => undefined);
+      await page.waitForTimeout(1000);
+    }
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    const cleanup = async () => {
+      await page.goto('http://localhost:4200');
+      await new LoginPage(page).login();
+
+      const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+      await workersPage.goToPropertyWorkers();
+      await page.waitForTimeout(1000);
+      await workersPage.clearTable();
+
+      const propertiesPage = new BackendConfigurationPropertiesPage(page);
+      await propertiesPage.goToProperties();
+      await page.waitForTimeout(1000);
+      await propertiesPage.clearTable();
+    };
+    try {
+      await Promise.race([
+        cleanup(),
+        new Promise(resolve => setTimeout(resolve, 60000)),
+      ]);
+    } catch (err: any) {
+      console.log(`afterAll cleanup failed (non-fatal): ${err?.message ?? err}`);
+    }
+    try { await page.close(); } catch {}
+  });
+
+  // -----------------------------------------------------------------------
+  // Seed test — property + worker. Runs first via describe.serial.
+  // -----------------------------------------------------------------------
+  test('seed: create property + worker', async ({ page }) => {
+    test.setTimeout(600000);
+
+    const propertiesPage = new BackendConfigurationPropertiesPage(page);
+    const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+
+    await propertiesPage.goToProperties();
+    await propertiesPage.createProperty(property);
+    await workersPage.goToPropertyWorkers();
+    await workersPage.create(worker);
+
+    seeded = true;
+  });
+
+  // =======================================================================
+  // KC01 — future card shows every populated row in spec order and hides
+  //   the empty ones.
+  //
+  //   Creates a one-off next-week Monday 09:00 event with: an eForm, an
+  //   inline-created planning tag (report headline) that is ALSO added as a
+  //   set-tag, and the seeded worker as assignee — then asserts the card:
+  //     schedule row (date + 09:00), repeat row ("Does not repeat" — always
+  //     rendered), domain row (property name), calendar_today row (board
+  //     name + color dot), group row (worker chip), style row (tag chip),
+  //     stacks row (planning-tag name), checklist row (eForm label);
+  //     attach_file + image rows ABSENT (no value); toggle_on row (status
+  //     defaults active); policy row PRESENT (complianceEnabled defaults
+  //     true). Action row shows the edit pencil, NOT the historical View
+  //     button.
+  // =======================================================================
+  test('KC01: future card shows populated rows and hides empty ones', async ({ page }) => {
+    test.setTimeout(300000);
+
+    const uiPage = new CalendarUiEnhancementsPage(page);
+    const calendarPage = new CalendarPage(page);
+
+    // Monday 09:00 next week (openCreateModalAtSlot advances one week, so
+    // the slot is guaranteed future regardless of CI wall-clock).
+    await uiPage.openCreateModalAtSlot(0, 9);
+
+    await page.locator('#calendarEventTitle').fill(kc01Title);
+
+    // eForm: first option; capture its label for the checklist-row assert.
+    const eform = page.locator('#calendarEventEform');
+    await eform.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+    kc01EformLabel = await calendarPage.getSelectValue('#calendarEventEform');
+    expect(kc01EformLabel).toBeTruthy();
+
+    // Planning tag (report headline): inline-create so we know its exact
+    // name, then add the SAME tag to the set-tags multi-select (the two
+    // fields share the tag pool — see l/calendar-tags-roundtrip.spec.ts).
+    await calendarPage.inlineCreatePlanningTag(kc01Tag);
+    await calendarPage.addExistingTag(kc01Tag);
+
+    // Assignee: the seeded worker (only option).
+    const assignee = page.locator('#calendarEventAssignee');
+    await assignee.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.locator('#calendarEventTitle').click();
+    await page.waitForTimeout(300);
+
+    const createResp = page.waitForResponse(
+      r => r.url().includes('/api/backend-configuration-pn/calendar/tasks')
+        && !r.url().includes('/tasks/week')
+        && r.request().method() === 'POST',
+      { timeout: 30000 }
+    );
+    await page.locator('#calendarEventSaveBtn').click();
+    await createResp;
+    await page.waitForTimeout(1500);
+    await uiPage.findEventBlock(kc01Title).waitFor({ state: 'visible', timeout: 10000 });
+
+    // ----- Open the card and assert the tense-aware action row ------------
+    await uiPage.openEventPreview(kc01Title);
+    await expect(calendarPage.getPreviewEditButton()).toBeVisible();
+    await expect(calendarPage.getPreviewViewButton()).toHaveCount(0);
+
+    expect(await calendarPage.getPreviewTitleText()).toContain(kc01Title);
+
+    // schedule — localized "Weekday D. Month YYYY; 09:00 – 10:00". Assert
+    // the stable tokens (year of next week's Monday + the 09:00 start)
+    // rather than the locale-dependent weekday/month names.
+    const now = new Date();
+    const nextMonday = new Date(now);
+    nextMonday.setDate(now.getDate() - ((now.getDay() + 6) % 7) + 7);
+    const scheduleRow = calendarPage.getPreviewRowByIcon('schedule');
+    await expect(scheduleRow).toBeVisible();
+    await expect(scheduleRow).toContainText(String(nextMonday.getFullYear()));
+    await expect(scheduleRow).toContainText('09:00');
+
+    // repeat — ALWAYS rendered; one-off shows the "Does not repeat"
+    // translation (da: "Gentages ikke").
+    const repeatRow = calendarPage.getPreviewRowByIcon('repeat');
+    await expect(repeatRow).toBeVisible();
+    await expect(repeatRow).toContainText(/Does not repeat|Gentages ikke/);
+
+    // domain — property name.
+    await expect(calendarPage.getPreviewRowByIcon('domain')).toContainText(property.name as string);
+
+    // calendar_today — board name + color dot (every property has an
+    // auto-created default board; we assert presence, not its name).
+    const boardRow = calendarPage.getPreviewRowByIcon('calendar_today');
+    await expect(boardRow).toBeVisible();
+    await expect(boardRow.locator('.preview-board-dot')).toBeVisible();
+
+    // group — assignee chip with the seeded worker (future card: chips,
+    // never the "Completed by" variant).
+    const groupRow = calendarPage.getPreviewRowByIcon('group');
+    await expect(groupRow).toBeVisible();
+    await expect(groupRow.locator('.preview-chip').first()).toContainText(worker.name as string);
+
+    // style — the set-tag chip.
+    const tagsRow = calendarPage.getPreviewRowByIcon('style');
+    await expect(tagsRow).toBeVisible();
+    expect(await calendarPage.getPreviewChipTexts('style')).toContain(kc01Tag);
+
+    // stacks — report headline resolves to the planning tag's name.
+    await expect(calendarPage.getPreviewRowByIcon('stacks')).toContainText(kc01Tag);
+
+    // checklist — eForm name resolved via the container's eForm list (loads
+    // async on card-open, so rely on the assertion's retry).
+    await expect(calendarPage.getPreviewRowByIcon('checklist')).toContainText(kc01EformLabel, { timeout: 10000 });
+
+    // Empty rows are hidden: no attachments → no attach_file row; not a
+    // completed card → no image (case thumbnails) row.
+    await expect(calendarPage.getPreviewRowByIcon('attach_file')).toHaveCount(0);
+    await expect(calendarPage.getPreviewRowByIcon('image')).toHaveCount(0);
+
+    // toggle — status defaults ACTIVE → toggle_on row (and no toggle_off).
+    await expect(calendarPage.getPreviewRowByIcon('toggle_on')).toBeVisible();
+    await expect(calendarPage.getPreviewRowByIcon('toggle_off')).toHaveCount(0);
+
+    // policy — complianceEnabled defaults true → row present on a future card.
+    await expect(calendarPage.getPreviewRowByIcon('policy')).toBeVisible();
+
+    await calendarPage.closePreviewPopover();
+  });
+
+  // =======================================================================
+  // KC02 — the policy row is gated on the overdue/compliance toggle, and
+  //   value-less optional rows stay hidden.
+  //
+  //   Creates a plain event (no set-tags, no attachments) with
+  //   #calendarEventComplianceOff picked in the create modal
+  //   (onPickOverdueHidden → status stays/becomes active,
+  //   complianceEnabled=false — see t/calendar-edit-fields.spec.ts) and
+  //   asserts: policy row ABSENT, toggle_on row present, style +
+  //   attach_file + image rows ABSENT, repeat row still present.
+  // =======================================================================
+  test('KC02: compliance-off card hides the policy row; empty optional rows absent', async ({ page }) => {
+    test.setTimeout(300000);
+
+    const uiPage = new CalendarUiEnhancementsPage(page);
+    const calendarPage = new CalendarPage(page);
+    const title = `KC02-${generateRandmString(5)}`;
+
+    // Tuesday 09:00 next week — distinct slot from KC01 (Monday).
+    await uiPage.openCreateModalAtSlot(1, 9);
+
+    await page.locator('#calendarEventTitle').fill(title);
+
+    const eform = page.locator('#calendarEventEform');
+    await eform.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+
+    const planningTag = page.locator('#calendarEventPlanningTag');
+    await planningTag.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+
+    const assignee = page.locator('#calendarEventAssignee');
+    await assignee.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.locator('#calendarEventTitle').click();
+    await page.waitForTimeout(300);
+
+    // Overdue policy OFF (also forces status active).
+    await page.locator('#calendarEventComplianceOff').click();
+    await page.waitForTimeout(300);
+
+    const createResp = page.waitForResponse(
+      r => r.url().includes('/api/backend-configuration-pn/calendar/tasks')
+        && !r.url().includes('/tasks/week')
+        && r.request().method() === 'POST',
+      { timeout: 30000 }
+    );
+    await page.locator('#calendarEventSaveBtn').click();
+    await createResp;
+    await page.waitForTimeout(1500);
+    await uiPage.findEventBlock(title).waitFor({ state: 'visible', timeout: 10000 });
+
+    await uiPage.openEventPreview(title);
+
+    // Repeat row is unconditional; schedule row present.
+    await expect(calendarPage.getPreviewRowByIcon('schedule')).toBeVisible();
+    await expect(calendarPage.getPreviewRowByIcon('repeat')).toBeVisible();
+
+    // complianceEnabled=false → NO policy row.
+    await expect(calendarPage.getPreviewRowByIcon('policy')).toHaveCount(0);
+
+    // The compliance radio forces status active → toggle_on.
+    await expect(calendarPage.getPreviewRowByIcon('toggle_on')).toBeVisible();
+    await expect(calendarPage.getPreviewRowByIcon('toggle_off')).toHaveCount(0);
+
+    // No set-tags, no attachments, not completed → rows hidden.
+    await expect(calendarPage.getPreviewRowByIcon('style')).toHaveCount(0);
+    await expect(calendarPage.getPreviewRowByIcon('attach_file')).toHaveCount(0);
+    await expect(calendarPage.getPreviewRowByIcon('image')).toHaveCount(0);
+
+    await calendarPage.closePreviewPopover();
+  });
+
+  // =======================================================================
+  // KC03 — an INACTIVE (dimmed) event's card shows the toggle_off row.
+  // =======================================================================
+  test('KC03: status-inactive card shows the toggle_off row', async ({ page }) => {
+    test.setTimeout(300000);
+
+    const uiPage = new CalendarUiEnhancementsPage(page);
+    const calendarPage = new CalendarPage(page);
+    const title = `KC03-${generateRandmString(5)}`;
+
+    // Wednesday 09:00 next week.
+    await uiPage.openCreateModalAtSlot(2, 9);
+
+    await page.locator('#calendarEventTitle').fill(title);
+
+    const eform = page.locator('#calendarEventEform');
+    await eform.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+
+    const planningTag = page.locator('#calendarEventPlanningTag');
+    await planningTag.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+
+    const assignee = page.locator('#calendarEventAssignee');
+    await assignee.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.locator('#calendarEventTitle').click();
+    await page.waitForTimeout(300);
+
+    // Status → inactive (task dims on the grid and hides in the app).
+    await page.locator('#calendarEventStatusInactive').click();
+    await page.waitForTimeout(300);
+
+    const createResp = page.waitForResponse(
+      r => r.url().includes('/api/backend-configuration-pn/calendar/tasks')
+        && !r.url().includes('/tasks/week')
+        && r.request().method() === 'POST',
+      { timeout: 30000 }
+    );
+    await page.locator('#calendarEventSaveBtn').click();
+    await createResp;
+    await page.waitForTimeout(1500);
+    await uiPage.findEventBlock(title).waitFor({ state: 'visible', timeout: 10000 });
+
+    await uiPage.openEventPreview(title);
+
+    await expect(calendarPage.getPreviewRowByIcon('toggle_off')).toBeVisible();
+    await expect(calendarPage.getPreviewRowByIcon('toggle_on')).toHaveCount(0);
+
+    await calendarPage.closePreviewPopover();
+  });
+
+  // =======================================================================
+  // KC04 — LIVE REFRESH: edit KC01's event (new title + planning tag added
+  //   as a set-tag) and, WITHOUT page.reload(), assert both the grid tile
+  //   and a re-opened card show the fresh values. The refresh is driven by
+  //   the container's post-save loadTasks (/tasks/week POST) re-render.
+  // =======================================================================
+  test('KC04: tile and re-opened card show edited values without a page reload', async ({ page }) => {
+    test.setTimeout(300000);
+
+    const uiPage = new CalendarUiEnhancementsPage(page);
+    const calendarPage = new CalendarPage(page);
+    // Deliberately NOT containing kc01Title, so the old-tile-gone assert
+    // can't accidentally match the new tile.
+    const newTitle = `KC04-${generateRandmString(5)}`;
+    const newTag = `KCTag-${generateRandmString(5)}`;
+
+    // KC01's event lives on next week's Monday.
+    await uiPage.navigateToNextWeek();
+    await uiPage.findEventBlock(kc01Title).waitFor({ state: 'visible', timeout: 10000 });
+
+    // Open the card → edit modal (tense-aware click helper).
+    await uiPage.openEventPreview(kc01Title);
+    await calendarPage.clickEditOrViewInPreview();
+
+    // New title + a second inline-created planning tag, also added as a
+    // set-tag (same dual-pool mechanics as KC01).
+    await page.locator('#calendarEventTitle').fill(newTitle);
+    await calendarPage.inlineCreatePlanningTag(newTag);
+    await calendarPage.addExistingTag(newTag);
+
+    // One-off event → the save PUTs directly (no repeat-scope modal).
+    // Register BOTH waiters before clicking save so neither can miss.
+    const putWait = page.waitForResponse(
+      r => r.url().endsWith('/api/backend-configuration-pn/calendar/tasks')
+        && r.request().method() === 'PUT',
+      { timeout: 30000 }
+    );
+    const reloadWait = page.waitForResponse(
+      r => r.url().includes('/api/backend-configuration-pn/calendar/tasks/week')
+        && r.request().method() === 'POST',
+      { timeout: 30000 }
+    );
+    await page.locator('#calendarEventSaveBtn').click();
+    await putWait;
+    await reloadWait;
+    await page.waitForTimeout(800);
+
+    // NO page.reload() — the re-rendered grid must already show the new
+    // title, and the old title must be gone.
+    await uiPage.findEventBlock(newTitle).waitFor({ state: 'visible', timeout: 10000 });
+    await expect(page.locator('.task-block').filter({ hasText: kc01Title })).toHaveCount(0);
+
+    // Re-open the card: fresh title, fresh tag chip, fresh report headline.
+    await uiPage.openEventPreview(newTitle);
+    expect(await calendarPage.getPreviewTitleText()).toContain(newTitle);
+    expect(await calendarPage.getPreviewChipTexts('style')).toContain(newTag);
+    await expect(calendarPage.getPreviewRowByIcon('stacks')).toContainText(newTag);
+    // Still a future one-off card: edit pencil, toggle + policy rows intact.
+    await expect(calendarPage.getPreviewEditButton()).toBeVisible();
+    await expect(calendarPage.getPreviewViewButton()).toHaveCount(0);
+
+    await calendarPage.closePreviewPopover();
+  });
+
+  // =======================================================================
+  // KC05 — HISTORICAL (past, uncompleted) card: #calendarEventViewBtn
+  //   replaces #calendarEventEditBtn; clicking it opens the edit modal in
+  //   readonly mode; toggle/policy rows are omitted; the group row still
+  //   shows the planned assignees (Q2 — "Udført af" is completed-only).
+  //
+  //   fixme rationale: an uncompleted PAST event cannot be produced via the
+  //   UI — past grid slots are inert (v/ V03), the create modal's
+  //   datepicker floors at today, the backend CreateTask guard rejects past
+  //   starts ("CannotCreateTaskInThePast",
+  //   BackendConfigurationCalendarService.CreateTask), and move/resize into
+  //   the past is silently rejected server-side. Same conclusion as
+  //   t/calendar-edit-fields.spec.ts E17. The isHistorical branch
+  //   (completed || taskDate+endTime < now, mirroring the edit modal's
+  //   isInPast rule) is covered at component level.
+  // =======================================================================
+  test.fixme('KC05: past card shows the View button and opens the readonly modal', async () => {
+    // Intended (unreachable — see fixme rationale above): produce an event
+    // whose taskDate+endTime is in the past, then:
+    //   await uiPage.openEventPreview(title);
+    //   await expect(calendarPage.getPreviewViewButton()).toBeVisible();
+    //   await expect(calendarPage.getPreviewEditButton()).toHaveCount(0);
+    //   await expect(calendarPage.getPreviewRowByIcon('toggle_on')).toHaveCount(0);
+    //   await expect(calendarPage.getPreviewRowByIcon('toggle_off')).toHaveCount(0);
+    //   await expect(calendarPage.getPreviewRowByIcon('policy')).toHaveCount(0);
+    //   // Q2: uncompleted historical → planned assignee chips, no "Udført af".
+    //   await expect(calendarPage.getPreviewRowByIcon('group').locator('.preview-chip')).toHaveCount(1);
+    //   await calendarPage.clickEditOrViewInPreview();
+    //   // Readonly modal: all controls disabled.
+    //   await expect(page.locator('#calendarEventTitle')).toBeDisabled();
+  });
+
+  // =======================================================================
+  // KC06 — COMPLETED card: group row shows "Udført af"/"Completed by" +
+  //   completer name, no toggle/policy rows, image row with case-photo
+  //   thumbnails → lightbox (ids calendarLightbox, calendarLightboxPrev,
+  //   calendarLightboxNext, calendarLightboxClose, calendarLightboxImage;
+  //   wrap-around ‹ ›, arrows hidden for a single image).
+  //
+  //   fixme rationale: a completed task cannot be produced in e2e — saving
+  //   the combined complete modal requires driving its embedded eForm's
+  //   mandatory fields (impractical/flaky; see p/calendar-complete.spec.ts
+  //   header + X03/X09, which are fixme for the same reason). A completed
+  //   case WITH Picture-field data is doubly unreachable (no spec in the
+  //   suite produces picture data — the w/ attachment uploads are event
+  //   file attachments, not case photos). Completed-card rendering and the
+  //   lightbox stay component-level; DoneBy/DoneAt population is covered
+  //   server-side (CalendarTaskResponseModel.DoneByName fill in
+  //   GetTasksForWeek). The absence of the image row on non-completed cards
+  //   IS asserted (KC01–KC03).
+  // =======================================================================
+  test.fixme('KC06: completed card shows "Udført af" + thumbnails and no toggle/policy rows', async () => {
+    // Intended (unreachable — see fixme rationale above): fully complete an
+    // event via `.completion-btn` + app-calendar-complete-event-modal save
+    // (#completeWorkerSelect / #completeDoneAt / #completeSaveBtn), then:
+    //   await uiPage.openEventPreview(title);
+    //   await expect(calendarPage.getPreviewViewButton()).toBeVisible();
+    //   await expect(calendarPage.getPreviewRowByIcon('group'))
+    //     .toContainText(/Udført af|Completed by/);
+    //   await expect(calendarPage.getPreviewRowByIcon('group')).toContainText(worker.name);
+    //   await expect(calendarPage.getPreviewRowByIcon('toggle_on')).toHaveCount(0);
+    //   await expect(calendarPage.getPreviewRowByIcon('toggle_off')).toHaveCount(0);
+    //   await expect(calendarPage.getPreviewRowByIcon('policy')).toHaveCount(0);
+    //   // With case photos: thumbnails → lightbox
+    //   await calendarPage.getPreviewRowByIcon('image').locator('.preview-thumb').first().click();
+    //   await expect(page.locator('#calendarLightbox')).toBeVisible();
+    //   await page.locator('#calendarLightboxNext').click();   // wrap-around
+    //   await page.locator('#calendarLightboxClose').click();
+  });
+});

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-resize.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/u/calendar-resize.spec.ts
@@ -457,6 +457,9 @@ test.describe.serial('Calendar event resize', () => {
       await expect(calendarPage.getPreviewEditButton()).toBeVisible();
       await expect(calendarPage.getPreviewCopyButton()).toBeVisible();
       await expect(calendarPage.getPreviewDeleteButton()).toBeVisible();
+      // Tense-aware action row: a FUTURE event renders the edit pencil, not
+      // the historical View (visibility) replacement.
+      await expect(calendarPage.getPreviewViewButton()).toHaveCount(0);
     });
 
     test('F2: clicking Edit in the popover opens the edit modal with the title pre-filled', async ({ page }) => {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -548,4 +548,6 @@ export const bgBG = {
   At: 'В',
   'Time of day': 'Време на деня',
   'Done date': 'Дата на завършване',
+  'Completed by': 'Завършено от',
+  View: 'Преглед',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -548,4 +548,6 @@ export const csCZ = {
   At: 'Na',
   'Time of day': 'Denní doba',
   'Done date': 'Datum dokončení',
+  'Completed by': 'Dokončeno kým',
+  View: 'Pohled',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -549,4 +549,6 @@ export const da = {
   At: 'Kl.',
   'Time of day': 'Tidspunkt',
   'Done date': 'Udført dato',
+  'Completed by': 'Udført af',
+  View: 'Vis',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -597,4 +597,5 @@ export const deDE = {
   At: 'Bei',
   'Time of day': 'Uhrzeit',
   'Done date': 'Fertigstellungsdatum',
+  'Completed by': 'Abgeschlossen von',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -548,4 +548,6 @@ export const elGR = {
   At: 'Στο',
   'Time of day': 'Ώρα της ημέρας',
   'Done date': 'Ημερομηνία ολοκλήρωσης',
+  'Completed by': 'Ολοκληρώθηκε από',
+  View: 'Θέα',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -567,4 +567,6 @@ export const enUS= {
   Employees: 'Employees',
   At: 'At',
   'Time of day': 'Time of day',
+  'Completed by': 'Completed by',
+  View: 'View',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -548,4 +548,6 @@ export const esES = {
   At: 'En',
   'Time of day': 'Hora del día',
   'Done date': 'Fecha de finalización',
+  'Completed by': 'Completado por',
+  View: 'Vista',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -548,4 +548,6 @@ export const etET = {
   At: 'Kell',
   'Time of day': 'Kellaaeg',
   'Done date': 'Valmis kuupäev',
+  'Completed by': 'Lõpetanud',
+  View: 'Vaade',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -548,4 +548,6 @@ export const fiFI = {
   At: 'Klo',
   'Time of day': 'Kellonaika',
   'Done date': 'Valmistumispäivämäärä',
+  'Completed by': 'Valmistui',
+  View: 'Näytä',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -547,4 +547,6 @@ export const frFR = {
   At: 'À',
   'Time of day': 'Heure de la journée',
   'Done date': 'Date de réalisation',
+  'Completed by': 'Terminé par',
+  View: 'Voir',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -548,4 +548,6 @@ export const hrHR = {
   At: 'Na',
   'Time of day': 'Doba dana',
   'Done date': 'Datum završetka',
+  'Completed by': 'Završio/la',
+  View: 'Pogled',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -548,4 +548,6 @@ export const huHU = {
   At: 'At',
   'Time of day': 'Napszak',
   'Done date': 'Kész dátum',
+  'Completed by': 'Befejezte',
+  View: 'Kilátás',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -548,4 +548,6 @@ export const isIS = {
   At: 'Á',
   'Time of day': 'Tími dags',
   'Done date': 'Lokadagur',
+  'Completed by': 'Lokið af',
+  View: 'Skoða',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -548,4 +548,6 @@ export const itIT = {
   At: 'A',
   'Time of day': 'ora del giorno',
   'Done date': 'Data di completamento',
+  'Completed by': 'Completato da',
+  View: 'Visualizzazione',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -548,4 +548,6 @@ export const ltLT = {
   At: 'Prie',
   'Time of day': 'Paros laikas',
   'Done date': 'Atlikimo data',
+  'Completed by': 'Užbaigė',
+  View: 'Peržiūrėti',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -548,4 +548,6 @@ export const lvLV = {
   At: 'Plkst.',
   'Time of day': 'Dienas laiks',
   'Done date': 'Pabeigšanas datums',
+  'Completed by': 'Pabeidzis',
+  View: 'Skatīt',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -548,4 +548,6 @@ export const nlNL = {
   At: 'Bij',
   'Time of day': 'Tijdstip van de dag',
   'Done date': 'Voltooiingsdatum',
+  'Completed by': 'Voltooid door',
+  View: 'Weergave',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -548,4 +548,6 @@ export const noNO = {
   At: 'På',
   'Time of day': 'Tid på dagen',
   'Done date': 'Ferdigdato',
+  'Completed by': 'Fullført av',
+  View: 'Utsikt',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -548,4 +548,6 @@ export const plPL = {
   At: 'Na ',
   'Time of day': 'Pora dnia',
   'Done date': 'Data wykonania',
+  'Completed by': 'Ukończone przez',
+  View: 'Pogląd',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -548,4 +548,6 @@ export const ptBR = {
   At: 'No',
   'Time of day': 'Hora do dia',
   'Done date': 'Data de conclusão',
+  'Completed by': 'Concluído por',
+  View: 'Visualizar',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -548,4 +548,6 @@ export const ptPT = {
   At: 'No',
   'Time of day': 'Hora do dia',
   'Done date': 'Data de conclusão',
+  'Completed by': 'Concluído por',
+  View: 'Visualizar',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -548,4 +548,6 @@ export const roRO = {
   At: 'La',
   'Time of day': 'Momentul zilei',
   'Done date': 'Data finalizării',
+  'Completed by': 'Completat de',
+  View: 'Vedere',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -548,4 +548,6 @@ export const skSK = {
   At: 'O',
   'Time of day': 'Denný čas',
   'Done date': 'Dátum dokončenia',
+  'Completed by': 'Dokončil/a',
+  View: 'Zobraziť',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -548,4 +548,6 @@ export const slSL = {
   At: 'Ob',
   'Time of day': 'Čas dneva',
   'Done date': 'Datum zaključka',
+  'Completed by': 'Dokončal/a',
+  View: 'Ogled',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -548,4 +548,6 @@ export const svSE = {
   At: 'På',
   'Time of day': 'Tid på dagen',
   'Done date': 'Klardatum',
+  'Completed by': 'Slutförd av',
+  View: 'Se',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -548,4 +548,6 @@ export const ukUA = {
   At: 'О',
   'Time of day': 'Час доби',
   'Done date': 'Дата виконання',
+  'Completed by': 'Завершено',
+  View: 'Переглянути',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/calendar/calendar-task.model.ts
@@ -50,7 +50,7 @@ export interface CalendarTaskModel {
   // Surfaced from the AreaRulePlanning by the calendar `tasks/index` endpoint so
   // the "Opgaver og handlinger" table can resolve the eForm label and the
   // "Overskrift" (planning-tag) name from the option lists. Both optional —
-  // the week endpoint does not populate them.
+  // populated by both the tasks/index and week endpoints.
   eformId?: number | null;
   itemPlanningTagId?: number | null;
 
@@ -72,6 +72,14 @@ export interface CalendarTaskModel {
   // recurring rule share the same attachment list — see
   // 2026-05-06-calendar-event-attachments-design.md (Q1 master-rule scope).
   attachments?: CalendarTaskAttachment[];
+
+  // Completed-case fields for the historical preview card (backend
+  // CalendarTaskResponseModel.SdkCaseId / DoneByName / DoneAt). `sdkCaseId`
+  // enables the Picture-thumbnail row; `doneByName` feeds the "Completed by"
+  // group row. All optional — future/uncompleted rows omit them.
+  sdkCaseId?: number | null;
+  doneByName?: string | null;
+  doneAt?: string | null;
 }
 
 export interface CalendarTaskAttachment {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/calendar.module.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/calendar.module.ts
@@ -59,6 +59,7 @@ import {
   ComplianceCaseModalComponent,
   CalendarSelectWorkerModalComponent,
   CalendarCompleteEventModalComponent,
+  CalendarImageLightboxComponent,
 } from './modals';
 
 // Re-export modal components for barrel
@@ -73,6 +74,7 @@ export {
   ComplianceCaseModalComponent,
   CalendarSelectWorkerModalComponent,
   CalendarCompleteEventModalComponent,
+  CalendarImageLightboxComponent,
 };
 
 @NgModule({
@@ -98,6 +100,7 @@ export {
     ComplianceCaseModalComponent,
     CalendarSelectWorkerModalComponent,
     CalendarCompleteEventModalComponent,
+    CalendarImageLightboxComponent,
     TeamCreateDialogComponent,
     TeamDeleteDialogComponent,
     TagCreateDialogComponent,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -687,6 +687,10 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
   onTaskClickedFromGrid(event: {task: CalendarTaskLayoutModel; cellLeft: number; cellRight: number; slotTop: number}) {
     this.closePreviewOverlay();
 
+    // Refresh the eForm option list so the preview card can resolve the
+    // task's eformId to a display name (same pattern as openEditModal).
+    this.loadEforms();
+
     const positions = this.buildPopoverPositions(event.cellLeft, event.cellRight);
     const anchorX = this.pickAnchorX(event.cellLeft, event.cellRight);
 
@@ -712,6 +716,8 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       employees: this.employees,
       tags: this.tags.map(t => t.name),
       properties: this.properties,
+      eforms: this.eforms$,
+      planningTags: this.tags.map(t => ({id: t.id, name: t.name})),
     };
 
     const popoverInjector = Injector.create({

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-image-lightbox/calendar-image-lightbox.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-image-lightbox/calendar-image-lightbox.component.html
@@ -1,0 +1,42 @@
+<div class="lightbox" id="calendarLightbox">
+  <button
+    class="lightbox-btn lightbox-close"
+    id="calendarLightboxClose"
+    (click)="close()"
+    [attr.aria-label]="'Close' | translate"
+    [title]="'Close' | translate"
+  >
+    <mat-icon>close</mat-icon>
+  </button>
+
+  <button
+    *ngIf="data.images.length > 1"
+    class="lightbox-btn lightbox-nav lightbox-nav--prev"
+    id="calendarLightboxPrev"
+    (click)="prev()"
+    [attr.aria-label]="'Previous' | translate"
+    [title]="'Previous' | translate"
+  >
+    <mat-icon>chevron_left</mat-icon>
+  </button>
+
+  <img
+    class="lightbox-image"
+    id="calendarLightboxImage"
+    [src]="currentSrc | authImage | async"
+    alt=""
+  />
+
+  <button
+    *ngIf="data.images.length > 1"
+    class="lightbox-btn lightbox-nav lightbox-nav--next"
+    id="calendarLightboxNext"
+    (click)="next()"
+    [attr.aria-label]="'Next' | translate"
+    [title]="'Next' | translate"
+  >
+    <mat-icon>chevron_right</mat-icon>
+  </button>
+
+  <div class="lightbox-counter">{{ currentIndex + 1 }} / {{ data.images.length }}</div>
+</div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-image-lightbox/calendar-image-lightbox.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-image-lightbox/calendar-image-lightbox.component.scss
@@ -1,0 +1,75 @@
+// Dark centered lightbox. The component fills the MDC dialog surface, so a
+// dark background here (with the surface's border-radius) reads as a dark
+// modal without any global panel-class overrides.
+.lightbox {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(20, 20, 20, 0.97);
+  border-radius: inherit;
+  padding: 48px 72px;
+  min-width: 320px;
+  min-height: 240px;
+}
+
+.lightbox-image {
+  max-width: min(80vw, 1200px);
+  max-height: 78vh;
+  object-fit: contain;
+  border-radius: 4px;
+}
+
+.lightbox-btn {
+  background: rgba(255, 255, 255, 0.12);
+  border: none;
+  outline: none;
+  cursor: pointer;
+  color: #fff;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  padding: 0;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.24);
+  }
+
+  mat-icon {
+    font-size: 24px;
+    width: 24px;
+    height: 24px;
+  }
+}
+
+.lightbox-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+
+  &--prev {
+    left: 16px;
+  }
+
+  &--next {
+    right: 16px;
+  }
+}
+
+.lightbox-counter {
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 13px;
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-image-lightbox/calendar-image-lightbox.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/calendar-image-lightbox/calendar-image-lightbox.component.ts
@@ -1,0 +1,50 @@
+import {Component, Inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+
+export interface CalendarImageLightboxData {
+  /** SDK uploaded-data file names, rendered via template-files/get-image. */
+  images: string[];
+  startIndex: number;
+}
+
+/**
+ * Centered dark lightbox for the historical task card's case images.
+ * ‹ › wrap around; hidden with a single image. Esc + backdrop click close
+ * (MatDialog defaults — the opener passes disableClose: false).
+ */
+@Component({
+  standalone: false,
+  selector: 'app-calendar-image-lightbox',
+  templateUrl: './calendar-image-lightbox.component.html',
+  styleUrls: ['./calendar-image-lightbox.component.scss'],
+})
+export class CalendarImageLightboxComponent {
+  currentIndex: number;
+
+  constructor(
+    private dialogRef: MatDialogRef<CalendarImageLightboxComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: CalendarImageLightboxData,
+  ) {
+    const count = data?.images?.length ?? 0;
+    this.currentIndex = count > 0
+      ? Math.min(Math.max(data.startIndex ?? 0, 0), count - 1)
+      : 0;
+  }
+
+  get currentSrc(): string {
+    return `/api/template-files/get-image/${this.data.images[this.currentIndex]}`;
+  }
+
+  prev() {
+    const count = this.data.images.length;
+    this.currentIndex = (this.currentIndex - 1 + count) % count;
+  }
+
+  next() {
+    this.currentIndex = (this.currentIndex + 1) % this.data.images.length;
+  }
+
+  close() {
+    this.dialogRef.close();
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/index.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/index.ts
@@ -8,3 +8,4 @@ export * from './board-delete-modal/board-delete-modal.component';
 export * from './compliance-case-modal/compliance-case-modal.component';
 export {CalendarSelectWorkerModalComponent} from './calendar-select-worker-modal/calendar-select-worker-modal.component';
 export * from './calendar-complete-event-modal/calendar-complete-event-modal.component';
+export * from './calendar-image-lightbox/calendar-image-lightbox.component';

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -382,11 +382,13 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       });
     }
 
-    // Disable all controls for past tasks
+    // Disable all controls for past tasks. Completed tasks are readonly
+    // regardless of date (R2 immutability) — a completed-but-future task
+    // must open readonly too.
     if (this.isEditMode && this.dateControl.value) {
       const taskDate = this.dateControl.value;
       const endTime = this.endTimeControl.value || '00:00';
-      if (this.isInPast(taskDate, endTime)) {
+      if (this.isInPast(taskDate, endTime) || task?.completed) {
         this.isReadonly = true;
         this.titleControl.disable();
         this.dateControl.disable();
@@ -868,7 +870,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
     // date seeded from the source event; the user is expected to pick a new
     // date before saving, and we surface that via the standard datepicker
     // min-date validator rather than silently returning.
-    if (this.isEditMode && this.isInPast(this.dateControl.value!, this.startTimeControl.value!)) {
+    if (this.isEditMode && (this.isInPast(this.dateControl.value!, this.startTimeControl.value!) || this.data.task?.completed)) {
       return;
     }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.html
@@ -1,8 +1,11 @@
 <div [class.gcal-popover-card]="usePopoverMode">
   <!-- Action icons row -->
   <div class="preview-actions-row">
-    <button class="preview-icon-btn" id="calendarEventEditBtn" (click)="onEdit()" [title]="'Edit' | translate">
+    <button *ngIf="!isHistorical" class="preview-icon-btn" id="calendarEventEditBtn" (click)="onEdit()" [title]="'Edit' | translate">
       <mat-icon>edit</mat-icon>
+    </button>
+    <button *ngIf="isHistorical" class="preview-icon-btn" id="calendarEventViewBtn" (click)="onEdit()" [title]="'View' | translate">
+      <mat-icon>visibility</mat-icon>
     </button>
     <button class="preview-icon-btn" id="calendarEventCopyBtn" (click)="onCopy()" [title]="'Copy' | translate">
       <mat-icon>content_copy</mat-icon>
@@ -23,28 +26,71 @@
     <!-- Title -->
     <div class="preview-title">{{ data.task.title }}</div>
 
-    <!-- Date + Time -->
+    <!-- Schedule: day name + date + time -->
     <div class="preview-row">
       <mat-icon class="preview-icon">schedule</mat-icon>
-      <span>{{ data.task.taskDate | date:'d. MMMM yyyy' }}<ng-container *ngIf="timeDisplay">; {{ timeDisplay }}</ng-container></span>
+      <span>{{ scheduleDateLabel }}<ng-container *ngIf="data.task.isAllDay">; {{ 'All day' | translate }}</ng-container><ng-container *ngIf="!data.task.isAllDay && timeDisplay">; {{ timeDisplay }}</ng-container></span>
     </div>
 
-    <!-- Repeat -->
-    <div class="preview-row" *ngIf="data.task.repeatRule && data.task.repeatRule !== 'none'">
-      <mat-icon class="preview-icon">sync</mat-icon>
+    <!-- Repeat (always shown — "Does not repeat" for one-off tasks) -->
+    <div class="preview-row">
+      <mat-icon class="preview-icon">repeat</mat-icon>
       <span>{{ repeatLabel }}</span>
     </div>
 
-    <!-- Repeat = none -->
-    <div class="preview-row" *ngIf="!data.task.repeatRule || data.task.repeatRule === 'none'">
-      <mat-icon class="preview-icon">sync</mat-icon>
-      <span>{{ 'Does not repeat' | translate }}</span>
+    <!-- Property -->
+    <div class="preview-row" *ngIf="propertyName">
+      <mat-icon class="preview-icon">domain</mat-icon>
+      <span>{{ propertyName }}</span>
+    </div>
+
+    <!-- Calendar (board) + color dot -->
+    <div class="preview-row" *ngIf="boardName">
+      <mat-icon class="preview-icon">calendar_today</mat-icon>
+      <span class="preview-board-dot" [style.background-color]="boardColor"></span>
+      <span>{{ boardName }}</span>
+    </div>
+
+    <!-- Completed by (historical + completed cards) -->
+    <div class="preview-row" *ngIf="completedByName">
+      <mat-icon class="preview-icon">group</mat-icon>
+      <span>{{ 'Completed by' | translate }}: {{ completedByName }}</span>
+    </div>
+
+    <!-- Assignees: worker + team chips -->
+    <div class="preview-row preview-row--chips" *ngIf="!completedByName && assigneeChips.length">
+      <mat-icon class="preview-icon">group</mat-icon>
+      <span class="preview-chips">
+        <span class="preview-chip preview-chip--worker" *ngFor="let chip of assigneeChips">{{ chip }}</span>
+      </span>
     </div>
 
     <!-- Tags -->
-    <div class="preview-row" *ngIf="data.task.tags?.length">
-      <mat-icon class="preview-icon">label</mat-icon>
-      <span>{{ data.task.tags.join(', ') }}</span>
+    <div class="preview-row preview-row--chips" *ngIf="data.task.tags?.length">
+      <mat-icon class="preview-icon">style</mat-icon>
+      <span class="preview-chips">
+        <span class="preview-chip" *ngFor="let tag of data.task.tags">{{ tag }}</span>
+      </span>
+    </div>
+
+    <!-- Report headline (item-planning tag) -->
+    <div class="preview-row" *ngIf="reportHeadline">
+      <mat-icon class="preview-icon">stacks</mat-icon>
+      <span>{{ reportHeadline }}</span>
+    </div>
+
+    <!-- eForm -->
+    <div class="preview-row" *ngIf="eformName">
+      <mat-icon class="preview-icon">checklist</mat-icon>
+      <span>{{ eformName }}</span>
+    </div>
+
+    <!-- Attachments -->
+    <div class="preview-row preview-row--chips" *ngIf="data.task.attachments?.length">
+      <mat-icon class="preview-icon">attach_file</mat-icon>
+      <span class="preview-chips">
+        <span class="preview-chip" *ngFor="let att of data.task.attachments">{{ att.originalFileName }}</span>
+      </span>
     </div>
 
     <!-- Description -->
@@ -59,16 +105,32 @@
       <a [href]="data.task.driveLink" target="_blank" rel="noopener">{{ 'Open link' | translate }}</a>
     </div>
 
-    <!-- Property -->
-    <div class="preview-row" *ngIf="propertyName">
-      <mat-icon class="preview-icon">business</mat-icon>
-      <span>{{ propertyName }}</span>
+    <!-- Case images (historical + completed cards; hidden when none) -->
+    <div class="preview-row preview-row--images" *ngIf="caseImagesLoading || caseImageFileNames.length">
+      <mat-icon class="preview-icon">image</mat-icon>
+      <mat-spinner *ngIf="caseImagesLoading" diameter="20"></mat-spinner>
+      <span class="preview-thumbs" *ngIf="!caseImagesLoading">
+        <img
+          *ngFor="let fileName of caseImageFileNames; let i = index"
+          class="preview-thumb"
+          [src]="imageSrc(fileName) | authImage | async"
+          (click)="openLightbox(i)"
+          alt=""
+        />
+      </span>
     </div>
 
-    <!-- Calendar (board) -->
-    <div class="preview-row" *ngIf="boardName">
-      <mat-icon class="preview-icon">calendar_today</mat-icon>
-      <span>{{ boardName }}</span>
+    <!-- Status toggle (future cards only) -->
+    <div class="preview-row" *ngIf="!isHistorical">
+      <mat-icon class="preview-icon preview-toggle--on" *ngIf="data.task.status">toggle_on</mat-icon>
+      <mat-icon class="preview-icon preview-toggle--off" *ngIf="!data.task.status">toggle_off</mat-icon>
+      <span>{{ (data.task.status ? 'Task visible on calendar and shown in app' : 'Task dimmed on calendar and not shown in app') | translate }}</span>
+    </div>
+
+    <!-- Compliance/overdue policy (future cards only) -->
+    <div class="preview-row" *ngIf="!isHistorical && data.task.complianceEnabled">
+      <mat-icon class="preview-icon">policy</mat-icon>
+      <span>{{ 'Overdue task shown in app' | translate }}</span>
     </div>
   </div>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.scss
@@ -96,3 +96,82 @@
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
+
+// Board color dot on the calendar row.
+.preview-board-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+// Chip rows (assignees / tags / attachments) — modeled on the module's
+// compliance-chip style (calendar-compliance-view.component.scss).
+.preview-row--chips {
+  align-items: flex-start;
+
+  .preview-icon {
+    margin-top: 5px;
+  }
+}
+
+.preview-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.preview-chip {
+  background: #f1f3f4;
+  border-radius: 12px;
+  padding: 2px 10px;
+  font-size: 12px;
+  white-space: nowrap;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &--worker {
+    background: #1a73e8;
+    color: #fff;
+  }
+}
+
+// Status toggle row. No theme variable exists for these — the app's SCSS
+// only defines --error (#ea4335); use the spec'd Google green/red directly.
+.preview-toggle--on {
+  color: #188038;
+}
+
+.preview-toggle--off {
+  color: #d93025;
+}
+
+// Completed-case Picture thumbnails (historical cards).
+.preview-row--images {
+  align-items: flex-start;
+
+  .preview-icon {
+    margin-top: 7px;
+  }
+}
+
+.preview-thumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.preview-thumb {
+  width: 64px;
+  height: 64px;
+  object-fit: cover;
+  border-radius: 6px;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.85;
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.ts
@@ -1,12 +1,19 @@
-import {Component, EventEmitter, Inject, Optional, Output} from '@angular/core';
+import {Component, EventEmitter, Inject, OnDestroy, OnInit, Optional, Output} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {Overlay} from '@angular/cdk/overlay';
+import {Observable, Subscription} from 'rxjs';
 import {dialogConfigHelper} from 'src/app/common/helpers';
-import {BackendConfigurationPnCalendarService} from '../../../../services';
+import {
+  BackendConfigurationPnCalendarService,
+  BackendConfigurationPnCompliancesService,
+} from '../../../../services';
 import {CalendarBoardModel, CalendarTaskModel, RepeatDeleteScope} from '../../../../models/calendar';
-import {CommonDictionaryModel} from 'src/app/common/models';
+import {CommonDictionaryModel, DataItemDto, ElementDto, ReplyElementDto} from 'src/app/common/models';
 import {TaskDeleteModalComponent} from '../task-delete-modal/task-delete-modal.component';
 import {RepeatScopeModalComponent} from '../repeat-scope-modal/repeat-scope-modal.component';
+import {CalendarImageLightboxComponent} from '../calendar-image-lightbox/calendar-image-lightbox.component';
+import {CalendarRepeatService} from '../../services/calendar-repeat.service';
+import {getCurrentLocale} from '../../services/calendar-locale.helper';
 import {TranslateService} from '@ngx-translate/core';
 
 export interface TaskPreviewModalData {
@@ -15,6 +22,13 @@ export interface TaskPreviewModalData {
   employees: CommonDictionaryModel[];
   tags: string[];
   properties: CommonDictionaryModel[];
+  // eForm option list (id + label) for resolving the task's eformId to a
+  // display name. Passed as the container's eforms$ observable — the
+  // container calls loadEforms() before opening the preview.
+  eforms: Observable<{id: number; label: string}[]>;
+  // Item-planning tags (id + name) for resolving itemPlanningTagId to the
+  // report headline ("Overskrift") name.
+  planningTags: {id: number; name: string}[];
 }
 
 @Component({
@@ -23,9 +37,19 @@ export interface TaskPreviewModalData {
   templateUrl: './task-preview-modal.component.html',
   styleUrls: ['./task-preview-modal.component.scss'],
 })
-export class TaskPreviewModalComponent {
+export class TaskPreviewModalComponent implements OnInit, OnDestroy {
   @Output() popoverClose = new EventEmitter<string | null>();
   usePopoverMode = false;
+
+  private eformsList: {id: number; label: string}[] = [];
+
+  // Picture-field thumbnails of the completed case (historical + completed
+  // cards only). Loaded lazily per card-open — never cached across openings
+  // (the component is recreated on every open).
+  caseImageFileNames: string[] = [];
+  caseImagesLoading = false;
+
+  private subs: Subscription[] = [];
 
   constructor(
     @Optional() private dialogRef: MatDialogRef<TaskPreviewModalComponent>,
@@ -33,8 +57,23 @@ export class TaskPreviewModalComponent {
     private dialog: MatDialog,
     private overlay: Overlay,
     private calendarService: BackendConfigurationPnCalendarService,
+    private compliancesService: BackendConfigurationPnCompliancesService,
+    private repeatService: CalendarRepeatService,
     private translate: TranslateService,
   ) {}
+
+  ngOnInit() {
+    if (this.data.eforms) {
+      this.subs.push(this.data.eforms.subscribe(list => (this.eformsList = list ?? [])));
+    }
+    if (this.isHistorical && this.data.task.completed && this.data.task.sdkCaseId) {
+      this.loadCaseImages();
+    }
+  }
+
+  ngOnDestroy() {
+    this.subs.forEach(s => s.unsubscribe());
+  }
 
   get boardName(): string {
     const board = this.data.boards.find(b => b.id === this.data.task.boardId);
@@ -49,6 +88,28 @@ export class TaskPreviewModalComponent {
   get propertyName(): string {
     const prop = this.data.properties?.find(p => p.id === this.data.task.propertyId);
     return prop?.name ?? '';
+  }
+
+  get eformName(): string {
+    const id = this.data.task.eformId;
+    if (id == null) return '';
+    return this.eformsList.find(e => e.id === id)?.label ?? '';
+  }
+
+  get reportHeadline(): string {
+    const id = this.data.task.itemPlanningTagId;
+    if (id == null) return '';
+    return this.data.planningTags?.find(t => t.id === id)?.name ?? '';
+  }
+
+  /** Localized "Torsdag 16. juli 2026" — weekday first-letter capitalized. */
+  get scheduleDateLabel(): string {
+    const locale = getCurrentLocale(this.translate);
+    const d = new Date(this.data.task.taskDate);
+    const weekday = d.toLocaleDateString(locale, {weekday: 'long'});
+    const rest = d.toLocaleDateString(locale, {day: 'numeric', month: 'long', year: 'numeric'});
+    const label = `${weekday} ${rest}`;
+    return label.charAt(0).toUpperCase() + label.slice(1);
   }
 
   get timeDisplay(): string {
@@ -66,17 +127,126 @@ export class TaskPreviewModalComponent {
     return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
   }
 
+  /**
+   * Full Gentag option label, matching what the edit modal's dropdown shows
+   * for the task: reconstruct the repeat meta and format it via
+   * CalendarRepeatService (e.g. "Weekly every torsdag", "Every 2 weeks: …").
+   * Falls back to a generic rule label for legacy rows the reconstruction
+   * can't recover.
+   */
   get repeatLabel(): string {
-    const rule = this.data.task.repeatRule;
+    const task = this.data.task;
+    if (!task.repeatRule || task.repeatRule === 'none') {
+      return this.translate.instant('Does not repeat');
+    }
+    const meta = this.repeatService.reconstructMetaFromTask(task);
+    if (meta) {
+      return this.repeatService.formatCustomRepeatLabel(meta, getCurrentLocale(this.translate));
+    }
     const labels: Record<string, string> = {
       daily: this.translate.instant('Daily'),
       weeklyOne: this.translate.instant('Weekly'),
       weeklyAll: this.translate.instant('Every weekday'),
+      weekdays: this.translate.instant('All weekdays (Monday to Friday)'),
       monthlyDom: this.translate.instant('Monthly'),
       yearlyOne: this.translate.instant('Yearly'),
       custom: this.translate.instant('Custom'),
     };
-    return labels[rule] ?? rule;
+    return labels[task.repeatRule] ?? task.repeatRule;
+  }
+
+  /**
+   * Historical = completed (R2 immutability — regardless of date) OR the
+   * task's end lies in the past. Mirrors the edit modal's isInPast rule
+   * (taskDate + endTime vs. now).
+   */
+  get isHistorical(): boolean {
+    const task = this.data.task;
+    if (task.completed) return true;
+    const endTime = task.endText || this.hourToTimeStr(task.startHour + task.duration) || '00:00';
+    const [hours, minutes] = endTime.split(':').map(Number);
+    const end = new Date(task.taskDate);
+    end.setHours(hours, minutes, 0, 0);
+    return end < new Date();
+  }
+
+  /** Non-null only when the group row should show "Completed by: <name>". */
+  get completedByName(): string | null {
+    const task = this.data.task;
+    if (this.isHistorical && task.completed && task.doneByName) {
+      return task.doneByName;
+    }
+    return null;
+  }
+
+  get assigneeChips(): string[] {
+    const task = this.data.task;
+    return [...(task.workerNames ?? []), ...(task.workerTagNames ?? [])];
+  }
+
+  imageSrc(fileName: string): string {
+    return `/api/template-files/get-image/${fileName}`;
+  }
+
+  openLightbox(index: number) {
+    this.dialog.open(CalendarImageLightboxComponent, {
+      ...dialogConfigHelper(this.overlay, {
+        images: this.caseImageFileNames,
+        startIndex: index,
+      }),
+      // Lightbox must close on Esc + backdrop click (dialogConfigHelper
+      // defaults to disableClose: true).
+      disableClose: false,
+      maxWidth: '95vw',
+    });
+  }
+
+  private loadCaseImages() {
+    this.caseImagesLoading = true;
+    // templateId is unused server-side for the lookup; pass the task's
+    // eformId when present (may be null on week-endpoint rows).
+    this.subs.push(
+      this.compliancesService
+        .getCase(this.data.task.sdkCaseId!, this.data.task.eformId ?? 0)
+        .subscribe({
+          next: op => {
+            this.caseImagesLoading = false;
+            if (op && op.success && op.model) {
+              this.caseImageFileNames = this.collectPictureFileNames(op.model);
+            }
+          },
+          // Errors hide the row silently (caseImageFileNames stays empty).
+          error: () => (this.caseImagesLoading = false),
+        })
+    );
+  }
+
+  /**
+   * Walk the ReplyElement exactly like the complete-event modal's
+   * partialLoadCase: recurse element lists + FieldContainers, collect the
+   * Picture fieldValues' uploadedDataObj.fileName.
+   */
+  private collectPictureFileNames(reply: ReplyElementDto): string[] {
+    const out: string[] = [];
+    const walkDataItem = (item: DataItemDto) => {
+      if (item.fieldType === 'FieldContainer') {
+        (item.dataItemList ?? []).forEach(walkDataItem);
+        return;
+      }
+      if (item.fieldType === 'Picture') {
+        (item.fieldValues ?? []).forEach(v => {
+          if (v.uploadedDataObj?.fileName) {
+            out.push(v.uploadedDataObj.fileName);
+          }
+        });
+      }
+    };
+    const walkElement = (el: ElementDto) => {
+      (el.elementList ?? []).forEach(walkElement);
+      (el.dataItemList ?? []).forEach(walkDataItem);
+    };
+    (reply.elementList ?? []).forEach(walkElement);
+    return out;
   }
 
   onEdit() {


### PR DESCRIPTION
## Summary

Extends the calendar task-preview popover (opgavekortet) per the reviewed design mockup:

**Future tasks** — the card now shows the complete field set, in order: schedule (localized weekday + date + time), repeat (always, full Gentag label), property (`domain`), calendar name + color dot (`calendar_today`), assignee/team chips (`group`), tag chips (`style`), report headline (`stacks`), eForm (`checklist`), attachment chips (`attach_file`), green/red visible-dimmed toggle row, and the overdue-in-app `policy` row (only when enabled). Empty rows are hidden.

**Historical tasks** (past end time, or completed — R2 immutability) — the edit pencil is replaced by a `visibility` action (`#calendarEventViewBtn`) opening the edit modal in its readonly mode; completed cards show **Udført af** + the actual completer; toggle/policy rows are omitted; case photo thumbnails render lazily from the completed SDK case's Picture fields and open in a new centered lightbox modal (wrap-around ‹ ›, X/Esc/backdrop close, arrows hidden for a single image).

**Backend** — `GetTasksForWeek` now returns `DoneByName`/`DoneAt` on completed compliance rows, resolved from the already-batch-loaded SDK case + site dictionary (zero additional queries). No endpoint or migration changes.

**Also fixed** — completed-but-future occurrences were still editable in the edit modal; the readonly guard now covers `completed`.

**Live refresh** — all edit/copy/complete/delete paths re-render the grid and a re-opened card without a page reload (verified in browser).

## Tests

- New `m/calendar-task-card.spec.ts`: future-card row assertions, policy/status gating, live-refresh-without-reload (KC01–KC04; KC05/KC06 fixme with reasons matching suite precedent — past/completed cards aren't producible via UI, consistent with t/E17 + p/X03).
- Page objects hardened: `clickEditOrViewInPreview()` resolves whichever action renders; audit confirmed no existing spec previews a past/completed event.
- `u/calendar-resize` F1 extended to lock the tense-aware action row.

## Verification

Verified live in dev: future card rows/icons/chips, historical eye→readonly modal, 'Udført af' from the new backend fields, image-row hidden for photo-less cases, and no-F5 refresh after edit/complete. Full solution + dev ng build green; code-reviewed with zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)