### PR TITLE
Add Settings.RegisterPushToken gRPC for reminder-push device tokens

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/SettingsGrpcServicePushTokenTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/SettingsGrpcServicePushTokenTests.cs
@@ -1,0 +1,152 @@
+using System.Linq;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Services.GrpcServices;
+using Grpc.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.Settings.V1;
+using NSubstitute;
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+/// <summary>
+/// DB-backed tests for <see cref="SettingsGrpcService.RegisterPushToken"/>'s
+/// upsert semantics against the real unique (WorkerId, FcmToken) index.
+/// The critical case is <see cref="RegisterPushToken_AfterSoftDelete_RevivesExistingRow"/>:
+/// the index has no WorkflowState filter and PnBase.Delete() only soft-deletes,
+/// so re-registering after logout MUST Update() the removed row back to
+/// Created instead of Create()ing a duplicate (which would throw
+/// DbUpdateException).
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class SettingsGrpcServicePushTokenTests : TestBaseSetup
+{
+    // The DeviceToken tables were added after the raw SQL bootstrap script
+    // (SQL/420_eform-backend-configuration-plugin.sql) was last regenerated,
+    // so TestBaseSetup.Setup's DROP+CREATE pass never touches them and rows
+    // would otherwise accumulate across tests (mirrors
+    // AdhocServiceTaskCrudTests.CleanAdhocTables).
+    [SetUp]
+    public async Task CleanDeviceTokenTables()
+    {
+        BackendConfigurationPnDbContext!.DeviceTokenVersions.RemoveRange(
+            BackendConfigurationPnDbContext.DeviceTokenVersions);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.DeviceTokens.RemoveRange(
+            BackendConfigurationPnDbContext.DeviceTokens);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+    }
+
+    private SettingsGrpcService CreateSut(int resolvedWorkerId)
+    {
+        var resolver = Substitute.For<IGrpcSiteResolver>();
+        resolver.GetSdkSiteIdAsync().Returns(resolvedWorkerId);
+        return new SettingsGrpcService(
+            BackendConfigurationPnDbContext!,
+            resolver,
+            NullLogger<SettingsGrpcService>.Instance);
+    }
+
+    private static RegisterPushTokenRequest MakeRequest(string token, string platform = "android") =>
+        new() { FcmToken = token, Platform = platform };
+
+    private static ServerCallContext Context() => Substitute.For<ServerCallContext>();
+
+    [Test]
+    public async Task RegisterPushToken_NewToken_CreatesRow()
+    {
+        var sut = CreateSut(7);
+
+        await sut.RegisterPushToken(MakeRequest("token-a"), Context());
+
+        var rows = await BackendConfigurationPnDbContext!.DeviceTokens.AsNoTracking().ToListAsync();
+        Assert.That(rows, Has.Count.EqualTo(1));
+        Assert.That(rows[0].WorkerId, Is.EqualTo(7));
+        Assert.That(rows[0].FcmToken, Is.EqualTo("token-a"));
+        Assert.That(rows[0].Platform, Is.EqualTo("android"));
+        Assert.That(rows[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(rows[0].Version, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task RegisterPushToken_ExistingToken_UpdatesRowInsteadOfCreating()
+    {
+        var sut = CreateSut(7);
+        await sut.RegisterPushToken(MakeRequest("token-a", "android"), Context());
+
+        await sut.RegisterPushToken(MakeRequest("token-a", "ios"), Context());
+
+        var rows = await BackendConfigurationPnDbContext!.DeviceTokens.AsNoTracking().ToListAsync();
+        Assert.That(rows, Has.Count.EqualTo(1));
+        Assert.That(rows[0].WorkerId, Is.EqualTo(7));
+        Assert.That(rows[0].FcmToken, Is.EqualTo("token-a"));
+        Assert.That(rows[0].Platform, Is.EqualTo("ios"));
+        Assert.That(rows[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(rows[0].Version, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task RegisterPushToken_AfterSoftDelete_RevivesExistingRow()
+    {
+        var sut = CreateSut(7);
+        await sut.RegisterPushToken(MakeRequest("token-a"), Context());
+
+        // Logout path: PnBase.Delete() soft-deletes (WorkflowState=Removed,
+        // row stays and still occupies the unique (WorkerId, FcmToken) slot).
+        var stored = await BackendConfigurationPnDbContext!.DeviceTokens.SingleAsync();
+        await stored.Delete(BackendConfigurationPnDbContext);
+        Assert.That(
+            (await BackendConfigurationPnDbContext.DeviceTokens.AsNoTracking().SingleAsync()).WorkflowState,
+            Is.EqualTo(Constants.WorkflowStates.Removed));
+
+        // Re-register after login: must revive, not Create() a duplicate.
+        await sut.RegisterPushToken(MakeRequest("token-a", "android"), Context());
+
+        var rows = await BackendConfigurationPnDbContext.DeviceTokens.AsNoTracking().ToListAsync();
+        Assert.That(rows, Has.Count.EqualTo(1));
+        Assert.That(rows[0].Id, Is.EqualTo(stored.Id));
+        Assert.That(rows[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(rows[0].Platform, Is.EqualTo("android"));
+    }
+
+    [Test]
+    public async Task RegisterPushToken_SameTokenForSecondWorker_CreatesSecondRow()
+    {
+        await CreateSut(7).RegisterPushToken(MakeRequest("token-a"), Context());
+
+        await CreateSut(8).RegisterPushToken(MakeRequest("token-a"), Context());
+
+        var rows = await BackendConfigurationPnDbContext!.DeviceTokens.AsNoTracking()
+            .OrderBy(t => t.WorkerId).ToListAsync();
+        Assert.That(rows, Has.Count.EqualTo(2));
+        Assert.That(rows[0].WorkerId, Is.EqualTo(7));
+        Assert.That(rows[1].WorkerId, Is.EqualTo(8));
+        Assert.That(rows.Select(r => r.FcmToken), Is.All.EqualTo("token-a"));
+    }
+
+    [Test]
+    public void RegisterPushToken_NoResolvableWorker_ThrowsUnauthenticated()
+    {
+        var sut = CreateSut(0);
+
+        var ex = Assert.ThrowsAsync<RpcException>(async () =>
+            await sut.RegisterPushToken(MakeRequest("token-a"), Context()));
+        Assert.That(ex!.StatusCode, Is.EqualTo(StatusCode.Unauthenticated));
+        Assert.That(BackendConfigurationPnDbContext!.DeviceTokens.AsNoTracking().Count(), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void RegisterPushToken_EmptyToken_ThrowsInvalidArgument()
+    {
+        var sut = CreateSut(7);
+
+        var ex = Assert.ThrowsAsync<RpcException>(async () =>
+            await sut.RegisterPushToken(MakeRequest("   "), Context()));
+        Assert.That(ex!.StatusCode, Is.EqualTo(StatusCode.InvalidArgument));
+        Assert.That(BackendConfigurationPnDbContext!.DeviceTokens.AsNoTracking().Count(), Is.EqualTo(0));
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/BackendConfiguration.Pn.csproj
@@ -285,7 +285,7 @@
     <PackageReference Include="Microting.EformAngularFrontendBase" Version="10.0.36" />
     <PackageReference Include="Microting.eFormApi.BasePn" Version="10.0.30" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
-    <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.46" />
+    <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.47" />
     <PackageReference Include="Microting.eFormCaseTemplateBase" Version="10.0.34" />
     <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.36" />
     <PackageReference Include="Microting.TimePlanningBase" Version="10.0.55" />
@@ -308,6 +308,7 @@
       <Protobuf Include="Protos\documents.proto" GrpcServices="Server" ProtoRoot="Protos" />
       <Protobuf Include="Protos\events.proto" GrpcServices="Server" ProtoRoot="Protos" />
       <Protobuf Include="Protos\adhoc.proto" GrpcServices="Server" ProtoRoot="Protos" />
+      <Protobuf Include="Protos\settings.proto" GrpcServices="Server" ProtoRoot="Protos" />
     </ItemGroup>
 
 </Project>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/EformBackendConfigurationPlugin.cs
@@ -850,6 +850,7 @@ public class EformBackendConfigurationPlugin : IEformPlugin
             endpoints.MapGrpcService<Services.GrpcServices.DocumentsGrpcService>();
             endpoints.MapGrpcService<Services.GrpcServices.EventsGrpcService>();
             endpoints.MapGrpcService<Services.GrpcServices.AdhocGrpcService>();
+            endpoints.MapGrpcService<Services.GrpcServices.SettingsGrpcService>();
         });
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/settings.proto
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Protos/settings.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package microting.settings.v1;
+
+service Settings {
+  rpc RegisterPushToken(RegisterPushTokenRequest) returns (RegisterPushTokenResponse);
+  rpc SetUserPrefs(SetUserPrefsRequest) returns (SetUserPrefsResponse);
+}
+
+message RegisterPushTokenRequest {
+  string fcm_token = 1;
+  string platform = 2;          // "android" | "ios"
+}
+message RegisterPushTokenResponse {}
+
+message SetUserPrefsRequest {
+  string language = 1;          // BCP-47 (e.g. "da", "en")
+  bool biometric_enabled = 2;
+  bool push_enabled = 3;
+}
+message SetUserPrefsResponse {}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/SettingsGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/SettingsGrpcService.cs
@@ -1,0 +1,93 @@
+using System.Threading.Tasks;
+using Grpc.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.Settings.V1;
+
+namespace BackendConfiguration.Pn.Services.GrpcServices;
+
+/// <summary>
+/// gRPC adapter for the mobile "Settings" contract
+/// (<c>/microting.settings.v1.Settings/*</c>, Protos/settings.proto — kept
+/// byte-for-byte identical to the mobile client's copy, hence the
+/// package-derived <c>Microting.Settings.V1</c> codegen namespace instead of
+/// this repo's usual <c>BackendConfiguration.Pn.Grpc.*</c> option).
+///
+/// <c>RegisterPushToken</c> resolves the caller's SDK site id via
+/// <see cref="IGrpcSiteResolver"/> (mirroring <c>AdhocGrpcService</c>'s
+/// convention: <c>RpcException(Unauthenticated)</c> when the resolver returns
+/// 0) and upserts a <see cref="DeviceToken"/> row for reminder push delivery.
+///
+/// UPSERT contract (documented on the unique (WorkerId, FcmToken) index in
+/// <c>BackendConfigurationPnDbContext</c> and on <see cref="DeviceToken"/>):
+/// the index has NO WorkflowState filter and <c>PnBase.Delete()</c> only
+/// soft-deletes, so the lookup MUST include soft-deleted rows and
+/// <c>Update()</c> an existing row (flipping WorkflowState back to Created)
+/// — <c>Create()</c> is only legal when no row exists at all, otherwise a
+/// re-register after logout would violate the unique index.
+///
+/// <c>SetUserPrefs</c> is intentionally not overridden yet — the base class
+/// answers <c>Unimplemented</c>, which the mobile client tolerates.
+/// </summary>
+public class SettingsGrpcService(
+    BackendConfigurationPnDbContext dbContext,
+    IGrpcSiteResolver siteResolver,
+    ILogger<SettingsGrpcService> logger)
+    : Settings.SettingsBase
+{
+    public override async Task<RegisterPushTokenResponse> RegisterPushToken(
+        RegisterPushTokenRequest request,
+        ServerCallContext context)
+    {
+        var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
+
+        var fcmToken = request.FcmToken?.Trim() ?? string.Empty;
+        if (fcmToken.Length == 0)
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "fcm_token must be non-empty."));
+        }
+
+        // Platform is stored exactly as sent ("android"/"ios"/"unknown").
+        var platform = request.Platform ?? string.Empty;
+
+        // No WorkflowState filter here — soft-deleted rows MUST be found and
+        // revived via Update(); see the class doc / the base repo's index note.
+        var existing = await dbContext.DeviceTokens
+            .FirstOrDefaultAsync(t => t.WorkerId == workerId && t.FcmToken == fcmToken)
+            .ConfigureAwait(false);
+
+        if (existing != null)
+        {
+            existing.Platform = platform;
+            existing.WorkflowState = Constants.WorkflowStates.Created;
+            await existing.Update(dbContext).ConfigureAwait(false);
+        }
+        else
+        {
+            var deviceToken = new DeviceToken
+            {
+                WorkerId = workerId,
+                FcmToken = fcmToken,
+                Platform = platform
+            };
+            await deviceToken.Create(dbContext).ConfigureAwait(false);
+        }
+
+        return new RegisterPushTokenResponse();
+    }
+
+    private async Task<int> ResolveWorkerIdAsync()
+    {
+        var workerId = await siteResolver.GetSdkSiteIdAsync().ConfigureAwait(false);
+        if (workerId == 0)
+        {
+            logger.LogWarning("SettingsGrpcService: no resolvable SDK worker/site identity for the caller.");
+            throw new RpcException(new Status(StatusCode.Unauthenticated,
+                "Caller has no resolvable SDK worker/site identity."));
+        }
+        return workerId;
+    }
+}


### PR DESCRIPTION
Backend half of the mobile token-registration contract (flutter-adhoc PR #10). Base bumped to 10.0.47 (DeviceTokens + reminder markers).

- Protos/settings.proto byte-identical to the mobile client (sha-verified); server codegen only; RPC path /microting.settings.v1.Settings/RegisterPushToken.
- SettingsGrpcService mirrors AdhocGrpcService conventions: GrpcSiteResolver identity (Unauthenticated on unresolvable), InvalidArgument on empty token, and the documented unique-index upsert contract — lookup including soft-deleted rows, Update+revive (WorkflowState back to Created) vs Create. SetUserPrefs intentionally left to the generated base (Unimplemented).
- 6 integration tests incl. the soft-delete-revive trap, cross-worker same-token, and identity-failure paths; per-test DeviceToken table cleanup per fixture convention.

Review (fresh reviewer): approve, no findings ≥ threshold; generated-code claims verified against actual codegen output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)