### PR TITLE
Calendar: month view fills the viewport height

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-month-view/calendar-month-view.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-month-view/calendar-month-view.component.scss
@@ -1,7 +1,20 @@
+// Mirror the week grid's :host block: .calendar-main is a flex column and
+// stretches app-calendar-week-grid via an explicit flex:1 rule, but custom
+// elements default to inline — without this the month view sizes to content
+// and leaves dead space below instead of filling the viewport.
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .month-view {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   padding: 8px 16px 16px;
   overflow: auto;
 }


### PR DESCRIPTION
One-file SCSS fix: mirror the week grid's `:host` flex block on `app-calendar-month-view` so the 6-week grid stretches to the bottom of the viewport instead of sizing to content (follow-up to #1066). Verified live: grid bottom lands exactly at the viewport edge, rows distribute evenly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)