### PR TITLE
Calendar: optional report headline via checkbox

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskWizardService/BackendConfigurationTaskWizardService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskWizardService/BackendConfigurationTaskWizardService.cs
@@ -366,12 +366,6 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
     /// <inheritdoc />
     public async Task<OperationResult> CreateTask(TaskWizardCreateModel createModel)
     {
-        if (!createModel.ItemPlanningTagId.HasValue) // This is the report table header tag
-        {
-            return new OperationResult(false,
-                _localizationService.GetString("ReportTableHeaderTagIsRequired"));
-        }
-
         if (createModel.FolderId == null)
         {
             return new OperationResult(false,
@@ -453,7 +447,7 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                 DayOfMonth = dayOfMonth,
                 UpdatedByUserId = _userService.UserId,
                 CreatedByUserId = _userService.UserId,
-                ReportGroupPlanningTagId = (int)createModel.ItemPlanningTagId!
+                ReportGroupPlanningTagId = createModel.ItemPlanningTagId
             };
 
 
@@ -884,7 +878,7 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                     planning.Enabled = true;
                     planning.DayOfWeek = planning.StartDate.DayOfWeek;
                     planning.RepeatEvery = updateModel.RepeatEvery;
-                    planning.ReportGroupPlanningTagId = (int)updateModel.ItemPlanningTagId!;
+                    planning.ReportGroupPlanningTagId = updateModel.ItemPlanningTagId;
                     planning.SdkFolderName = folderName;
                     planning.SdkFolderId = updateModel.FolderId;
                     planning.ShowExpireDate = true;
@@ -1055,7 +1049,7 @@ public class BackendConfigurationTaskWizardService : IBackendConfigurationTaskWi
                     planning.SdkFolderName = folderName;
                     planning.SdkFolderId = updateModel.FolderId;
                     planning.UpdatedByUserId = _userService.UserId;
-                    planning.ReportGroupPlanningTagId = (int)updateModel.ItemPlanningTagId!;
+                    planning.ReportGroupPlanningTagId = updateModel.ItemPlanningTagId;
                     planning.ShowExpireDate = true;
                     await planning.Update(_itemsPlanningPnDbContext);
 

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/v/calendar-create-validation.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/v/calendar-create-validation.spec.ts
@@ -16,19 +16,25 @@ import {
  *
  * Proves the create modal's save-guard and the backend's create-time
  * validation legs behave correctly. The modal's Save button
- * (`#calendarEventSaveBtn`) is DISABLED when the title is empty OR there are
- * zero assignees (task-create-edit-modal.component.html ~line 415:
- *   [disabled]="titleControl.invalid || !(assigneeControl.value?.length)"
- * ). The planning tag is NOT part of that guard, so a save WITHOUT a planning
- * tag is reachable through the UI and is rejected server-side instead.
+ * (`#calendarEventSaveBtn`) is DISABLED when the title is empty, there are
+ * zero assignees, OR the report-headline checkbox is checked with no
+ * planning tag selected (task-create-edit-modal.component.html ~line 415:
+ *   [disabled]="titleControl.invalid || !(assigneeControl.value?.length) ||
+ *     (reportHeadlineEnabledControl.value && !planningTagControl.value)"
+ * ). The report-headline checkbox (`#calendarEventReportHeadlineToggle`)
+ * defaults to CHECKED in create mode, so the planning tag is required
+ * client-side UNLESS the user unchecks it — at which point the dropdown is
+ * disabled, the value is excluded from the payload (`itemPlanningTagId:
+ * null`), and the create succeeds (the old server-side
+ * `ReportTableHeaderTagIsRequired` rejection has been removed).
  *
  * This determines which validation legs are reachable end-to-end:
- *   - empty-title          → Save disabled            (UI guard)        [V01]
- *   - zero-assignee        → Save disabled            (UI guard)        [V02]
- *   - past-slot create     → modal never opens        (grid guard)      [V03]
- *   - sub-15-min duration  → clamps to 0.25 h         (modal clamp)     [V04]
- *   - missing planning tag → backend success=false    (server guard)    [V06]
- *   - Active + no sites    → unreachable (Save disabled w/ 0 assignees) [V05 fixme]
+ *   - empty-title            → Save disabled            (UI guard)        [V01]
+ *   - zero-assignee          → Save disabled            (UI guard)        [V02]
+ *   - past-slot create       → modal never opens        (grid guard)      [V03]
+ *   - sub-15-min duration    → clamps to 0.25 h         (modal clamp)     [V04]
+ *   - checked + no headline  → Save disabled            (UI guard)        [V06]
+ *   - Active + no sites      → unreachable (Save disabled w/ 0 assignees) [V05 fixme]
  *
  * The backend `AtLeastOneWorkerMustBeAssigned` leg (CalendarService.CreateTask
  * ~line 882) is unreachable via the UI because Save is disabled with zero
@@ -351,27 +357,13 @@ test.describe.serial('Calendar create-event validation (#892)', () => {
   });
 
   // =======================================================================
-  // V06 — a missing planning tag is rejected by the backend.
+  // V06 — the report-headline checkbox gates save client-side.
   // =======================================================================
-  // The planning tag is NOT part of the save guard, so with title + assignee
-  // present Save is ENABLED even when no planning tag is selected. In create
-  // mode planningTagControl defaults to null (component ~line 124) and is NOT
-  // auto-seeded (only the eForm + board get defaults), so simply NOT picking a
-  // tag leaves it empty — no clear-control interaction is required.
-  //
-  // The backend rejects this: CalendarService.CreateTask delegates to
-  // taskWizardService.CreateTask, which returns
-  //   OperationResult(false, GetString("ReportTableHeaderTagIsRequired"))
-  // when ItemPlanningTagId has no value (TaskWizardService ~line 347-351).
-  //
-  // ASSERTION (with documented robustness): the message is LOCALIZED
-  // (en-US: "Report tag is required"; da: "Rapport ettiket er påkrævet"), so
-  // we do NOT assert on a single fixed string. We assert the strong,
-  // language-independent invariants — `success === false` and that NO event
-  // block was created — and additionally accept the message if it matches the
-  // resource KEY or either the en/da localized text (whichever the
-  // localization service returns for the test user's language).
-  test('V06: missing planning tag is rejected by the backend', async ({ page }) => {
+  // Checked (default) + no tag selected => #calendarEventSaveBtn disabled.
+  // Unchecking the checkbox lifts the gate and the create succeeds with
+  // itemPlanningTagId: null (server guard was removed; data is excluded
+  // from reports because the null ReportGroupPlanningTagId group is skipped).
+  test('V06: report headline required only while its checkbox is checked', async ({ page }) => {
     const calendarPage = new CalendarUiEnhancementsPage(page);
     const title = `V06-${generateRandmString(5)}`;
 
@@ -383,39 +375,27 @@ test.describe.serial('Calendar create-event validation (#892)', () => {
     // Deliberately DO NOT pick a planning tag (stays null in create mode).
     await pickFirstAssignee(page);
 
-    // Save is enabled (title + assignee present).
-    await expect(page.locator('#calendarEventSaveBtn')).toBeEnabled();
+    // Report-headline checkbox defaults to CHECKED + no tag selected =>
+    // Save must be disabled by the client-side guard.
+    const saveBtn = page.locator('#calendarEventSaveBtn');
+    await expect(saveBtn, 'checked + empty headline must block save').toBeDisabled();
 
-    // Pre-register the create-POST response waiter BEFORE clicking save.
-    const respPromise = page.waitForResponse(
-      r => isCreatePost(r.request().method(), r.url()),
-      { timeout: 30000 }
-    );
-    await page.locator('#calendarEventSaveBtn').click();
-    const resp = await respPromise;
-    const body = await resp.json().catch(() => null);
+    // Uncheck the report-headline toggle — the gate lifts and Save enables.
+    await page.locator('#calendarEventReportHeadlineToggle').click();
+    await expect(saveBtn, 'unchecked headline must allow save').toBeEnabled();
+
+    const [response] = await Promise.all([
+      page.waitForResponse(r => isCreatePost(r.request().method(), r.url()), { timeout: 30000 }),
+      saveBtn.click(),
+    ]);
+    const body = await response.json().catch(() => null);
     console.log(
-      `V06 create (no planning tag): status=${resp.status()}, success=${body?.success}, message=${body?.message}`
+      `V06 create (headline unchecked): status=${response.status()}, success=${body?.success}, message=${body?.message}`
     );
+    expect(body?.success, 'create without a report headline must succeed').toBeTruthy();
 
-    // Strong, language-independent invariant: the backend rejected the create.
-    expect(body?.success, 'create without a planning tag must be rejected').toBeFalsy();
-
-    // The message is localized; accept the resource key OR the en/da text.
-    const msg = (body?.message ?? '').toString();
-    expect(
-      /ReportTableHeaderTagIsRequired|Report tag is required|Rapport ettiket er p[åa]kr[æa]vet/i.test(msg),
-      `message should reference the planning-tag-required rejection; got "${msg}"`
-    ).toBeTruthy();
-
-    // And no event block was created on the grid.
     await page.waitForTimeout(1000);
-    expect(
-      await page.locator('.task-block').filter({ hasText: title }).count(),
-      'no event block should be created when the planning tag is missing'
-    ).toBe(0);
-
-    await calendarPage.closeEventModal();
+    await calendarPage.findEventBlock(title).waitFor({ state: 'visible', timeout: 10000 });
   });
 
   // =======================================================================

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/v/calendar-report-headline-toggle.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/v/calendar-report-headline-toggle.spec.ts
@@ -172,7 +172,7 @@ test.describe.serial('Calendar report-headline checkbox', () => {
     await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
     await page.locator('.ng-dropdown-panel .ng-option').first().click();
     await page.waitForTimeout(300);
-    const chosen = await select.locator('.ng-value').innerText();
+    const chosen = (await select.locator('.ng-value-label').innerText()).trim();
     await toggle.click();
     await page.waitForTimeout(300);
     await expect(toggle.locator('input')).not.toBeChecked();
@@ -183,7 +183,7 @@ test.describe.serial('Calendar report-headline checkbox', () => {
     await toggle.click();
     await page.waitForTimeout(300);
     await expect(select.locator('input')).toBeEnabled();
-    await expect(select.locator('.ng-value')).toHaveText(chosen);
+    await expect(select.locator('.ng-value-label')).toHaveText(chosen);
 
     await calendarPage.closeEventModal();
   });

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/v/calendar-report-headline-toggle.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/v/calendar-report-headline-toggle.spec.ts
@@ -32,6 +32,18 @@ import {
  * to make Save reachable, and none of these tests need a multi-assignee
  * list. Lives in `v/` to share the matrix slot with
  * calendar-create-validation.spec.ts and reuse CalendarUiEnhancementsPage.
+ *
+ * Slot strategy: each test gets a fresh page (beforeEach re-navigates to the
+ * calendar's real current week), so every `openCreateModalAtSlot`/
+ * `openCreateModalAt9AM()` call independently advances one week (chevron
+ * click) and lands on next week's target day — it never compounds across
+ * tests. What DOES compound is a same-day collision: two persisting tests
+ * both targeting next-week Monday would race for the same cell. Per the
+ * sibling calendar-create-validation.spec.ts convention ("Each test uses a
+ * DISTINCT weekday ... so the serial suite never collides on a shared
+ * week"), T01 (non-persisting, cancels) and T02 (persists) share Monday
+ * (day 0) safely since T01 never saves; T03 (persists) uses Tuesday (day 1)
+ * to avoid colliding with T02's saved block.
  */
 
 const property: PropertyCreateUpdate = {
@@ -162,11 +174,14 @@ test.describe.serial('Calendar report-headline checkbox', () => {
     await page.waitForTimeout(300);
     const chosen = await select.locator('.ng-value').innerText();
     await toggle.click();
+    await page.waitForTimeout(300);
     await expect(toggle.locator('input')).not.toBeChecked();
     await expect(select.locator('input')).toBeDisabled();
+    await expect(select).toHaveClass(/mtx-select-disabled/);
 
     // re-check: enabled again with the same value
     await toggle.click();
+    await page.waitForTimeout(300);
     await expect(select.locator('input')).toBeEnabled();
     await expect(select.locator('.ng-value')).toHaveText(chosen);
 
@@ -201,6 +216,7 @@ test.describe.serial('Calendar report-headline checkbox', () => {
     // Deliberately DO NOT pick a planning tag — uncheck the report-headline
     // toggle instead so Save is reachable without one.
     await page.locator('#calendarEventReportHeadlineToggle').click();
+    await page.waitForTimeout(300);
 
     const [response] = await Promise.all([
       page.waitForResponse(
@@ -226,14 +242,22 @@ test.describe.serial('Calendar report-headline checkbox', () => {
   // =======================================================================
   // T03 — unchecking on edit removes the headline from the task.
   // =======================================================================
+  // Uses Tuesday (day offset 1) rather than openCreateModalAt9AM()'s Monday
+  // (day 0) — T02 already persists a saved block on next-week Monday, and
+  // each test gets a fresh page (openCreateModalAtSlot always lands on
+  // "next week" from a freshly-loaded current week), so reusing Monday here
+  // would race T02's block for the same cell. Distinct weekday per
+  // persisting test matches the convention in
+  // calendar-create-validation.spec.ts (V01-V06 each use their own day).
   test('unchecking on edit removes the headline from the task', async ({ page }) => {
     const title = `remove-headline-${generateRandmString(5)}`;
-    await calendarPage.openCreateModalAt9AM();
+    await calendarPage.openCreateModalAtSlot(1, 9);
     await calendarPage.fillAndSaveEvent(title); // creates WITH a headline
 
     await calendarPage.openEditModal(title);
     await expect(page.locator('#calendarEventReportHeadlineToggle input')).toBeChecked();
     await page.locator('#calendarEventReportHeadlineToggle').click(); // uncheck
+    await page.waitForTimeout(300);
     await calendarPage.clickSaveInEditModal();
     await page.waitForTimeout(1000);
 

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/v/calendar-report-headline-toggle.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/v/calendar-report-headline-toggle.spec.ts
@@ -1,0 +1,246 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../../Page objects/Login.page';
+import { generateRandmString } from '../../../helper-functions';
+import { CalendarUiEnhancementsPage } from '../calendar-ui-enhancements.page';
+import {
+  BackendConfigurationPropertiesPage,
+  PropertyCreateUpdate,
+} from '../BackendConfigurationProperties.page';
+import {
+  BackendConfigurationPropertyWorkersPage,
+  PropertyWorker,
+} from '../BackendConfigurationPropertyWorkers.page';
+
+/**
+ * Calendar report-headline checkbox suite.
+ *
+ * The create/edit-task modal has a `mat-checkbox`
+ * (`#calendarEventReportHeadlineToggle`) in front of the "Report headline"
+ * mtx-select (`#calendarEventPlanningTag`):
+ *   - Create mode: checkbox defaults CHECKED, dropdown enabled.
+ *   - Checked + no tag selected => `#calendarEventSaveBtn` is DISABLED (the
+ *     new save-guard leg: `reportHeadlineEnabledControl.value &&
+ *     !planningTagControl.value`).
+ *   - Unchecked => label dims, `#calendarEventPlanningTag` control disabled
+ *     (its value is retained visually), Save is allowed, and the POST body
+ *     carries `itemPlanningTagId: null` (the old server-side
+ *     `ReportTableHeaderTagIsRequired` rejection has been removed).
+ *   - Edit mode: checkbox is seeded checked iff the task has a headline;
+ *     unchecking + saving removes the headline series-wide.
+ *
+ * Single property + single worker seed suffices here — one worker is enough
+ * to make Save reachable, and none of these tests need a multi-assignee
+ * list. Lives in `v/` to share the matrix slot with
+ * calendar-create-validation.spec.ts and reuse CalendarUiEnhancementsPage.
+ */
+
+const property: PropertyCreateUpdate = {
+  name: generateRandmString(5),
+  chrNumber: generateRandmString(5),
+  address: generateRandmString(5),
+  cvrNumber: '1111111',
+};
+
+const worker: PropertyWorker = {
+  name: generateRandmString(5),
+  surname: generateRandmString(5),
+  language: 'Dansk',
+  properties: [property.name],
+  workerEmail: generateRandmString(5) + '@test.com',
+};
+
+let seeded = false;
+
+test.describe.serial('Calendar report-headline checkbox', () => {
+  let calendarPage: CalendarUiEnhancementsPage;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4200');
+    await new LoginPage(page).login();
+    await page.waitForTimeout(2000);
+
+    calendarPage = new CalendarUiEnhancementsPage(page);
+    await calendarPage.goToCalendar();
+    await calendarPage.ensureSidebarOpen();
+
+    if (seeded) {
+      const folderResp = page.waitForResponse(
+        r => r.url().includes('/api/backend-configuration-pn/properties/get-folder-dtos'),
+        { timeout: 60000 }
+      );
+      await calendarPage.selectProperty(property.name);
+      await folderResp.catch(() => undefined);
+      await page.waitForTimeout(1000);
+    }
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    const cleanup = async () => {
+      await page.goto('http://localhost:4200');
+      await new LoginPage(page).login();
+
+      const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+      await workersPage.goToPropertyWorkers();
+      await page.waitForTimeout(1000);
+      await workersPage.clearTable();
+
+      const propertiesPage = new BackendConfigurationPropertiesPage(page);
+      await propertiesPage.goToProperties();
+      await page.waitForTimeout(1000);
+      await propertiesPage.clearTable();
+    };
+    try {
+      await Promise.race([
+        cleanup(),
+        new Promise(resolve => setTimeout(resolve, 60000)),
+      ]);
+    } catch (err: any) {
+      console.log(`afterAll cleanup failed (non-fatal): ${err?.message ?? err}`);
+    }
+    try { await page.close(); } catch {}
+  });
+
+  // -----------------------------------------------------------------------
+  // Seed test — property + ONE worker. Runs first via describe.serial.
+  // -----------------------------------------------------------------------
+  test('seed: create property + worker', async ({ page }) => {
+    test.setTimeout(600000);
+
+    const propertiesPage = new BackendConfigurationPropertiesPage(page);
+    const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+
+    await propertiesPage.goToProperties();
+    await propertiesPage.createProperty(property);
+    await workersPage.goToPropertyWorkers();
+    await workersPage.create(worker);
+
+    seeded = true;
+
+    // Sanity: open a create modal and confirm the assignee dropdown lists the
+    // seeded worker, so the assignee-dependent legs below are exercisable.
+    const seedCalendarPage = new CalendarUiEnhancementsPage(page);
+    await seedCalendarPage.goToCalendar();
+    await seedCalendarPage.ensureSidebarOpen();
+    const folderResp = page.waitForResponse(
+      r => r.url().includes('/api/backend-configuration-pn/properties/get-folder-dtos'),
+      { timeout: 60000 }
+    );
+    await seedCalendarPage.selectProperty(property.name);
+    await folderResp.catch(() => undefined);
+    await page.waitForTimeout(1000);
+
+    await seedCalendarPage.openCreateModalAtSlot(0, 8);
+    const assignee = page.locator('#calendarEventAssignee');
+    await assignee.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    const optionCount = await page.locator('.ng-dropdown-panel .ng-option').count();
+    expect(
+      optionCount,
+      `assignee dropdown should list the seeded worker; got ${optionCount}`
+    ).toBeGreaterThanOrEqual(1);
+    await seedCalendarPage.closeEventModal();
+  });
+
+  // =======================================================================
+  // T01 — unchecking dims and disables the report-headline dropdown;
+  // re-checking restores the previously picked value.
+  // =======================================================================
+  test('unchecking dims and disables the report headline dropdown; re-checking restores value', async ({ page }) => {
+    await calendarPage.openCreateModalAt9AM();
+    const select = page.locator('#calendarEventPlanningTag');
+    const toggle = page.locator('#calendarEventReportHeadlineToggle');
+
+    // default: checked + enabled, placeholder visible
+    await expect(toggle.locator('input')).toBeChecked();
+    await expect(select.locator('input')).toBeEnabled();
+
+    // pick a tag, then uncheck: select disabled, value retained visually
+    await select.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+    const chosen = await select.locator('.ng-value').innerText();
+    await toggle.click();
+    await expect(toggle.locator('input')).not.toBeChecked();
+    await expect(select.locator('input')).toBeDisabled();
+
+    // re-check: enabled again with the same value
+    await toggle.click();
+    await expect(select.locator('input')).toBeEnabled();
+    await expect(select.locator('.ng-value')).toHaveText(chosen);
+
+    await calendarPage.closeEventModal();
+  });
+
+  // =======================================================================
+  // T02 — a task created with the checkbox unchecked stores no headline.
+  // =======================================================================
+  test('task created with checkbox unchecked stores no headline', async ({ page }) => {
+    const title = `no-headline-${generateRandmString(5)}`;
+    await calendarPage.openCreateModalAt9AM();
+
+    // Fill title / eForm / assignee exactly as fillAndSaveEvent does, but
+    // skip the planning tag — mirrors the locator steps in
+    // calendar-ui-enhancements.page.ts fillAndSaveEvent().
+    await page.locator('#calendarEventTitle').fill(title);
+
+    const eform = page.locator('#calendarEventEform');
+    await eform.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.waitForTimeout(300);
+
+    const assignee = page.locator('#calendarEventAssignee');
+    await assignee.click();
+    await page.locator('.ng-dropdown-panel').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('.ng-dropdown-panel .ng-option').first().click();
+    await page.locator('#calendarEventTitle').click();
+    await page.waitForTimeout(300);
+
+    // Deliberately DO NOT pick a planning tag — uncheck the report-headline
+    // toggle instead so Save is reachable without one.
+    await page.locator('#calendarEventReportHeadlineToggle').click();
+
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        r => r.url().includes('/calendar/tasks') && r.request().method() === 'POST',
+        { timeout: 30000 }
+      ),
+      page.locator('#calendarEventSaveBtn').click(),
+    ]);
+    expect((await response.json().catch(() => null))?.success).toBeTruthy();
+
+    await page.waitForTimeout(1000);
+    await calendarPage.findEventBlock(title).waitFor({ state: 'visible', timeout: 10000 });
+
+    // Reopen: checkbox unchecked, select disabled and empty.
+    await calendarPage.openEditModal(title);
+    await expect(page.locator('#calendarEventReportHeadlineToggle input')).not.toBeChecked();
+    await expect(page.locator('#calendarEventPlanningTag input')).toBeDisabled();
+    await expect(page.locator('#calendarEventPlanningTag .ng-value')).toHaveCount(0);
+
+    await calendarPage.closeEventModal();
+  });
+
+  // =======================================================================
+  // T03 — unchecking on edit removes the headline from the task.
+  // =======================================================================
+  test('unchecking on edit removes the headline from the task', async ({ page }) => {
+    const title = `remove-headline-${generateRandmString(5)}`;
+    await calendarPage.openCreateModalAt9AM();
+    await calendarPage.fillAndSaveEvent(title); // creates WITH a headline
+
+    await calendarPage.openEditModal(title);
+    await expect(page.locator('#calendarEventReportHeadlineToggle input')).toBeChecked();
+    await page.locator('#calendarEventReportHeadlineToggle').click(); // uncheck
+    await calendarPage.clickSaveInEditModal();
+    await page.waitForTimeout(1000);
+
+    await calendarPage.openEditModal(title);
+    await expect(page.locator('#calendarEventReportHeadlineToggle input')).not.toBeChecked();
+    await expect(page.locator('#calendarEventPlanningTag .ng-value')).toHaveCount(0);
+
+    await calendarPage.closeEventModal();
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -555,4 +555,5 @@ export const bgBG = {
   'This task is part of a recurring series. What do you want to move?': 'Тази задача е част от повтаряща се поредица. Какво искате да преместите?',
   'This task is part of a recurring series. What do you want to delete?': 'Тази задача е част от повтаряща се поредица. Какво искате да изтриете?',
   'Updated.': 'Актуализирано.',
+  'Select / create report headline': 'Изберете/създайте заглавие на отчета',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -555,4 +555,5 @@ export const csCZ = {
   'This task is part of a recurring series. What do you want to move?': 'Tento úkol je součástí opakující se série. Co chcete přesunout?',
   'This task is part of a recurring series. What do you want to delete?': 'Tento úkol je součástí opakující se série. Co chcete smazat?',
   'Updated.': 'Aktualizováno.',
+  'Select / create report headline': 'Vybrat/vytvořit nadpis zprávy',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -556,4 +556,5 @@ export const da = {
   'This task is part of a recurring series. What do you want to move?': 'Denne opgave er en del af en tilbagevendende serie. Hvad vil du flytte?',
   'This task is part of a recurring series. What do you want to delete?': 'Denne opgave er en del af en tilbagevendende serie. Hvad vil du slette?',
   'Updated.': 'Opdateret.',
+  'Select / create report headline': 'Vælg / opret rapportoverskrift',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -603,4 +603,5 @@ export const deDE = {
   'This task is part of a recurring series. What do you want to move?': 'Diese Aufgabe ist Teil einer wiederkehrenden Serie. Was möchten Sie bewegen?',
   'This task is part of a recurring series. What do you want to delete?': 'Diese Aufgabe ist Teil einer wiederkehrenden Serie. Was möchten Sie löschen?',
   'Updated.': 'Aktualisiert.',
+  'Select / create report headline': 'Berichtsüberschrift auswählen/erstellen',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -555,4 +555,5 @@ export const elGR = {
   'This task is part of a recurring series. What do you want to move?': 'Αυτή η εργασία αποτελεί μέρος μιας επαναλαμβανόμενης σειράς εργασιών. Τι θέλετε να μετακινήσετε;',
   'This task is part of a recurring series. What do you want to delete?': 'Αυτή η εργασία αποτελεί μέρος μιας επαναλαμβανόμενης σειράς εργασιών. Τι θέλετε να διαγράψετε;',
   'Updated.': 'Ενημερώθηκε.',
+  'Select / create report headline': 'Επιλογή / δημιουργία τίτλου αναφοράς',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -435,6 +435,7 @@ export const enUS= {
   'Copy of': 'Copy of',
   'eForm': 'eForm',
   'Report headline': 'Report headline',
+  'Select / create report headline': 'Select / create report headline',
   // Calendar sidebar
   'My properties': 'My properties',
   'My calendars': 'My calendars',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -555,4 +555,5 @@ export const esES = {
   'This task is part of a recurring series. What do you want to move?': 'Esta tarea forma parte de una serie recurrente. ¿Qué quieres mover?',
   'This task is part of a recurring series. What do you want to delete?': 'Esta tarea forma parte de una serie recurrente. ¿Qué desea eliminar?',
   'Updated.': 'Actualizado.',
+  'Select / create report headline': 'Seleccione / cree el título del informe',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -555,4 +555,5 @@ export const etET = {
   'This task is part of a recurring series. What do you want to move?': 'See ülesanne on osa korduvast seeriast. Mida sa liigutada tahad?',
   'This task is part of a recurring series. What do you want to delete?': 'See ülesanne on osa korduvast seeriast. Mida soovite kustutada?',
   'Updated.': 'Uuendatud.',
+  'Select / create report headline': 'Valige/looge aruande pealkiri',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -555,4 +555,5 @@ export const fiFI = {
   'This task is part of a recurring series. What do you want to move?': 'Tämä tehtävä on osa toistuvaa sarjaa. Mitä haluat siirtää?',
   'This task is part of a recurring series. What do you want to delete?': 'Tämä tehtävä on osa toistuvaa sarjaa. Mitä haluat poistaa?',
   'Updated.': 'Päivitetty.',
+  'Select / create report headline': 'Valitse/luo raportin otsikko',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -554,4 +554,5 @@ export const frFR = {
   'This task is part of a recurring series. What do you want to move?': 'Cette tâche fait partie d\'une série récurrente. Que souhaitez-vous déplacer ?',
   'This task is part of a recurring series. What do you want to delete?': 'Cette tâche fait partie d\'une série récurrente. Que souhaitez-vous supprimer ?',
   'Updated.': 'Mis à jour.',
+  'Select / create report headline': 'Sélectionner / créer un titre de rapport',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -555,4 +555,5 @@ export const hrHR = {
   'This task is part of a recurring series. What do you want to move?': 'Ovaj zadatak je dio ponavljajućeg niza. Što želite premjestiti?',
   'This task is part of a recurring series. What do you want to delete?': 'Ovaj zadatak je dio ponavljajućeg niza. Što želite izbrisati?',
   'Updated.': 'Ažurirano.',
+  'Select / create report headline': 'Odaberite/izradite naslov izvješća',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -555,4 +555,5 @@ export const huHU = {
   'This task is part of a recurring series. What do you want to move?': 'Ez a feladat egy ismétlődő sorozat része. Mit szeretne áthelyezni?',
   'This task is part of a recurring series. What do you want to delete?': 'Ez a feladat egy ismétlődő sorozat része. Mit szeretne törölni?',
   'Updated.': 'Frissítve.',
+  'Select / create report headline': 'Jelentés címsorának kiválasztása/létrehozása',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -555,4 +555,5 @@ export const isIS = {
   'This task is part of a recurring series. What do you want to move?': 'Þetta verkefni er hluti af endurtekinni seríu. Hvað viltu færa?',
   'This task is part of a recurring series. What do you want to delete?': 'Þetta verkefni er hluti af endurtekinni röð. Hvað viltu eyða?',
   'Updated.': 'Uppfært.',
+  'Select / create report headline': 'Velja / búa til fyrirsögn skýrslu',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -555,4 +555,5 @@ export const itIT = {
   'This task is part of a recurring series. What do you want to move?': 'Questo compito fa parte di una serie ricorrente. Cosa vuoi spostare?',
   'This task is part of a recurring series. What do you want to delete?': 'Questa operazione fa parte di una serie ricorrente. Cosa desideri eliminare?',
   'Updated.': 'Aggiornato.',
+  'Select / create report headline': 'Seleziona/crea il titolo del report',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -555,4 +555,5 @@ export const ltLT = {
   'This task is part of a recurring series. What do you want to move?': 'Ši užduotis yra pasikartojančios serijos dalis. Ką norite perkelti?',
   'This task is part of a recurring series. What do you want to delete?': 'Ši užduotis yra pasikartojančios serijos dalis. Ką norite ištrinti?',
   'Updated.': 'Atnaujinta.',
+  'Select / create report headline': 'Pasirinkti / sukurti ataskaitos antraštę',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -555,4 +555,5 @@ export const lvLV = {
   'This task is part of a recurring series. What do you want to move?': 'Šis uzdevums ir daļa no atkārtotas sērijas. Ko vēlaties pārvietot?',
   'This task is part of a recurring series. What do you want to delete?': 'Šis uzdevums ir daļa no atkārtotas virknes. Ko vēlaties dzēst?',
   'Updated.': 'Atjaunināts.',
+  'Select / create report headline': 'Atlasīt/izveidot pārskata virsrakstu',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -555,4 +555,5 @@ export const nlNL = {
   'This task is part of a recurring series. What do you want to move?': 'Deze taak maakt deel uit van een terugkerende reeks. Wat wilt u verplaatsen?',
   'This task is part of a recurring series. What do you want to delete?': 'Deze taak maakt deel uit van een terugkerende reeks. Wat wilt u verwijderen?',
   'Updated.': 'Bijgewerkt.',
+  'Select / create report headline': 'Selecteer/maak een rapportkop',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -555,4 +555,5 @@ export const noNO = {
   'This task is part of a recurring series. What do you want to move?': 'Denne oppgaven er en del av en gjentakende serie. Hva vil du flytte?',
   'This task is part of a recurring series. What do you want to delete?': 'Denne oppgaven er en del av en gjentakende serie. Hva vil du slette?',
   'Updated.': 'Oppdatert.',
+  'Select / create report headline': 'Velg / opprett rapportoverskrift',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -555,4 +555,5 @@ export const plPL = {
   'This task is part of a recurring series. What do you want to move?': 'To zadanie jest częścią cyklicznej serii. Co chcesz przenieść?',
   'This task is part of a recurring series. What do you want to delete?': 'To zadanie jest częścią cyklicznej serii. Co chcesz usunąć?',
   'Updated.': 'Zaktualizowano.',
+  'Select / create report headline': 'Wybierz/utwórz nagłówek raportu',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -555,4 +555,5 @@ export const ptBR = {
   'This task is part of a recurring series. What do you want to move?': 'Esta tarefa faz parte de uma série recorrente. O que você deseja mover?',
   'This task is part of a recurring series. What do you want to delete?': 'Esta tarefa faz parte de uma série recorrente. O que você deseja excluir?',
   'Updated.': 'Atualizado.',
+  'Select / create report headline': 'Selecionar/criar título do relatório',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -555,4 +555,5 @@ export const ptPT = {
   'This task is part of a recurring series. What do you want to move?': 'Esta tarefa faz parte de uma série recorrente. O que você deseja mover?',
   'This task is part of a recurring series. What do you want to delete?': 'Esta tarefa faz parte de uma série recorrente. O que você deseja excluir?',
   'Updated.': 'Atualizado.',
+  'Select / create report headline': 'Selecionar/criar título do relatório',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -555,4 +555,5 @@ export const roRO = {
   'This task is part of a recurring series. What do you want to move?': 'Această sarcină face parte dintr-o serie recurentă. Ce vrei să muți?',
   'This task is part of a recurring series. What do you want to delete?': 'Această sarcină face parte dintr-o serie recurentă. Ce doriți să ștergeți?',
   'Updated.': 'Actualizat.',
+  'Select / create report headline': 'Selectați/creați titlul raportului',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -555,4 +555,5 @@ export const skSK = {
   'This task is part of a recurring series. What do you want to move?': 'Táto úloha je súčasťou opakujúcej sa série. Čo chcete presunúť?',
   'This task is part of a recurring series. What do you want to delete?': 'Táto úloha je súčasťou opakujúcej sa série. Čo chcete odstrániť?',
   'Updated.': 'Aktualizované.',
+  'Select / create report headline': 'Vybrať/vytvoriť nadpis prehľadu',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -555,4 +555,5 @@ export const slSL = {
   'This task is part of a recurring series. What do you want to move?': 'Ta naloga je del ponavljajoče se serije. Kaj želite premakniti?',
   'This task is part of a recurring series. What do you want to delete?': 'To opravilo je del ponavljajoče se serije. Kaj želite izbrisati?',
   'Updated.': 'Posodobljeno.',
+  'Select / create report headline': 'Izberite/ustvarite naslov poročila',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -555,4 +555,5 @@ export const svSE = {
   'This task is part of a recurring series. What do you want to move?': 'Den här uppgiften är en del av en återkommande serie. Vad vill du flytta?',
   'This task is part of a recurring series. What do you want to delete?': 'Den här uppgiften är en del av en återkommande serie. Vad vill du ta bort?',
   'Updated.': 'Uppdaterad.',
+  'Select / create report headline': 'Välj/skapa rapportrubrik',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -555,4 +555,5 @@ export const ukUA = {
   'This task is part of a recurring series. What do you want to move?': 'Це завдання є частиною повторюваної серії. Що ви хочете перемістити?',
   'This task is part of a recurring series. What do you want to delete?': 'Це завдання є частиною повторюваної серії. Що ви хочете видалити?',
   'Updated.': 'Оновлено.',
+  'Select / create report headline': 'Вибрати / створити заголовок звіту',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.html
@@ -203,8 +203,15 @@
     <div class="gcal-row">
       <mat-icon class="gcal-icon">view_compact</mat-icon>
       <div class="gcal-row-content">
+        <mat-checkbox
+          id="calendarEventReportHeadlineToggle"
+          class="gcal-report-headline-toggle"
+          [formControl]="reportHeadlineEnabledControl"
+          (change)="onReportHeadlineToggled($event.checked)"
+        >
+          <span [class.gcal-label-dim]="!reportHeadlineEnabledControl.value">{{ 'Report headline' | translate }}</span>
+        </mat-checkbox>
         <mat-form-field class="w-100">
-          <mat-label>{{ 'Report headline' | translate }}</mat-label>
           <mtx-select
             id="calendarEventPlanningTag"
             [formControl]="planningTagControl"
@@ -213,6 +220,7 @@
             bindLabel="name"
             [addTag]="addPlanningTag"
             addTagText="{{ 'Create new' | translate }}"
+            placeholder="{{ 'Select / create report headline' | translate }}"
             [clearable]="true"
             [searchable]="true"
             appendTo="body"
@@ -480,7 +488,7 @@
 
   <div class="gcal-actions" *ngIf="!isReadonly">
     <button id="calendarEventSaveBtn" class="btn-primary btn-primary--icon-left"
-            [disabled]="titleControl.invalid || !((assigneeControl.value?.length) || (workerTagsControl.value?.length))"
+            [disabled]="titleControl.invalid || !((assigneeControl.value?.length) || (workerTagsControl.value?.length)) || (reportHeadlineEnabledControl.value && !planningTagControl.value)"
             [title]="!((assigneeControl.value?.length) || (workerTagsControl.value?.length)) ? ('At least one worker or worker tag must be assigned' | translate) : ''"
             (click)="onSave()">
       {{ isEditMode ? ('Save changes' | translate) : ('Save' | translate) }}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.scss
@@ -451,3 +451,14 @@ mat-form-field.w-100.mat-mdc-form-field-type-mtx-select {
   padding-left: 12px;
   border-left: 2px solid rgba(0, 0, 0, 0.08);
 }
+
+// Report headline row: the checkbox carries the label. When unchecked the
+// label dims to Material's disabled tone; the select greys itself via the
+// control's disabled state.
+.gcal-report-headline-toggle {
+  margin-left: -10px; // compensate the MDC checkbox touch-target padding so the box aligns with the field edge
+}
+
+.gcal-label-dim {
+  color: rgba(0, 0, 0, 0.38);
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/modals/task-create-edit-modal/task-create-edit-modal.component.ts
@@ -148,6 +148,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
   boardControl = new FormControl<number | null>(null);
   eformControl = new FormControl<number | null>(null);
   planningTagControl = new FormControl<number | null>(null);
+  reportHeadlineEnabledControl = new FormControl<boolean>(true, {nonNullable: true});
   statusControl = new FormControl<boolean>(true, {nonNullable: true});
   complianceEnabledControl = new FormControl<boolean>(true, {nonNullable: true});
 
@@ -169,6 +170,14 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
     private translationService: TranslationService,
     private appSettingsStateService: AppSettingsStateService,
   ) {}
+
+  onReportHeadlineToggled(checked: boolean) {
+    if (checked) {
+      this.planningTagControl.enable();
+    } else {
+      this.planningTagControl.disable();
+    }
+  }
 
   addPlanningTag = (name: string): Promise<{id: number; name: string}> => {
     return this.persistTag(name).then(tag => {
@@ -323,6 +332,10 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       this.propertyControl.setValue(task.propertyId ?? this.data.propertyId);
       this.eformControl.setValue(task['eformId'] ?? null);
       this.planningTagControl.setValue(task['itemPlanningTagId'] ?? null);
+      this.reportHeadlineEnabledControl.setValue(!!task['itemPlanningTagId']);
+      if (!task['itemPlanningTagId']) {
+        this.planningTagControl.disable();
+      }
       this.statusControl.setValue(task.status ?? true);
       this.complianceEnabledControl.setValue(task.complianceEnabled ?? true);
       // Seed attachments from the task DTO. The backend mapper populates
@@ -358,6 +371,10 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       this.propertyControl.setValue(sourceTask.propertyId ?? this.data.propertyId);
       this.eformControl.setValue(sourceTask['eformId'] ?? null);
       this.planningTagControl.setValue(sourceTask['itemPlanningTagId'] ?? null);
+      this.reportHeadlineEnabledControl.setValue(!!sourceTask['itemPlanningTagId']);
+      if (!sourceTask['itemPlanningTagId']) {
+        this.planningTagControl.disable();
+      }
       this.statusControl.setValue(sourceTask.status ?? true);
       this.complianceEnabledControl.setValue(sourceTask.complianceEnabled ?? true);
     } else {
@@ -405,6 +422,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
         this.boardControl.disable();
         this.eformControl.disable();
         this.planningTagControl.disable();
+        this.reportHeadlineEnabledControl.disable();
         this.statusControl.disable();
         this.complianceEnabledControl.disable();
       }
@@ -1027,7 +1045,7 @@ export class TaskCreateEditModalComponent implements OnInit, AfterViewInit, OnDe
       complianceEnabled: this.complianceEnabledControl.value,
       folderId: this.data.folderId,
       eformId: this.eformControl.value,
-      itemPlanningTagId: this.planningTagControl.value,
+      itemPlanningTagId: this.reportHeadlineEnabledControl.value ? this.planningTagControl.value : null,
 
       // Keep these for local/UI use and backward compat
       title: this.titleControl.value,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-create-modal/task-wizard-create-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-create-modal/task-wizard-create-modal.component.html
@@ -301,6 +301,7 @@
       class="btn-primary btn-primary--icon-left"
       id="createTaskBtn"
       (click)="create()"
+      [disabled]="!taskForm.value.itemPlanningTagId"
     >
       <span>{{ 'Create' | translate }}</span>
     </button>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-update-modal/task-wizard-update-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-update-modal/task-wizard-update-modal.component.ts
@@ -100,7 +100,11 @@ export class TaskWizardUpdateModalComponent implements OnInit, OnDestroy {
   }
 
   get disabledSaveButton(): boolean {
-    return R.equals(this.taskForm.value, this.copyModel);
+    // Require a report headline only when the loaded task had one: removal is
+    // blocked here, but tasks created without a headline (calendar checkbox
+    // unchecked) stay editable without forcing one back on.
+    return R.equals(this.taskForm.value, this.copyModel)
+      || (!this.taskForm.value.itemPlanningTagId && !!this.copyModel?.itemPlanningTagId);
   }
 
 


### PR DESCRIPTION
## Summary

Adds a checkbox in front of **Rapportoverskrift** in the calendar create/edit-task modal (default checked). Unchecked: the label dims, the dropdown is disabled, and the task saves with `itemPlanningTagId: null` — its collected data is then automatically excluded from the Word/Excel report (report generation groups by `Planning.ReportGroupPlanningTagId` and skips the null group; pre-existing behavior, no report-service changes).

Spec: `docs/superpowers/specs/2026-07-17-calendar-report-headline-checkbox-design.md` (workspace meta-repo).

## Changes

- **Backend** (`BackendConfigurationTaskWizardService`): removed the `ReportTableHeaderTagIsRequired` create guard; three `(int)ItemPlanningTagId!` casts now assign the nullable directly. `UpdateTags` already handled set→null (stale `PlanningsTags` link row is deleted); the create-path link row was already `HasValue`-guarded. No migrations — both columns were already nullable.
- **Calendar modal**: new `reportHeadlineEnabledControl` + `mat-checkbox` (`#calendarEventReportHeadlineToggle`) carrying the row label; dropdown placeholder "Vælg / opret rapportoverskrift" (new i18n key, 26 locales); save button additionally gated on `(checked && no tag)`; edit/copy seed the checkbox from the task; readonly mode disables it; unchecked ⇒ payload sends `itemPlanningTagId: null`.
- **Task wizard**: keeps requiring a headline client-side (Create button + update-modal save gate) since the shared server guard is gone. Tasks that never had a headline (created via the new flow) stay editable without forcing one back on; removal of an existing headline is still blocked there.
- **e2e**: rewrote V06 in `v/calendar-create-validation.spec.ts` (old test asserted the removed server rejection) and added `v/calendar-report-headline-toggle.spec.ts` (default state, gate, uncheck→create→reopen, edit-mode removal). Audited all 26 specs clicking `#calendarEventSaveBtn` — none hit the new gate.

## Intentional behavior notes

- Scope-"this"/single-occurrence edits do not alter the headline — it lives at planning (series) level, like eForm/folder today.
- The `ReportTableHeaderTagIsRequired` entry in `Resources/localization.json` is deliberately retained (removing it across ~30 languages is churn).

## Verification

Live-verified end-to-end in dev (full solution rebuild): default checked with Danish placeholder; checked+empty blocks Gem; unchecked dims/disables and the POST with `itemPlanningTagId: null` returns `CalendarTaskCreatedSuccessfully`; reopened task seeds unchecked; wizard Create gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)