### PR TITLE
Add e2e regression lock: now-line renders above task tiles

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.spec.ts
@@ -893,4 +893,39 @@ test.describe.serial('Calendar UI enhancements', () => {
       await calendarPage.closeEventModal();
     });
   });
+
+  // -----------------------------------------------------------------------
+  // N. Now-line (current-time indicator) stacking — regression lock for
+  //    PR #992: the red timeline must render in FRONT of task tiles
+  //    ("Tidslinje skal ligge forrest ift. grid"). A clicked/raised tile
+  //    gets z-index 999 (calendar-task-block.component.ts click-to-raise);
+  //    the now-line sits at z-index 1000 (calendar-week-grid.component.scss
+  //    .now-line). Both resolve in the same stacking context
+  //    (.day-cell-content), so comparing computed z-indexes is a faithful
+  //    proxy for paint order.
+  // =======================================================================
+  test.describe('Calendar — now-line above task tiles', () => {
+    test('N1: now-line is visible today and stacks above raised tiles', async ({ page }) => {
+      await page.locator('app-calendar-week-grid').waitFor({ state: 'visible', timeout: 10000 });
+
+      // Exactly one line — rendered only in today's column of the current week.
+      const nowLine = page.locator('app-calendar-week-grid .now-line');
+      await expect(nowLine).toHaveCount(1);
+      await expect(nowLine).toBeVisible();
+
+      const zIndex = await nowLine.evaluate(
+        el => parseInt(getComputedStyle(el).zIndex, 10)
+      );
+      const RAISED_TILE_Z = 999; // calendar-task-block.component.ts raise value
+      expect(zIndex).toBeGreaterThan(RAISED_TILE_Z);
+    });
+
+    test('N2: now-line disappears when navigating away from the current week', async ({ page }) => {
+      await page.locator('app-calendar-week-grid').waitFor({ state: 'visible', timeout: 10000 });
+      const calendarPage = new CalendarUiEnhancementsPage(page);
+
+      await calendarPage.navigateToNextWeek();
+      await expect(page.locator('app-calendar-week-grid .now-line')).toHaveCount(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Regression coverage for PR #992 (the "Tidslinje skal ligge forrest ift. grid" fix, shipped in v10.0.49) — the fix had no e2e lock, so a future z-index change could silently push the current-time line behind event tiles again.

Two tests in the r/ calendar-ui-enhancements suite:

- **N1** — the now-line is visible (exactly one, in today's column) and its computed `z-index` is greater than the raised-tile value (999 from click-to-raise). Both elements share the `.day-cell-content` stacking context, so the computed-style comparison faithfully proxies paint order.
- **N2** — navigating to the next week removes the line (it only renders in the current week's today column).

Both assertions were validated against the live dev app (count 1 / z-index 1000 this week; count 0 next week), plus a forced-overlap visual check confirming the line paints over a tile.

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)