### PR TITLE
Calendar: Uge→Dag shows today on current week; autofocus Titel on create

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/m/calendar-task-card.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/m/calendar-task-card.spec.ts
@@ -447,6 +447,12 @@ test.describe.serial('Calendar task-card preview (task-card-preview-fields)', ()
     await uiPage.openEventPreview(kc01Title);
     await calendarPage.clickEditOrViewInPreview();
 
+    // Edit mode must NOT steal focus to Titel — autofocus is create-only
+    // (2026-07-17 design; the create-side assertion lives in
+    // o/calendar-create-fields.spec.ts).
+    await page.waitForTimeout(500);
+    await expect(page.locator('#calendarEventTitle')).not.toBeFocused();
+
     // New title + a second inline-created planning tag, also added as a
     // set-tag (same dual-pool mechanics as KC01).
     await page.locator('#calendarEventTitle').fill(newTitle);

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/o/calendar-create-fields.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/o/calendar-create-fields.spec.ts
@@ -168,6 +168,9 @@ test.describe.serial('Calendar create-event field combinations (#890)', () => {
     await page.waitForTimeout(1000);
 
     await calendarPage.openCreateModalAtSlot(0, 8);
+    // Create mode places the cursor in Titel so the user can type
+    // immediately (2026-07-17 design; edit/copy modes do NOT autofocus).
+    await expect(page.locator('#calendarEventTitle')).toBeFocused();
     const assignee = page.locator('#calendarEventAssignee');
     await assignee.click();
     await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/calendar-ui-enhancements.spec.ts
@@ -689,6 +689,33 @@ test.describe.serial('Calendar UI enhancements', () => {
       expect(crossTitle).toBe(formatWeekTitle(monday));
       expect(crossTitle).toContain(' - ');
     });
+
+    test('H5: day view from the CURRENT week lands on today (dags dato)', async ({ page }) => {
+      const calendarPage = new CalendarUiEnhancementsPage(page);
+      await page.locator('app-calendar-week-grid').waitFor({ state: 'visible', timeout: 10000 });
+
+      // NO navigation — the visible week is the current week. Switching to
+      // day view must show today, not the week's Monday (2026-07-17 design:
+      // "Når jeg i kalenderen står i ugevisning og vælger Dag, så skal dags
+      // dato vises"). H2 keeps covering the navigated-week → Monday case.
+      await calendarPage.switchToDayView();
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const actualHeader = await calendarPage.getCalendarHeaderDateText();
+      expect(actualHeader).toBe(formatLongDate(today));
+
+      // The single day-grid column header shows today's weekday + number
+      // (same two-line stack assertions as H2).
+      const dayCol = page
+        .locator('app-calendar-week-grid .mat-mdc-header-cell:not(.mat-column-time-axis)')
+        .first();
+      const expectedWeekdayShort = today
+        .toLocaleDateString('da-DK', { weekday: 'short' })
+        .toUpperCase();
+      await expect(dayCol.locator('.day-header-weekday')).toHaveText(expectedWeekdayShort);
+      await expect(dayCol.locator('.day-header-number')).toHaveText(String(today.getDate()));
+    });
   });
 
   // =======================================================================

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -487,9 +487,12 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
     // currently-viewed week so day-view lands on the first day of that
     // week and schedule-view shows that same week — preserving the
     // user's navigation context instead of jumping back to today.
-    // Exception: day view on the CURRENT week shows today ("dags dato") —
-    // see 2026-07-17-calendar-day-switch-today-and-title-autofocus-design.md.
-    // Schedule keeps Monday even on the current week (locked by e2e H3).
+    // Exception: switching to DAY view while the visible week is the
+    // current week lands on today ("dags dato") rather than Monday — the
+    // user expects to see the current day, not the start of the week.
+    // Schedule keeps Monday even on the current week (locked by e2e H3
+    // in r/calendar-ui-enhancements.spec.ts; the current-week day case
+    // is locked by H5).
     if (viewMode !== 'week' && this.viewMode === 'week') {
       const monday = this.getMondayOfWeek(new Date(this.currentDate));
       const isCurrentWeek =

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -487,9 +487,15 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
     // currently-viewed week so day-view lands on the first day of that
     // week and schedule-view shows that same week — preserving the
     // user's navigation context instead of jumping back to today.
+    // Exception: day view on the CURRENT week shows today ("dags dato") —
+    // see 2026-07-17-calendar-day-switch-today-and-title-autofocus-design.md.
+    // Schedule keeps Monday even on the current week (locked by e2e H3).
     if (viewMode !== 'week' && this.viewMode === 'week') {
       const monday = this.getMondayOfWeek(new Date(this.currentDate));
-      this.stateService.updateCurrentDate(this.toLocalDateString(monday));
+      const isCurrentWeek =
+        this.toLocalDateString(monday) === this.toLocalDateString(this.getMondayOfWeek(new Date()));
+      const target = viewMode === 'day' && isCurrentWeek ? new Date() : monday;
+      this.stateService.updateCurrentDate(this.toLocalDateString(target));
     }
     this.stateService.updateViewMode(viewMode);
     this.loadTasks();

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
@@ -13,7 +13,7 @@
       <div class="gcal-row-content">
         <mat-form-field class="w-100 gcal-translatable-field">
           <mat-label>{{ 'Title' | translate }}</mat-label>
-          <input matInput id="calendarEventTitle" [formControl]="titleControl" autocomplete="off">
+          <input matInput id="calendarEventTitle" #titleInput [formControl]="titleControl" autocomplete="off">
           <button mat-icon-button matIconSuffix type="button"
                   *ngIf="showTranslate"
                   id="calendarEventTitleTranslate"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -74,6 +74,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
   @Output() popoverClose = new EventEmitter<boolean | null>();
   @Output() timeChanged = new EventEmitter<{startHour: number; endHour: number}>();
   @ViewChild('descriptionTextarea') descriptionTextarea?: ElementRef<HTMLTextAreaElement>;
+  @ViewChild('titleInput') titleInput?: ElementRef<HTMLInputElement>;
   usePopoverMode = false;
 
   isEditMode = false;
@@ -808,6 +809,14 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
     setTimeout(() => {
       if (this.descriptionControl.value) {
         this.growTextarea(this.descriptionTextarea?.nativeElement ?? null);
+      }
+      // Pure create mode only: place the cursor in Titel so the user can
+      // type immediately. Edit keeps focus untouched; copy has a pre-filled
+      // title. The popover is a bare CDK overlay (no focus trap), so an
+      // imperative focus is required; the setTimeout already defers past
+      // the overlay's ensureOverlayInViewport repositioning.
+      if (!this.isEditMode && !this.data.sourceTask) {
+        this.titleInput?.nativeElement.focus({preventScroll: true});
       }
     });
   }


### PR DESCRIPTION
## Summary

Two approved calendar UX fixes:

**1. "Når jeg i kalenderen står i ugevisning (Uge) og vælger Dag, så skal dags dato vises."**
`onViewModeChange` snapped to the visible week's Monday unconditionally when leaving week view, so switching to Dag from the current week landed on Monday instead of today. Now: day view lands on **today** when the visible week is the current week; navigated weeks keep landing on their Monday (preserving the deliberate H1/H2 view-switch-preserves-week behavior), and schedule keeps Monday even on the current week (H3 unchanged).

**2. "Når jeg opretter ny opgave i kalenderen og modal åbnes, da skal cursoren placeres i tekstfeltet 'Titel'."**
The create popover is a bare CDK overlay (no focus trap, so `cdkFocusInitial` is inert) — nothing received focus on open. Now the Titel input is focused imperatively in `ngAfterViewInit` (`preventScroll`), **pure create mode only**: edit mode doesn't steal focus, copy mode (pre-filled title) is excluded.

## Tests

- **H5** (r/): no navigation → switch Uge→Dag → header + day-column show today. H2 keeps covering the navigated-week → Monday case.
- **o/calendar-create-fields**: `toBeFocused` on `#calendarEventTitle` right after the create modal opens.
- **m/ KC04**: `not.toBeFocused` after opening the edit modal.

## Verification

Verified live in dev: current week → "Fredag den 17. juli 2026" on switch; +2 weeks navigated → "Mandag den 27. juli 2026" (preserved); create modal → activeElement is the Titel input; edit modal → focus stays on body. Dev build green; code review returned zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)