### PR TITLE
fix: validate Copy TargetBoardId belongs to target property (task-list)

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/TaskListBatchCopyDeleteTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/TaskListBatchCopyDeleteTest.cs
@@ -130,6 +130,14 @@ public class TaskListBatchCopyDeleteTest : TestBaseSetup
             BackendConfigurationPnDbContext.PropertyWorkers);
         await BackendConfigurationPnDbContext.SaveChangesAsync();
 
+        // CalendarBoards has no DB-level FK on PropertyId, but clear it before
+        // Properties for the same reason as PropertyWorkers above (added for
+        // the Copy TargetBoardId/TargetProperty validation guard — see
+        // SeedTargetBoard).
+        BackendConfigurationPnDbContext.CalendarBoards.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarBoards);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
         BackendConfigurationPnDbContext.Areas.RemoveRange(
             BackendConfigurationPnDbContext.Areas);
         BackendConfigurationPnDbContext.Properties.RemoveRange(
@@ -293,6 +301,26 @@ public class TaskListBatchCopyDeleteTest : TestBaseSetup
         await BackendConfigurationPnDbContext.SaveChangesAsync();
     }
 
+    /// <summary>
+    /// Seeds a real CalendarBoard row belonging to <paramref name="propertyId"/>
+    /// to stand in as a Copy TargetBoardId. Copy's new TargetBoardId/
+    /// TargetProperty guard does a real CalendarBoards lookup scoped to
+    /// (Id, PropertyId), so — unlike the old tests, which passed the bare
+    /// literal 777 with no backing row — the target board must actually
+    /// exist on the target property. Ids are DB-identity-generated, so the
+    /// caller must use the returned Id, not a literal.
+    /// </summary>
+    private async Task<int> SeedTargetBoard(int propertyId)
+    {
+        var board = new CalendarBoard
+        {
+            Name = $"CopyTargetBoard-{Guid.NewGuid()}", PropertyId = propertyId,
+            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+        };
+        await board.Create(BackendConfigurationPnDbContext!);
+        return board.Id;
+    }
+
     // ---- Copy ----
 
     [Test]
@@ -301,11 +329,12 @@ public class TaskListBatchCopyDeleteTest : TestBaseSetup
         var arpId = await SeedTask([100], workerTagIds: [42]);
         var targetPropertyId = await SeedTargetProperty();
         await SeedPropertyWorker(targetPropertyId, 900);
+        var targetBoardId = await SeedTargetBoard(targetPropertyId);
         var startDate = DateTime.UtcNow.Date.AddDays(7);
 
         var result = await _taskListService.Copy(new TaskListBatchCopyModel
         {
-            TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = 777, StartDate = startDate,
+            TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = targetBoardId, StartDate = startDate,
             SiteId = 900
         });
 
