### PR TITLE
Calendar: month grid compresses to viewport (no scrollbar)

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-month-view/calendar-month-view.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-month-view/calendar-month-view.component.scss
@@ -69,7 +69,11 @@
   display: grid;
   grid-template-columns: 44px repeat(7, 1fr);
   flex: 1;
-  min-height: 96px;
+  // Rows share the available height evenly and may COMPRESS below their
+  // content height (cells clip via overflow:hidden) so the grid fits the
+  // viewport without a scrollbar. The floor only kicks in on very short
+  // windows, where .month-view's overflow:auto takes over as a fallback.
+  min-height: 64px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 
   &:last-child {
@@ -96,9 +100,13 @@
   border-right: 1px solid rgba(0, 0, 0, 0.08);
   padding: 2px 4px 4px;
   min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 2px;
+  // Chips beyond the compressed row height clip instead of growing the row
+  // (which would overflow the viewport and bring back the scrollbar).
+  overflow: hidden;
 
   &:last-child {
     border-right: none;


### PR DESCRIPTION
Follow-up to #1067: rows grew with their chip content, so on smaller viewports the grid overflowed and `.month-view` showed a scrollbar. Rows now distribute the available height evenly and compress below content height, with day cells clipping overflow; the 64px row floor plus `overflow:auto` remains as a fallback for very short windows. Verified live at 1920×1080, 1366×768 and 1280×650 — grid bottom lands on the viewport edge, no scrollbar, chips and +N labels render cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)