### PR TITLE
Calendar week title: name both months on border weeks, lowercase month names

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.spec.ts
@@ -648,6 +648,47 @@ test.describe.serial('Calendar UI enhancements', () => {
       const after = await calendarPage.getCalendarHeaderDateText();
       expect(after).toBe(formatLongDate(addDays(mondayOfThisWeekLocal(), 7)));
     });
+
+    // Mirror calendar-header.component.ts displayDate for WEEK view: locale
+    // month names untouched (da-DK ⇒ lowercase, never capitalized); a week
+    // straddling a month border names both months ("juni - juli 2026"); a
+    // year border keeps each month's own year ("december 2026 - januar 2027").
+    // See 2026-07-15-calendar-week-title-two-months-design.md.
+    function formatWeekTitle(monday: Date, locale = 'da-DK'): string {
+      const sunday = addDays(monday, 6);
+      const m1 = monday.toLocaleDateString(locale, { month: 'long' });
+      const m2 = sunday.toLocaleDateString(locale, { month: 'long' });
+      const y1 = monday.getFullYear();
+      const y2 = sunday.getFullYear();
+      if (m1 === m2 && y1 === y2) return `${m1} ${y1}`;
+      if (y1 === y2) return `${m1} - ${m2} ${y1}`;
+      return `${m1} ${y1} - ${m2} ${y2}`;
+    }
+
+    test('H4: week title is lowercase and names both months on border weeks', async ({ page }) => {
+      const calendarPage = new CalendarUiEnhancementsPage(page);
+      await page.locator('app-calendar-week-grid').waitFor({ state: 'visible', timeout: 10000 });
+
+      // Current week: title must match the rule exactly — in particular the
+      // month name keeps the locale's lowercase (no manual capitalization).
+      let monday = mondayOfThisWeekLocal();
+      const initial = await calendarPage.getCalendarHeaderDateText();
+      expect(initial).toBe(formatWeekTitle(monday));
+      expect(initial.charAt(0)).toBe(initial.charAt(0).toLowerCase());
+
+      // Walk forward to the next month-border week (always within 5 steps)
+      // and assert both month names appear, joined by the spaced hyphen.
+      let steps = 0;
+      while (monday.getMonth() === addDays(monday, 6).getMonth() && steps < 5) {
+        await calendarPage.navigateToNextWeek();
+        monday = addDays(monday, 7);
+        steps++;
+      }
+      expect(monday.getMonth()).not.toBe(addDays(monday, 6).getMonth());
+      const crossTitle = await calendarPage.getCalendarHeaderDateText();
+      expect(crossTitle).toBe(formatWeekTitle(monday));
+      expect(crossTitle).toContain(' - ');
+    });
   });
 
   // =======================================================================

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.ts
@@ -63,11 +63,22 @@ export class CalendarHeaderComponent implements OnInit, OnChanges {
       // Capitalize first letter (Danish locale returns "lørdag, …" lowercase).
       return formatted.charAt(0).toUpperCase() + formatted.slice(1);
     }
-    // Week view: "Month Year" (e.g. "April 2026").
+    // Week view: month(s) of the week's Monday and Sunday, rendered exactly
+    // as the locale produces them — Danish stays lowercase ("juli 2026").
+    // A week straddling a month border names both months with a spaced
+    // hyphen ("juni - juli 2026"); a year border keeps each month's own
+    // year ("december 2026 - januar 2027"). See
+    // 2026-07-15-calendar-week-title-two-months-design.md.
     const monday = this.getMondayOfWeek(d);
-    const formatted = monday.toLocaleDateString(locale, {month: 'long', year: 'numeric'});
-    // Capitalize first letter (Danish locale returns "april 2026" lowercase).
-    return formatted.charAt(0).toUpperCase() + formatted.slice(1);
+    const sunday = new Date(monday);
+    sunday.setDate(monday.getDate() + 6);
+    const m1 = monday.toLocaleDateString(locale, {month: 'long'});
+    const m2 = sunday.toLocaleDateString(locale, {month: 'long'});
+    const y1 = monday.getFullYear();
+    const y2 = sunday.getFullYear();
+    if (m1 === m2 && y1 === y2) return `${m1} ${y1}`;
+    if (y1 === y2) return `${m1} - ${m2} ${y1}`;
+    return `${m1} ${y1} - ${m2} ${y2}`;
   }
 
   get weekBadge(): string {


### PR DESCRIPTION
## Summary

Per the approved mockup (`calendar-week-title-mockup.html`): in **week view**, a week that straddles a month border now titles itself with both month names before the UGE chip — **"juni - juli 2026"** (uge 27: man 29. juni – søn 5. juli) — instead of showing only the Monday's month. Month names are rendered exactly as the locale produces them, so Danish is always lowercase ("juli 2026", never "Juli 2026"); the manual first-letter capitalization is removed from the week-view branch only. Year-border weeks keep each month's own year: **"december 2026 - januar 2027"** (uge 53).

Unchanged: day/schedule long-date titles (capital weekday letter stays), the ISO "UGE n" badge, and the compliance view's period label.

## Tests

New **H4** in `r/calendar-ui-enhancements.spec.ts`: asserts the current week's title matches the rule exactly (incl. lowercase first letter), then walks forward to the next month-border week (≤5 steps) and asserts both months appear joined by the spaced hyphen. Date math mirrors the component via a local `formatWeekTitle` helper (da-DK), same pattern as the existing `formatLongDate`.

## Verification

Verified live in dev: uge 29 → "juli 2026", uge 27 → "juni - juli 2026 · UGE 27"; the interactive mockup stepper validated all border weeks incl. uge 53 → "december 2026 - januar 2027". Dev build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)