@@ -315,7 +344,7 @@ public class TaskListBatchCopyDeleteTest : TestBaseSetup
         Assert.Multiple(() =>
         {
             Assert.That(call.PropertyId, Is.EqualTo(targetPropertyId));
-            Assert.That(call.BoardId, Is.EqualTo(777));
+            Assert.That(call.BoardId, Is.EqualTo(targetBoardId));
             Assert.That(call.StartDate, Is.EqualTo(startDate));
             // TaskWizardStatuses.NotActive == 2.
             Assert.That(call.Status, Is.EqualTo(2));
@@ -330,10 +359,11 @@ public class TaskListBatchCopyDeleteTest : TestBaseSetup
         var arpId = await SeedTask([100, 101], workerTagIds: [42, 43]);
         var targetPropertyId = await SeedTargetProperty();
         await SeedPropertyWorker(targetPropertyId, 900);
+        var targetBoardId = await SeedTargetBoard(targetPropertyId);
 
         var result = await _taskListService.Copy(new TaskListBatchCopyModel
         {
-            TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = 777,
+            TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = targetBoardId,
             StartDate = DateTime.UtcNow.Date.AddDays(7), SiteId = 900
         });
 
@@ -371,10 +401,11 @@ public class TaskListBatchCopyDeleteTest : TestBaseSetup
         var planning = await ItemsPlanningPnDbContext!.Plannings.FirstAsync(x => x.Id == arp.ItemPlanningId);
         var targetPropertyId = await SeedTargetProperty();
         await SeedPropertyWorker(targetPropertyId, 900);
+        var targetBoardId = await SeedTargetBoard(targetPropertyId);
 
         var result = await _taskListService.Copy(new TaskListBatchCopyModel
         {
-            TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = 777,
+            TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = targetBoardId,
             StartDate = DateTime.UtcNow.Date.AddDays(7), SiteId = 900
         });
 
@@ -401,10 +432,11 @@ public class TaskListBatchCopyDeleteTest : TestBaseSetup
             .AsNoTracking().FirstAsync(x => x.Id == arpId);
         var targetPropertyId = await SeedTargetProperty();
         await SeedPropertyWorker(targetPropertyId, 900);
+        var targetBoardId = await SeedTargetBoard(targetPropertyId);
 
         var result = await _taskListService.Copy(new TaskListBatchCopyModel
         {
-            TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = 777,
+            TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = targetBoardId,
             StartDate = DateTime.UtcNow.Date.AddDays(7), SiteId = 900
         });
 
@@ -431,10 +463,11 @@ public class TaskListBatchCopyDeleteTest : TestBaseSetup
         const int unknownArpId = 999_999;
         var targetPropertyId = await SeedTargetProperty();
         await SeedPropertyWorker(targetPropertyId, 900);
+        var targetBoardId = await SeedTargetBoard(targetPropertyId);
 
         var result = await _taskListService.Copy(new TaskListBatchCopyModel
         {
-            TaskIds = [unknownArpId, validArpId], TargetPropertyId = targetPropertyId, TargetBoardId = 777,
+            TaskIds = [unknownArpId, validArpId], TargetPropertyId = targetPropertyId, TargetBoardId = targetBoardId,
             StartDate = DateTime.UtcNow.Date.AddDays(7), SiteId = 900
         });
 
@@ -450,10 +483,11 @@ public class TaskListBatchCopyDeleteTest : TestBaseSetup
         var arpId = await SeedTask([100], workerTagIds: [42], createdInGuide: false);
         var targetPropertyId = await SeedTargetProperty();
         await SeedPropertyWorker(targetPropertyId, 900);
+        var targetBoardId = await SeedTargetBoard(targetPropertyId);
 
         var result = await _taskListService.Copy(new TaskListBatchCopyModel
         {
-            TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = 777,
+            TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = targetBoardId,
             StartDate = DateTime.UtcNow.Date.AddDays(7), SiteId = 900
         });
 
@@ -467,10 +501,11 @@ public class TaskListBatchCopyDeleteTest : TestBaseSetup
     {
         var targetPropertyId = await SeedTargetProperty();
         await SeedPropertyWorker(targetPropertyId, 900);
+        var targetBoardId = await SeedTargetBoard(targetPropertyId);
 
         var result = await _taskListService.Copy(new TaskListBatchCopyModel
         {
-            TaskIds = [], TargetPropertyId = targetPropertyId, TargetBoardId = 777,
+            TaskIds = [], TargetPropertyId = targetPropertyId, TargetBoardId = targetBoardId,
             StartDate = DateTime.UtcNow.Date.AddDays(7), SiteId = 900
         });
 
@@ -485,13 +520,42 @@ public class TaskListBatchCopyDeleteTest : TestBaseSetup
         // Seed the target property WITHOUT linking site 900 as a
         // PropertyWorker — the defense-in-depth guard must refuse the
         // whole batch before touching any task, even though the source
-        // task itself is perfectly valid.
+        // task itself is perfectly valid. Board is deliberately not seeded
+        // either: the SiteId guard runs first and must short-circuit before
+        // the TargetBoardId guard is ever reached, so an arbitrary literal
+        // TargetBoardId here is fine — it should never be evaluated.
         var arpId = await SeedTask([100], workerTagIds: [42]);
         var targetPropertyId = await SeedTargetProperty();
 
         var result = await _taskListService.Copy(new TaskListBatchCopyModel
         {
             TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = 777,
+            StartDate = DateTime.UtcNow.Date.AddDays(7), SiteId = 900
+        });
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(_createCalls, Is.Empty);
+    }
+
+    [Test]
+    public async Task Copy_BoardNotOnTargetProperty_FailsWholeBatch_WithoutCreateCalls()
+    {
+        // Seed a source task, a target property, and a PropertyWorker link
+        // for the site so the SiteId guard passes — but seed the
+        // CalendarBoard on a DIFFERENT (unrelated) property. The
+        // TargetBoardId/TargetProperty guard must refuse the whole batch
+        // before touching any task, even though the source task and site
+        // are both perfectly valid, exactly mirroring
+        // Copy_SiteNotOnTargetProperty_FailsWholeBatch_WithoutCreateCalls.
+        var arpId = await SeedTask([100], workerTagIds: [42]);
+        var targetPropertyId = await SeedTargetProperty();
+        await SeedPropertyWorker(targetPropertyId, 900);
+        var otherPropertyId = await SeedTargetProperty();
+        var boardOnOtherProperty = await SeedTargetBoard(otherPropertyId);
+
+        var result = await _taskListService.Copy(new TaskListBatchCopyModel
+        {
+            TaskIds = [arpId], TargetPropertyId = targetPropertyId, TargetBoardId = boardOnOtherProperty,
             StartDate = DateTime.UtcNow.Date.AddDays(7), SiteId = 900
         });
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/localization.json
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Resources/localization.json
@@ -5126,6 +5126,37 @@
     }
   },
   {
+    "Key": "SelectedBoardDoesNotBelongToTargetProperty",
+    "LocalizedValue": {
+      "en-US": "Selected board does not belong to the target property",
+      "da": "Den valgte tavle tilhører ikke den valgte ejendom",
+      "de": "Die ausgewählte Tafel gehört nicht zur Zielimmobilie",
+      "uk-UA": "Вибрана дошка не належить до цільового об'єкта",
+      "pl-PL": "Wybrana tablica nie należy do docelowej nieruchomości",
+      "no-NO": "Den valgte tavlen tilhører ikke den valgte eiendommen",
+      "sv-SE": "Den valda tavlan tillhör inte den valda fastigheten",
+      "es-ES": "El tablero seleccionado no pertenece a la propiedad de destino",
+      "fr-FR": "Le tableau sélectionné n'appartient pas à la propriété cible",
+      "it-IT": "La bacheca selezionata non appartiene alla proprietà di destinazione",
+      "nl-NL": "Het geselecteerde bord hoort niet bij de doellocatie",
+      "pt-BR": "O quadro selecionado não pertence à propriedade de destino",
+      "pt-PT": "O quadro selecionado não pertence à propriedade de destino",
+      "fi-FI": "Valittu taulu ei kuulu kohdekiinteistöön",
+      "et-ET": "Valitud tahvel ei kuulu sihtkinnistule",
+      "lv-LV": "Izvēlētā tāfele nepieder mērķa īpašumam",
+      "lt-LT": "Pasirinkta lenta nepriklauso tikslinei nuosavybei",
+      "ro-RO": "Panoul selectat nu aparține proprietății țintă",
+      "hr-HR": "Odabrana ploča ne pripada ciljnoj nekretnini",
+      "sl-SL": "Izbrana tabla ne pripada ciljni nepremičnini",
+      "cs-CZ": "Vybraná tabule nepatří k cílové nemovitosti",
+      "sk-SK": "Vybraná tabuľa nepatrí k cieľovej nehnuteľnosti",
+      "hu-HU": "A kiválasztott tábla nem tartozik a célingatlanhoz",
+      "bg-BG": "Избраната дъска не принадлежи към целевия имот",
+      "el-GR": "Ο επιλεγμένος πίνακας δεν ανήκει στο ακίνητο-στόχο",
+      "is-IS": "Valið borð tilheyrir ekki markfasteigninni"
+    }
+  },
+  {
     "Key": "PartiallyCompleted",
     "LocalizedValue": {
       "en-US": "Partially completed",

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskListService/BackendConfigurationTaskListService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskListService/BackendConfigurationTaskListService.cs
@@ -176,6 +176,24 @@ public class BackendConfigurationTaskListService(
                 localizationService.GetString("SelectedWorkerDoesNotBelongToTargetProperty"));
         }
 
+        // Defense-in-depth (mirrors the SiteId guard above): model.TargetBoardId
+        // ends up as CalendarTaskCreateRequestModel.BoardId, which CreateTask
+        // persists verbatim with no cross-check against model.TargetPropertyId —
+        // so a stale/crafted TargetBoardId from another property would silently
+        // land in the copy's CalendarConfiguration. Validate once, before
+        // touching any task, so a failure here never creates a partial batch.
+        var boardIsOnTargetProperty = await backendConfigurationPnDbContext.CalendarBoards
+            .AsNoTracking()
+            .AnyAsync(b =>
+                b.Id == model.TargetBoardId
+                && b.PropertyId == model.TargetPropertyId
+                && b.WorkflowState != Constants.WorkflowStates.Removed);
+        if (!boardIsOnTargetProperty)
+        {
+            return new OperationResult(false,
+                localizationService.GetString("SelectedBoardDoesNotBelongToTargetProperty"));
+        }
+
         return await RunPerTask(model.TaskIds, async id =>
         {
             var source = await BuildUpdateModel(id);


### PR DESCRIPTION
## Summary

Deferred M2 follow-up on the (now-merged) backend-configuration task-list feature: server-side validation that the Copy batch action's `TargetBoardId` belongs to `TargetPropertyId`.

`BackendConfigurationTaskListService.Copy` already guards that `model.SiteId` is a worker on `model.TargetPropertyId` (a `PropertyWorkers.AnyAsync` check at the top of the method), but did not validate `model.TargetBoardId`. `CalendarBoard` has a `PropertyId`, and a stale or crafted `TargetBoardId` from another property would have been persisted verbatim into the copy's `CalendarConfiguration`.

This adds a parallel guard, mirroring the existing `SiteId` check exactly:

- Looks up `CalendarBoards` for a non-removed row matching `(Id == TargetBoardId, PropertyId == TargetPropertyId)`.
- If none is found, the whole batch is refused up front (before any task is touched) with a new localized message, `SelectedBoardDoesNotBelongToTargetProperty`.

Defense-in-depth: the copy dialog's board picker is already scoped to the target property client-side, but the API must not trust that — same rationale as the existing `SiteId`/`PropertyWorkers` guard and `EventDeployService`'s equivalent check. This is an admin-only endpoint, so this closes the last remaining Copy validation gap identified during the original review (M2).

## Test plan

- [x] `dotnet build eFormAPI.sln -c Debug` (host app) — 0 errors
- [x] `dotnet build BackendConfiguration.Pn.Integration.Test.csproj -c Debug` — 0 errors
- [x] Added `Copy_BoardNotOnTargetProperty_FailsWholeBatch_WithoutCreateCalls`, mirroring `Copy_SiteNotOnTargetProperty_FailsWholeBatch_WithoutCreateCalls`: seeds a valid source task, target property, and a `PropertyWorker` link for the site (so the `SiteId` guard passes), but a `CalendarBoard` belonging to a *different* property — asserts `Success == false` and zero `CreateTask` calls on the mocked calendar service.
- [x] Updated every existing `Copy_*` happy-path test to seed a real `CalendarBoard` on the target property (via a new `SeedTargetBoard` helper) instead of passing the bare literal `777`, so they still exercise the happy path under the new guard.
- [ ] CI (unit/integration test suites run in CI, not locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)