### PR TITLE
Calendar task card: match mockup schedule layout and short toggle labels

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -550,4 +550,6 @@ export const bgBG = {
   'Done date': 'Дата на завършване',
   'Completed by': 'Завършено от',
   View: 'Преглед',
+  'Task visible on calendar': 'Задачата е видима в календара',
+  'Task dimmed on calendar': 'Задачата е затъмнена в календара',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -550,4 +550,6 @@ export const csCZ = {
   'Done date': 'Datum dokončení',
   'Completed by': 'Dokončeno kým',
   View: 'Pohled',
+  'Task visible on calendar': 'Úkol viditelný v kalendáři',
+  'Task dimmed on calendar': 'Úkol je v kalendáři zobrazen šedě',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -551,4 +551,6 @@ export const da = {
   'Done date': 'Udført dato',
   'Completed by': 'Udført af',
   View: 'Vis',
+  'Task visible on calendar': 'Opgave synlig i kalender',
+  'Task dimmed on calendar': 'Opgave nedtonet i kalender',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -598,4 +598,6 @@ export const deDE = {
   'Time of day': 'Uhrzeit',
   'Done date': 'Fertigstellungsdatum',
   'Completed by': 'Abgeschlossen von',
+  'Task visible on calendar': 'Aufgabe im Kalender sichtbar',
+  'Task dimmed on calendar': 'Aufgabe im Kalender ausgegraut',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -550,4 +550,6 @@ export const elGR = {
   'Done date': 'Ημερομηνία ολοκλήρωσης',
   'Completed by': 'Ολοκληρώθηκε από',
   View: 'Θέα',
+  'Task visible on calendar': 'Εργασία ορατή στο ημερολόγιο',
+  'Task dimmed on calendar': 'Η εργασία είναι απενεργοποιημένη στο ημερολόγιο',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -569,4 +569,6 @@ export const enUS= {
   'Time of day': 'Time of day',
   'Completed by': 'Completed by',
   View: 'View',
+  'Task visible on calendar': 'Task visible on calendar',
+  'Task dimmed on calendar': 'Task dimmed on calendar',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -550,4 +550,6 @@ export const esES = {
   'Done date': 'Fecha de finalización',
   'Completed by': 'Completado por',
   View: 'Vista',
+  'Task visible on calendar': 'Tarea visible en el calendario',
+  'Task dimmed on calendar': 'La tarea aparece atenuada en el calendario.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -550,4 +550,6 @@ export const etET = {
   'Done date': 'Valmis kuupäev',
   'Completed by': 'Lõpetanud',
   View: 'Vaade',
+  'Task visible on calendar': 'Ülesanne kalendris nähtav',
+  'Task dimmed on calendar': 'Ülesanne on kalendris tuhmitud',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -550,4 +550,6 @@ export const fiFI = {
   'Done date': 'Valmistumispäivämäärä',
   'Completed by': 'Valmistui',
   View: 'Näytä',
+  'Task visible on calendar': 'Tehtävä näkyy kalenterissa',
+  'Task dimmed on calendar': 'Tehtävä himmennettynä kalenterissa',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -549,4 +549,6 @@ export const frFR = {
   'Done date': 'Date de réalisation',
   'Completed by': 'Terminé par',
   View: 'Voir',
+  'Task visible on calendar': 'Tâche visible sur le calendrier',
+  'Task dimmed on calendar': 'Tâche grisée dans le calendrier',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -550,4 +550,6 @@ export const hrHR = {
   'Done date': 'Datum završetka',
   'Completed by': 'Završio/la',
   View: 'Pogled',
+  'Task visible on calendar': 'Zadatak vidljiv u kalendaru',
+  'Task dimmed on calendar': 'Zadatak je zatamnjen u kalendaru',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -550,4 +550,6 @@ export const huHU = {
   'Done date': 'Kész dátum',
   'Completed by': 'Befejezte',
   View: 'Kilátás',
+  'Task visible on calendar': 'Feladat látható a naptárban',
+  'Task dimmed on calendar': 'Feladat szürkítve a naptárban',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -550,4 +550,6 @@ export const isIS = {
   'Done date': 'Lokadagur',
   'Completed by': 'Lokið af',
   View: 'Skoða',
+  'Task visible on calendar': 'Verkefni sýnilegt á dagatali',
+  'Task dimmed on calendar': 'Verkefni dimmt í dagatali',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -550,4 +550,6 @@ export const itIT = {
   'Done date': 'Data di completamento',
   'Completed by': 'Completato da',
   View: 'Visualizzazione',
+  'Task visible on calendar': 'Attività visibile sul calendario',
+  'Task dimmed on calendar': 'Attività oscurata sul calendario',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -550,4 +550,6 @@ export const ltLT = {
   'Done date': 'Atlikimo data',
   'Completed by': 'Užbaigė',
   View: 'Peržiūrėti',
+  'Task visible on calendar': 'Užduotis matoma kalendoriuje',
+  'Task dimmed on calendar': 'Užduotis kalendoriuje rodoma blankiai',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -550,4 +550,6 @@ export const lvLV = {
   'Done date': 'Pabeigšanas datums',
   'Completed by': 'Pabeidzis',
   View: 'Skatīt',
+  'Task visible on calendar': 'Uzdevums ir redzams kalendārā',
+  'Task dimmed on calendar': 'Uzdevums kalendārā ir aptumšots',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -550,4 +550,6 @@ export const nlNL = {
   'Done date': 'Voltooiingsdatum',
   'Completed by': 'Voltooid door',
   View: 'Weergave',
+  'Task visible on calendar': 'Taak zichtbaar op de kalender',
+  'Task dimmed on calendar': 'Taak grijs weergegeven op de kalender',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -550,4 +550,6 @@ export const noNO = {
   'Done date': 'Ferdigdato',
   'Completed by': 'Fullført av',
   View: 'Utsikt',
+  'Task visible on calendar': 'Oppgave synlig i kalenderen',
+  'Task dimmed on calendar': 'Oppgave nedtonet i kalenderen',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -550,4 +550,6 @@ export const plPL = {
   'Done date': 'Data wykonania',
   'Completed by': 'Ukończone przez',
   View: 'Pogląd',
+  'Task visible on calendar': 'Zadanie widoczne w kalendarzu',
+  'Task dimmed on calendar': 'Zadanie przyciemnione w kalendarzu',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -550,4 +550,6 @@ export const ptBR = {
   'Done date': 'Data de conclusão',
   'Completed by': 'Concluído por',
   View: 'Visualizar',
+  'Task visible on calendar': 'Tarefa visível no calendário',
+  'Task dimmed on calendar': 'Tarefa esmaecida no calendário',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -550,4 +550,6 @@ export const ptPT = {
   'Done date': 'Data de conclusão',
   'Completed by': 'Concluído por',
   View: 'Visualizar',
+  'Task visible on calendar': 'Tarefa visível no calendário',
+  'Task dimmed on calendar': 'Tarefa esmaecida no calendário',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -550,4 +550,6 @@ export const roRO = {
   'Done date': 'Data finalizării',
   'Completed by': 'Completat de',
   View: 'Vedere',
+  'Task visible on calendar': 'Sarcină vizibilă în calendar',
+  'Task dimmed on calendar': 'Sarcină estompată în calendar',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -550,4 +550,6 @@ export const skSK = {
   'Done date': 'Dátum dokončenia',
   'Completed by': 'Dokončil/a',
   View: 'Zobraziť',
+  'Task visible on calendar': 'Úloha viditeľná v kalendári',
+  'Task dimmed on calendar': 'Úloha je v kalendári zobrazená sivou farbou',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -550,4 +550,6 @@ export const slSL = {
   'Done date': 'Datum zaključka',
   'Completed by': 'Dokončal/a',
   View: 'Ogled',
+  'Task visible on calendar': 'Opravilo vidno v koledarju',
+  'Task dimmed on calendar': 'Opravilo je v koledarju zatemnjeno',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -550,4 +550,6 @@ export const svSE = {
   'Done date': 'Klardatum',
   'Completed by': 'Slutförd av',
   View: 'Se',
+  'Task visible on calendar': 'Uppgift synlig i kalendern',
+  'Task dimmed on calendar': 'Uppgift nedtonad i kalendern',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -550,4 +550,6 @@ export const ukUA = {
   'Done date': 'Дата виконання',
   'Completed by': 'Завершено',
   View: 'Переглянути',
+  'Task visible on calendar': 'Завдання відображається в календарі',
+  'Task dimmed on calendar': 'Завдання затемнене в календарі',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.html
@@ -26,10 +26,14 @@
     <!-- Title -->
     <div class="preview-title">{{ data.task.title }}</div>
 
-    <!-- Schedule: day name + date + time -->
-    <div class="preview-row">
+    <!-- Schedule: day name + date, time on a smaller second line (mockup layout) -->
+    <div class="preview-row preview-row--schedule">
       <mat-icon class="preview-icon">schedule</mat-icon>
-      <span>{{ scheduleDateLabel }}<ng-container *ngIf="data.task.isAllDay">; {{ 'All day' | translate }}</ng-container><ng-container *ngIf="!data.task.isAllDay && timeDisplay">; {{ timeDisplay }}</ng-container></span>
+      <span class="preview-schedule">
+        {{ scheduleDateLabel }}
+        <span class="preview-schedule-sub" *ngIf="data.task.isAllDay">{{ 'All day' | translate }}</span>
+        <span class="preview-schedule-sub" *ngIf="!data.task.isAllDay && timeDisplay">{{ timeDisplay }}</span>
+      </span>
     </div>
 
     <!-- Repeat (always shown — "Does not repeat" for one-off tasks) -->
@@ -124,7 +128,7 @@
     <div class="preview-row" *ngIf="!isHistorical">
       <mat-icon class="preview-icon preview-toggle--on" *ngIf="data.task.status">toggle_on</mat-icon>
       <mat-icon class="preview-icon preview-toggle--off" *ngIf="!data.task.status">toggle_off</mat-icon>
-      <span>{{ (data.task.status ? 'Task visible on calendar and shown in app' : 'Task dimmed on calendar and not shown in app') | translate }}</span>
+      <span>{{ (data.task.status ? 'Task visible on calendar' : 'Task dimmed on calendar') | translate }}</span>
     </div>
 
     <!-- Compliance/overdue policy (future cards only) -->

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-preview-modal/task-preview-modal.component.scss
@@ -81,6 +81,26 @@
   flex-shrink: 0;
 }
 
+// Mockup layout: date on the first line, time (or "All day") on a smaller
+// muted second line. The icon top-aligns with the date line.
+.preview-row--schedule {
+  align-items: flex-start;
+
+  .preview-icon {
+    margin-top: 2px;
+  }
+}
+
+.preview-schedule {
+  display: flex;
+  flex-direction: column;
+
+  .preview-schedule-sub {
+    font-size: 12px;
+    color: #5f6368;
+  }
+}
+
 // Description can span multiple lines: top-align the icon and preserve the
 // line breaks / whitespace the user typed in the Beskrivelse field so the
 // formatting is reflected here. Long words wrap instead of overflowing.


### PR DESCRIPTION
## Summary

Two visual polish items to make the task-preview card match the approved design mockup exactly (follow-up to #1050):

- **Schedule row** — date on the first line, time (or *Hele dagen*) on a smaller muted second line, instead of a single semicolon-joined line.
- **Toggle row** — short labels **"Opgave synlig i kalender"** / **"Opgave nedtonet i kalender"** (new i18n keys propagated to all 26 locales, Danish hand-corrected; 'kalender' wording per the PR #1035 naming convention) instead of the long "…og vises i app" strings.

No logic changes. Existing e2e assertions are icon/partial-text based and unaffected (verified). Rendered result verified in dev against the mockup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)