### PR TITLE
feat: adhoc area management (dashboard Områder admin cluster)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,4 @@ eform-client/.idea/
 /eFormAPI/eFormAPI.Web/Plugins/BackendConfiguration.Pn/net6.0
 eFormAPI/eFormAPI.Web/
 .claude
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -356,3 +356,4 @@ eform-client/.idea/
 eFormAPI/eFormAPI.Web/
 .claude
 .worktrees/
+.superpowers/

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceAreaCrudTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceAreaCrudTests.cs
@@ -253,6 +253,18 @@ public class AdhocServiceAreaCrudTests : TestBaseSetup
         var reloaded = await BackendConfigurationPnDbContext!.AdhocAreas.SingleAsync(a => a.Id == area.Id);
         Assert.That(reloaded.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
         Assert.That(await sut.ListAreas(1, property.Id), Is.Empty);
+
+        // Soft delete must leave a version-history trail (same idiom as
+        // Microting.EformBackendConfigurationBase.Tests/AdhocAreaUTest.cs's
+        // AdhocArea_Delete_DoesDelete): a Created row from the initial
+        // Create() plus a Removed row from the Delete() above.
+        var versions = await BackendConfigurationPnDbContext.AdhocAreaVersions
+            .Where(v => v.AdhocAreaId == area.Id)
+            .OrderBy(v => v.Version)
+            .ToListAsync();
+        Assert.That(versions, Has.Count.EqualTo(2));
+        Assert.That(versions[0].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+        Assert.That(versions[1].WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
     }
 
     [Test]

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceAreaCrudTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceAreaCrudTests.cs
@@ -1,0 +1,338 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Services.BackendConfigurationAdhocService;
+using BackendConfiguration.Pn.Services.UserPropertyAccess;
+using Microsoft.EntityFrameworkCore;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using NSubstitute;
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+/// <summary>
+/// Drives the area mutation trio (CreateAreas/RenameArea/DeleteArea, spec
+/// 2026-07-30-adhoc-area-management-design.md). Same fixture conventions as
+/// <see cref="AdhocServiceReferenceDataTests"/>: FK-safe [SetUp] cleanup
+/// because the Adhoc* tables postdate the raw SQL bootstrap script.
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class AdhocServiceAreaCrudTests : TestBaseSetup
+{
+    [SetUp]
+    public async Task CleanAdhocTables()
+    {
+        BackendConfigurationPnDbContext!.AdhocTasks.RemoveRange(
+            BackendConfigurationPnDbContext.AdhocTasks);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AdhocAreas.RemoveRange(
+            BackendConfigurationPnDbContext.AdhocAreas);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+    }
+
+    private BackendConfigurationAdhocService CreateSut()
+    {
+        return new BackendConfigurationAdhocService(
+            BackendConfigurationPnDbContext!,
+            new BackendConfigurationUserPropertyAccess(BackendConfigurationPnDbContext!),
+            Substitute.For<IEFormCoreService>(),
+            new FakeAdhocPhotoStorage());
+    }
+
+    private async Task<Property> CreatePropertyAsync(string? name = null)
+    {
+        var property = new Property
+        {
+            Name = name ?? Guid.NewGuid().ToString(),
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await BackendConfigurationPnDbContext!.Properties.AddAsync(property);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        return property;
+    }
+
+    private async Task GrantPropertyAccessAsync(int propertyId, int workerId)
+    {
+        var propertyWorker = new PropertyWorker
+        {
+            PropertyId = propertyId,
+            WorkerId = workerId,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1,
+        };
+        await BackendConfigurationPnDbContext!.PropertyWorkers.AddAsync(propertyWorker);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+    }
+
+    // --- CreateAreas ---
+
+    [Test]
+    public async Task CreateAreas_CreatesTrimmedAreas_AndReturnsRefreshedList()
+    {
+        var property = await CreatePropertyAsync();
+        var sut = CreateSut();
+
+        var result = await sut.CreateAreas(0, property.Id, ["  Lade  ", "Stald"], isAdmin: true);
+
+        Assert.That(result.Select(a => a.Name), Is.EquivalentTo(new[] { "Lade", "Stald" }));
+        var stored = await BackendConfigurationPnDbContext!.AdhocAreas.ToListAsync();
+        Assert.That(stored.Select(a => a.Name), Is.EquivalentTo(new[] { "Lade", "Stald" }));
+        Assert.That(stored.All(a => a.PropertyId == property.Id), Is.True);
+    }
+
+    [Test]
+    public async Task CreateAreas_SkipsEmpties_InBatchDuplicates_AndExistingActives_CaseInsensitively()
+    {
+        var property = await CreatePropertyAsync();
+        var existing = new AdhocArea { PropertyId = property.Id, Name = "Lade" };
+        await existing.Create(BackendConfigurationPnDbContext!);
+        var sut = CreateSut();
+
+        var result = await sut.CreateAreas(
+            0, property.Id, ["", "  ", "lade", "Stald", "STALD", "Mark"], isAdmin: true);
+
+        Assert.That(result.Select(a => a.Name), Is.EquivalentTo(new[] { "Lade", "Stald", "Mark" }));
+        Assert.That(await BackendConfigurationPnDbContext!.AdhocAreas.CountAsync(), Is.EqualTo(3));
+    }
+
+    [Test]
+    public async Task CreateAreas_IsIdempotent_OnResubmit()
+    {
+        var property = await CreatePropertyAsync();
+        var sut = CreateSut();
+
+        await sut.CreateAreas(0, property.Id, ["Lade", "Stald"], isAdmin: true);
+        var second = await sut.CreateAreas(0, property.Id, ["Lade", "Stald"], isAdmin: true);
+
+        Assert.That(second, Has.Count.EqualTo(2));
+        Assert.That(await BackendConfigurationPnDbContext!.AdhocAreas.CountAsync(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task CreateAreas_DoesNotCollideWith_RemovedAreaName()
+    {
+        var property = await CreatePropertyAsync();
+        var removed = new AdhocArea { PropertyId = property.Id, Name = "Lade" };
+        await removed.Create(BackendConfigurationPnDbContext!);
+        await removed.Delete(BackendConfigurationPnDbContext!);
+        var sut = CreateSut();
+
+        var result = await sut.CreateAreas(0, property.Id, ["Lade"], isAdmin: true);
+
+        Assert.That(result.Single().Name, Is.EqualTo("Lade"));
+        Assert.That(result.Single().Id, Is.Not.EqualTo(removed.Id));
+    }
+
+    [Test]
+    public async Task CreateAreas_Throws_ForUnknownProperty()
+    {
+        var sut = CreateSut();
+
+        Assert.ThrowsAsync<ArgumentException>(async () =>
+            await sut.CreateAreas(0, 999999, ["Lade"], isAdmin: true));
+    }
+
+    // --- RenameArea ---
+
+    [Test]
+    public async Task RenameArea_Succeeds_AndTrims()
+    {
+        var property = await CreatePropertyAsync();
+        var area = new AdhocArea { PropertyId = property.Id, Name = "Lade" };
+        await area.Create(BackendConfigurationPnDbContext!);
+        var sut = CreateSut();
+
+        var result = await sut.RenameArea(0, area.Id, "  Maskinhal  ", isAdmin: true);
+
+        Assert.That(result.Name, Is.EqualTo("Maskinhal"));
+        var reloaded = await BackendConfigurationPnDbContext!.AdhocAreas.SingleAsync(a => a.Id == area.Id);
+        Assert.That(reloaded.Name, Is.EqualTo("Maskinhal"));
+    }
+
+    [Test]
+    public async Task RenameArea_Throws_OnDuplicateName_CaseInsensitive()
+    {
+        var property = await CreatePropertyAsync();
+        var area = new AdhocArea { PropertyId = property.Id, Name = "Lade" };
+        await area.Create(BackendConfigurationPnDbContext!);
+        var other = new AdhocArea { PropertyId = property.Id, Name = "Stald" };
+        await other.Create(BackendConfigurationPnDbContext!);
+        var sut = CreateSut();
+
+        Assert.ThrowsAsync<ArgumentException>(async () =>
+            await sut.RenameArea(0, area.Id, "stald", isAdmin: true));
+    }
+
+    [Test]
+    public async Task RenameArea_AllowsSameNameOnOtherProperty()
+    {
+        var property = await CreatePropertyAsync();
+        var otherProperty = await CreatePropertyAsync();
+        var area = new AdhocArea { PropertyId = property.Id, Name = "Lade" };
+        await area.Create(BackendConfigurationPnDbContext!);
+        var otherArea = new AdhocArea { PropertyId = otherProperty.Id, Name = "Stald" };
+        await otherArea.Create(BackendConfigurationPnDbContext!);
+        var sut = CreateSut();
+
+        var result = await sut.RenameArea(0, area.Id, "Stald", isAdmin: true);
+
+        Assert.That(result.Name, Is.EqualTo("Stald"));
+    }
+
+    [Test]
+    public async Task RenameArea_Throws_ForUnknownOrRemovedArea()
+    {
+        var property = await CreatePropertyAsync();
+        var removed = new AdhocArea { PropertyId = property.Id, Name = "Lade" };
+        await removed.Create(BackendConfigurationPnDbContext!);
+        await removed.Delete(BackendConfigurationPnDbContext!);
+        var sut = CreateSut();
+
+        Assert.ThrowsAsync<AdhocAreaNotFoundException>(async () =>
+            await sut.RenameArea(0, removed.Id, "Ny", isAdmin: true));
+        Assert.ThrowsAsync<AdhocAreaNotFoundException>(async () =>
+            await sut.RenameArea(0, 999999, "Ny", isAdmin: true));
+    }
+
+    [Test]
+    public async Task RenameArea_Throws_OnEmptyName()
+    {
+        var property = await CreatePropertyAsync();
+        var area = new AdhocArea { PropertyId = property.Id, Name = "Lade" };
+        await area.Create(BackendConfigurationPnDbContext!);
+        var sut = CreateSut();
+
+        Assert.ThrowsAsync<ArgumentException>(async () =>
+            await sut.RenameArea(0, area.Id, "   ", isAdmin: true));
+    }
+
+    // --- DeleteArea ---
+
+    [Test]
+    public async Task DeleteArea_SoftDeletes_AndListAreasStopsReturningIt()
+    {
+        var property = await CreatePropertyAsync();
+        await GrantPropertyAccessAsync(property.Id, 1);
+        var area = new AdhocArea { PropertyId = property.Id, Name = "Lade" };
+        await area.Create(BackendConfigurationPnDbContext!);
+        var sut = CreateSut();
+
+        await sut.DeleteArea(0, area.Id, isAdmin: true);
+
+        var reloaded = await BackendConfigurationPnDbContext!.AdhocAreas.SingleAsync(a => a.Id == area.Id);
+        Assert.That(reloaded.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+        Assert.That(await sut.ListAreas(1, property.Id), Is.Empty);
+    }
+
+    [Test]
+    public async Task DeleteArea_LeavesReferencingTasksUntouched()
+    {
+        var property = await CreatePropertyAsync();
+        var area = new AdhocArea { PropertyId = property.Id, Name = "Lade" };
+        await area.Create(BackendConfigurationPnDbContext!);
+        BackendConfigurationPnDbContext!.AdhocTasks.Add(new AdhocTaskEntity
+        {
+            Title = "Task in Lade",
+            Description = "d",
+            PropertyId = property.Id,
+            AreaId = area.Id,
+            CreatedByWorkerId = 1,
+            WorkflowState = Constants.WorkflowStates.Created,
+        });
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+        var sut = CreateSut();
+
+        await sut.DeleteArea(0, area.Id, isAdmin: true);
+
+        var task = await BackendConfigurationPnDbContext.AdhocTasks.SingleAsync();
+        Assert.That(task.AreaId, Is.EqualTo(area.Id));
+        Assert.That(task.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
+    }
+
+    [Test]
+    public async Task DeleteArea_Throws_ForUnknownArea()
+    {
+        var sut = CreateSut();
+
+        Assert.ThrowsAsync<AdhocAreaNotFoundException>(async () =>
+            await sut.DeleteArea(0, 999999, isAdmin: true));
+    }
+
+    // --- Access guard (all three mutations share RequirePropertyAccessAsync) ---
+
+    [Test]
+    public async Task AreaMutations_AdmitAdminDashboardIdentity()
+    {
+        var property = await CreatePropertyAsync();
+        var sut = CreateSut();
+
+        var created = await sut.CreateAreas(0, property.Id, ["Lade"], isAdmin: true);
+        var renamed = await sut.RenameArea(0, created.Single().Id, "Stald", isAdmin: true);
+        await sut.DeleteArea(0, renamed.Id, isAdmin: true);
+
+        Assert.That(await BackendConfigurationPnDbContext!.AdhocAreas
+            .CountAsync(a => a.WorkflowState != Constants.WorkflowStates.Removed), Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task AreaMutations_DenyNonAdminWorkerZero_MatchingListAreas()
+    {
+        var property = await CreatePropertyAsync();
+        var area = new AdhocArea { PropertyId = property.Id, Name = "Lade" };
+        await area.Create(BackendConfigurationPnDbContext!);
+        var sut = CreateSut();
+
+        Assert.ThrowsAsync<AdhocTaskUnauthorizedException>(async () =>
+            await sut.CreateAreas(0, property.Id, ["Stald"]));
+        Assert.ThrowsAsync<AdhocTaskUnauthorizedException>(async () =>
+            await sut.RenameArea(0, area.Id, "Stald"));
+        Assert.ThrowsAsync<AdhocTaskUnauthorizedException>(async () =>
+            await sut.DeleteArea(0, area.Id));
+    }
+
+    [Test]
+    public async Task AreaMutations_AdmitRealWorkerWithPropertyAccess()
+    {
+        var property = await CreatePropertyAsync();
+        await GrantPropertyAccessAsync(property.Id, 7);
+        var sut = CreateSut();
+
+        var created = await sut.CreateAreas(7, property.Id, ["Lade"]);
+        var renamed = await sut.RenameArea(7, created.Single().Id, "Stald");
+        await sut.DeleteArea(7, renamed.Id);
+
+        Assert.That(await BackendConfigurationPnDbContext!.AdhocAreas
+            .CountAsync(a => a.WorkflowState != Constants.WorkflowStates.Removed), Is.EqualTo(0));
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceAreaCrudTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceAreaCrudTests.cs
@@ -313,12 +313,44 @@ public class AdhocServiceAreaCrudTests : TestBaseSetup
         await area.Create(BackendConfigurationPnDbContext!);
         var sut = CreateSut();
 
+        // CreateAreas already names the propertyId explicitly - nothing to
+        // enumerate - so it keeps the plain unauthorized signal.
         Assert.ThrowsAsync<AdhocTaskUnauthorizedException>(async () =>
             await sut.CreateAreas(0, property.Id, ["Stald"]));
-        Assert.ThrowsAsync<AdhocTaskUnauthorizedException>(async () =>
+
+        // RenameArea/DeleteArea are id-only mutations: enumeration hardening
+        // means access denial on a real-but-inaccessible area id surfaces as
+        // "not found", same as a genuinely unknown id (see
+        // AreaMutations_DeniedAccessAndMissingArea_AreIndistinguishable).
+        Assert.ThrowsAsync<AdhocAreaNotFoundException>(async () =>
             await sut.RenameArea(0, area.Id, "Stald"));
-        Assert.ThrowsAsync<AdhocTaskUnauthorizedException>(async () =>
+        Assert.ThrowsAsync<AdhocAreaNotFoundException>(async () =>
             await sut.DeleteArea(0, area.Id));
+    }
+
+    [Test]
+    public async Task AreaMutations_DeniedAccessAndMissingArea_AreIndistinguishable()
+    {
+        var property = await CreatePropertyAsync();
+        var area = new AdhocArea { PropertyId = property.Id, Name = "Lade" };
+        await area.Create(BackendConfigurationPnDbContext!);
+        var sut = CreateSut();
+
+        // Worker 0 has no access to `property`. Enumeration-hardening intent:
+        // a real area id it may not touch and a wholly nonexistent id must
+        // throw the exact same exception type, so the response can't be used
+        // to tell "exists but denied" apart from "doesn't exist".
+        var deniedRename = Assert.ThrowsAsync<AdhocAreaNotFoundException>(async () =>
+            await sut.RenameArea(0, area.Id, "Stald"));
+        var missingRename = Assert.ThrowsAsync<AdhocAreaNotFoundException>(async () =>
+            await sut.RenameArea(0, 999999, "Stald"));
+        Assert.That(deniedRename!.GetType(), Is.EqualTo(missingRename!.GetType()));
+
+        var deniedDelete = Assert.ThrowsAsync<AdhocAreaNotFoundException>(async () =>
+            await sut.DeleteArea(0, area.Id));
+        var missingDelete = Assert.ThrowsAsync<AdhocAreaNotFoundException>(async () =>
+            await sut.DeleteArea(0, 999999));
+        Assert.That(deniedDelete!.GetType(), Is.EqualTo(missingDelete!.GetType()));
     }
 
     [Test]

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/AdhocController.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/AdhocController.cs
@@ -212,6 +212,33 @@ public class AdhocController : Controller
             "ErrorWhileGettingAdhocAreas");
     }
 
+    [HttpPost]
+    [Route("areas")]
+    public async Task<OperationDataResult<List<AdhocAreaModel>>> CreateAreas([FromBody] AdhocAreaCreateModel model)
+    {
+        return await ExecuteAsync(
+            () => _adhocService.CreateAreas(DashboardWorkerId, model?.PropertyId ?? 0, model?.Names ?? [], IsAdmin),
+            "ErrorWhileCreatingAdhocAreas");
+    }
+
+    [HttpPut]
+    [Route("areas/{id:int}")]
+    public async Task<OperationDataResult<AdhocAreaModel>> RenameArea(int id, [FromBody] AdhocAreaRenameModel model)
+    {
+        return await ExecuteAsync(
+            () => _adhocService.RenameArea(DashboardWorkerId, id, model?.Name ?? string.Empty, IsAdmin),
+            "ErrorWhileUpdatingAdhocArea");
+    }
+
+    [HttpDelete]
+    [Route("areas/{id:int}")]
+    public async Task<OperationResult> DeleteArea(int id)
+    {
+        return await ExecuteAsync(
+            () => _adhocService.DeleteArea(DashboardWorkerId, id, IsAdmin),
+            "ErrorWhileDeletingAdhocArea");
+    }
+
     [HttpGet]
     [Route("workers")]
     public async Task<OperationDataResult<List<AdhocWorkerModel>>> ListWorkers(int propertyId)

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Adhoc/AdhocTaskModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Adhoc/AdhocTaskModel.cs
@@ -276,6 +276,19 @@ public class AdhocTagCreateModel
     public string Name { get; set; } = "";
 }
 
+/// <summary>Body for <c>POST areas</c> (area-management spec 2026-07-30) - batch create, one name per line in the dashboard modal.</summary>
+public class AdhocAreaCreateModel
+{
+    public int PropertyId { get; set; }
+    public List<string> Names { get; set; } = [];
+}
+
+/// <summary>Body for <c>PUT areas/{id}</c>.</summary>
+public class AdhocAreaRenameModel
+{
+    public string Name { get; set; } = "";
+}
+
 /// <summary>Body for <c>POST {id}/copy</c> (M5/P3) - mirrors the mockup's Kopier modal's Ja/Nej-med-kommentarer choice.</summary>
 public class AdhocCopyTaskModel
 {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/AdhocAreaNotFoundException.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/AdhocAreaNotFoundException.cs
@@ -1,0 +1,44 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2022 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BackendConfiguration.Pn.Services.BackendConfigurationAdhocService;
+
+using System;
+
+/// <summary>
+/// Thrown when a caller asks for an <c>AdhocArea</c> that does not exist or
+/// is soft-deleted (<c>WorkflowState == Removed</c>). Sibling of
+/// <see cref="AdhocTagNotFoundException"/>; both map to <c>NotFound</c> in
+/// the façades.
+/// </summary>
+public class AdhocAreaNotFoundException : Exception
+{
+    public int AreaId { get; }
+
+    public AdhocAreaNotFoundException(int areaId)
+        : base($"Adhoc area {areaId} was not found.")
+    {
+        AreaId = areaId;
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/BackendConfigurationAdhocService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/BackendConfigurationAdhocService.cs
@@ -703,6 +703,75 @@ public class BackendConfigurationAdhocService(
         await tag.Delete(dbContext);
     }
 
+    public async Task<List<AdhocAreaModel>> CreateAreas(int workerId, int propertyId, List<string> names, bool isAdmin = false)
+    {
+        await RequirePropertyAccessAsync(workerId, propertyId, isAdmin);
+
+        var propertyExists = await dbContext.Properties
+            .AnyAsync(p => p.Id == propertyId && p.WorkflowState != Constants.WorkflowStates.Removed);
+        if (!propertyExists)
+        {
+            throw new ArgumentException($"Property {propertyId} was not found.", nameof(propertyId));
+        }
+
+        var activeNames = await dbContext.AdhocAreas
+            .Where(a => a.PropertyId == propertyId && a.WorkflowState != Constants.WorkflowStates.Removed)
+            .Select(a => a.Name)
+            .ToListAsync();
+        // Case-insensitive skip set seeded with the property's active names;
+        // Add() returning false covers both in-batch and against-active
+        // duplicates (spec: silent skip, idempotent re-submit).
+        var seen = new HashSet<string>(activeNames, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var raw in names ?? [])
+        {
+            var trimmed = raw?.Trim() ?? "";
+            if (trimmed.Length == 0 || !seen.Add(trimmed))
+            {
+                continue;
+            }
+
+            var area = new AdhocArea { PropertyId = propertyId, Name = trimmed };
+            await area.Create(dbContext);
+        }
+
+        return await ListAreas(workerId, propertyId, isAdmin);
+    }
+
+    public async Task<AdhocAreaModel> RenameArea(int workerId, int areaId, string name, bool isAdmin = false)
+    {
+        var trimmedName = RequireNonEmptyAreaName(name);
+        var area = await LoadAreaOrThrowAsync(areaId);
+        await RequirePropertyAccessAsync(workerId, area.PropertyId, isAdmin);
+
+        var duplicate = await dbContext.AdhocAreas
+            .AnyAsync(a => a.Id != areaId
+                           && a.PropertyId == area.PropertyId
+                           && a.WorkflowState != Constants.WorkflowStates.Removed
+                           && a.Name.ToLower() == trimmedName.ToLower());
+        if (duplicate)
+        {
+            throw new ArgumentException(
+                $"An area named '{trimmedName}' already exists on this property.", nameof(name));
+        }
+
+        area.Name = trimmedName;
+        await area.Update(dbContext);
+
+        return new AdhocAreaModel { Id = area.Id, PropertyId = area.PropertyId, Name = area.Name };
+    }
+
+    public async Task DeleteArea(int workerId, int areaId, bool isAdmin = false)
+    {
+        var area = await LoadAreaOrThrowAsync(areaId);
+        await RequirePropertyAccessAsync(workerId, area.PropertyId, isAdmin);
+
+        // Soft-delete only (spec decision 2): tasks keep their AreaId so
+        // history is preserved; ListAreas already filters != Removed, so
+        // pickers self-clean. No join rows exist for areas (unlike tags).
+        await area.Delete(dbContext);
+    }
+
     private async Task RequirePropertyAccessAsync(int workerId, int propertyId, bool isAdmin)
     {
         if (isAdmin)
@@ -726,6 +795,29 @@ public class BackendConfigurationAdhocService(
         }
 
         return trimmed;
+    }
+
+    private static string RequireNonEmptyAreaName(string name)
+    {
+        var trimmed = name?.Trim() ?? "";
+        if (trimmed.Length == 0)
+        {
+            throw new ArgumentException("Area name must not be empty.", nameof(name));
+        }
+
+        return trimmed;
+    }
+
+    private async Task<AdhocArea> LoadAreaOrThrowAsync(int areaId)
+    {
+        var area = await dbContext.AdhocAreas
+            .FirstOrDefaultAsync(a => a.Id == areaId && a.WorkflowState != Constants.WorkflowStates.Removed);
+        if (area == null)
+        {
+            throw new AdhocAreaNotFoundException(areaId);
+        }
+
+        return area;
     }
 
     /// <summary>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/BackendConfigurationAdhocService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/BackendConfigurationAdhocService.cs
@@ -742,7 +742,7 @@ public class BackendConfigurationAdhocService(
     {
         var trimmedName = RequireNonEmptyAreaName(name);
         var area = await LoadAreaOrThrowAsync(areaId);
-        await RequirePropertyAccessAsync(workerId, area.PropertyId, isAdmin);
+        await RequirePropertyAccessForAreaOrThrowNotFoundAsync(workerId, area, isAdmin);
 
         var duplicate = await dbContext.AdhocAreas
             .AnyAsync(a => a.Id != areaId
@@ -764,7 +764,7 @@ public class BackendConfigurationAdhocService(
     public async Task DeleteArea(int workerId, int areaId, bool isAdmin = false)
     {
         var area = await LoadAreaOrThrowAsync(areaId);
-        await RequirePropertyAccessAsync(workerId, area.PropertyId, isAdmin);
+        await RequirePropertyAccessForAreaOrThrowNotFoundAsync(workerId, area, isAdmin);
 
         // Soft-delete only (spec decision 2): tasks keep their AreaId so
         // history is preserved; ListAreas already filters != Removed, so
@@ -783,6 +783,28 @@ public class BackendConfigurationAdhocService(
         {
             throw new AdhocTaskUnauthorizedException(
                 $"Worker {workerId} has no access to property {propertyId}.");
+        }
+    }
+
+    /// <summary>
+    /// Enumeration hardening for the id-only area mutations (RenameArea/
+    /// DeleteArea): a caller who fails the property-access check for an area
+    /// they already loaded must see the same "not found" error as a caller
+    /// who named a nonexistent area id - otherwise AdhocTaskUnauthorizedException
+    /// vs AdhocAreaNotFoundException lets an attacker distinguish "exists but
+    /// denied" from "doesn't exist" and enumerate area ids across properties.
+    /// CreateAreas is unaffected - the caller already names the propertyId
+    /// explicitly, so there is nothing to enumerate.
+    /// </summary>
+    private async Task RequirePropertyAccessForAreaOrThrowNotFoundAsync(int workerId, AdhocArea area, bool isAdmin)
+    {
+        try
+        {
+            await RequirePropertyAccessAsync(workerId, area.PropertyId, isAdmin);
+        }
+        catch (AdhocTaskUnauthorizedException)
+        {
+            throw new AdhocAreaNotFoundException(area.Id);
         }
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/IBackendConfigurationAdhocService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/IBackendConfigurationAdhocService.cs
@@ -129,13 +129,44 @@ public interface IBackendConfigurationAdhocService
     Task<List<AdhocPropertyModel>> ListProperties(int workerId, bool isAdmin = false);
 
     /// <summary>
-    /// Areas belonging to <paramref name="propertyId"/>. Areas are
-    /// admin-managed - there is no <c>CreateArea</c> here, mobile only lists.
+    /// Areas belonging to <paramref name="propertyId"/>. Mobile only lists;
+    /// dashboard mutations live in <c>CreateAreas</c>/<c>RenameArea</c>/<c>DeleteArea</c>
+    /// below (area-management spec 2026-07-30).
     /// Throws <see cref="AdhocTaskUnauthorizedException"/> if the caller has
     /// no access to <paramref name="propertyId"/> and <paramref name="isAdmin"/>
     /// is false.
     /// </summary>
     Task<List<AdhocAreaModel>> ListAreas(int workerId, int propertyId, bool isAdmin = false);
+
+    /// <summary>
+    /// Batch-creates areas on <paramref name="propertyId"/>: trims each
+    /// name, drops empties, and silently skips case-insensitive duplicates
+    /// (both within the batch and against the property's active areas), so
+    /// re-submitting a list is idempotent. Returns the refreshed active
+    /// list. Access mirrors <see cref="ListAreas"/>
+    /// (<c>RequirePropertyAccessAsync</c>): admins pass; non-admins need a
+    /// <c>PropertyWorker</c> row. Throws <see cref="ArgumentException"/> for
+    /// an unknown property.
+    /// </summary>
+    Task<List<AdhocAreaModel>> CreateAreas(int workerId, int propertyId, List<string> names, bool isAdmin = false);
+
+    /// <summary>
+    /// Renames an active area. Trims; throws <see cref="ArgumentException"/>
+    /// on empty or case-insensitively duplicate names (within the area's
+    /// property), <see cref="AdhocAreaNotFoundException"/> for unknown or
+    /// removed ids. Access mirrors <see cref="ListAreas"/> on the area's
+    /// property.
+    /// </summary>
+    Task<AdhocAreaModel> RenameArea(int workerId, int areaId, string name, bool isAdmin = false);
+
+    /// <summary>
+    /// Soft-deletes an area (<c>WorkflowState = Removed</c>). Referencing
+    /// tasks keep their <c>AreaId</c> - history is preserved (spec decision
+    /// 2). Throws <see cref="AdhocAreaNotFoundException"/> for unknown or
+    /// already-removed ids. Access mirrors <see cref="ListAreas"/> on the
+    /// area's property.
+    /// </summary>
+    Task DeleteArea(int workerId, int areaId, bool isAdmin = false);
 
     /// <summary>
     /// Workers with access to <paramref name="propertyId"/> (via

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
@@ -149,6 +149,45 @@ export class BackendConfigurationAdhocPage {
     await selectValueInNgSelector(this.page, '#toolbar-omraade', areaName);
   }
 
+  async openAreaCreateModal(): Promise<void> {
+    await this.page.locator('#adhocToolbarAreaCreateBtn').click();
+    await this.page.locator('#adhocAreaCreateTextarea').waitFor({state: 'visible'});
+  }
+
+  async createAreas(names: string[]): Promise<void> {
+    await this.openAreaCreateModal();
+    await this.page.locator('#adhocAreaCreateTextarea').fill(names.join('\n'));
+    await this.page.locator('#adhocAreaCreateSaveBtn').click();
+    await this.page.locator('#adhocAreaCreateTextarea').waitFor({state: 'hidden'});
+  }
+
+  async openAreaAdminModal(): Promise<void> {
+    await this.page.locator('#adhocToolbarAreaManageBtn').click();
+    await this.page.locator('#adhocAreaAdminCloseBtn').waitFor({state: 'visible'});
+  }
+
+  async renameAreaInAdminModal(areaId: number, newName: string): Promise<void> {
+    await this.page.locator(`#adhocAreaRenameBtn-${areaId}`).click();
+    await this.page.locator(`#adhocAreaRenameInput-${areaId}`).fill(newName);
+    await this.page.locator(`#adhocAreaRenameSaveBtn-${areaId}`).click();
+  }
+
+  async deleteAreaInAdminModal(areaId: number): Promise<void> {
+    await this.page.locator(`#adhocAreaDeleteBtn-${areaId}`).click();
+    await this.page.locator('#adhocAreaDeleteConfirmBtn').click();
+  }
+
+  async closeAreaAdminModal(): Promise<void> {
+    await this.page.locator('#adhocAreaAdminCloseBtn').click();
+  }
+
+  /** Resolves the numeric area id from the admin modal row showing `areaName`. */
+  async areaIdInAdminModal(areaName: string): Promise<number> {
+    const row = this.page.locator('.area-row', {hasText: areaName});
+    const btnId = await row.locator('button[id^="adhocAreaRenameBtn-"]').getAttribute('id');
+    return Number(btnId!.replace('adhocAreaRenameBtn-', ''));
+  }
+
   /** `labelSubstring` matches the visible "<Label> (<count>)" option text - e.g. "Løste". */
   async selectStatusFilter(labelSubstring: string): Promise<void> {
     await selectValueInNgSelector(this.page, '#task-status-filter', labelSubstring);

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
@@ -203,14 +203,17 @@ export class BackendConfigurationAdhocPage {
    * `area.id` (component template - frozen), so the id is read straight off
    * this row's own button `id` attribute immediately before clicking it,
    * rather than trusting a value resolved earlier in the test and
-   * re-interpolated into a fresh locator afterwards. That earlier
-   * resolve-then-reuse pattern is how a CI run once got stuck 120s waiting
-   * on `#adhocAreaRenameInput-2` that never appeared: once the click swaps
-   * the row's `<span class="area-name">` for the input, `hasText:
-   * areaName` (an ngModel VALUE, not text content) no longer matches
-   * that row at all, so this resolves the id ONCE, up front, while the
-   * name is still plain text, and never re-queries `.area-row` by name
-   * after that point.
+   * re-interpolated into a fresh locator afterwards. The id is resolved
+   * ONCE, up front, while the name is still plain text, because once the
+   * click swaps the row's `<span class="area-name">` for the input,
+   * `hasText: areaName` (an ngModel VALUE, not text content) no longer
+   * matches that row.
+   *
+   * History: the CI runs that got stuck waiting on `#adhocAreaRenameInput-2`
+   * were ultimately caused by the component template binding `[attr.id]` on
+   * the matInput - MatInput's own host binding (`'[id]': 'id'`, defaulting
+   * to `mat-input-N`) overwrote it, so the id never existed in the DOM. The
+   * template now binds `[id]` (MatInput's @Input) instead.
    */
   async renameAreaInAdminModal(areaName: string, newName: string): Promise<void> {
     const renameBtn = this.areaRowInAdminModal(areaName).locator('button[id^="adhocAreaRenameBtn-"]');

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
@@ -190,26 +190,53 @@ export class BackendConfigurationAdhocPage {
     await this.page.locator('#adhocAreaAdminCloseBtn').waitFor({state: 'visible'});
   }
 
-  async renameAreaInAdminModal(areaId: number, newName: string): Promise<void> {
-    await this.page.locator(`#adhocAreaRenameBtn-${areaId}`).click();
-    await this.page.locator(`#adhocAreaRenameInput-${areaId}`).fill(newName);
+  /** The admin-modal `.area-row` currently displaying `areaName`. */
+  private areaRowInAdminModal(areaName: string): Locator {
+    return this.page.locator('.area-row', {hasText: areaName});
+  }
+
+  /**
+   * Renames the area currently shown as `areaName` to `newName`.
+   *
+   * The row's rename button and its `adhocAreaRenameInput-{id}`/
+   * `adhocAreaRenameSaveBtn-{id}` counterparts all key off the SAME
+   * `area.id` (component template - frozen), so the id is read straight off
+   * this row's own button `id` attribute immediately before clicking it,
+   * rather than trusting a value resolved earlier in the test and
+   * re-interpolated into a fresh locator afterwards. That earlier
+   * resolve-then-reuse pattern is how a CI run once got stuck 120s waiting
+   * on `#adhocAreaRenameInput-2` that never appeared: once the click swaps
+   * the row's `<span class="area-name">` for the input, `hasText:
+   * areaName` (an ngModel VALUE, not text content) no longer matches
+   * that row at all, so this resolves the id ONCE, up front, while the
+   * name is still plain text, and never re-queries `.area-row` by name
+   * after that point.
+   */
+  async renameAreaInAdminModal(areaName: string, newName: string): Promise<void> {
+    const renameBtn = this.areaRowInAdminModal(areaName).locator('button[id^="adhocAreaRenameBtn-"]');
+    const btnId = await renameBtn.getAttribute('id');
+    const areaId = btnId!.replace('adhocAreaRenameBtn-', '');
+    await renameBtn.click();
+    const input = this.page.locator(`#adhocAreaRenameInput-${areaId}`);
+    await input.waitFor({state: 'visible', timeout: 15000});
+    await input.fill(newName);
     await this.page.locator(`#adhocAreaRenameSaveBtn-${areaId}`).click();
   }
 
-  async deleteAreaInAdminModal(areaId: number): Promise<void> {
-    await this.page.locator(`#adhocAreaDeleteBtn-${areaId}`).click();
+  /**
+   * Deletes the area currently shown as `areaName`. Unlike rename, delete
+   * never needs the row's numeric id at all - `adhocAreaDeleteBtn-{id}` is
+   * clicked directly off this row (scoped by the row locator, not
+   * reconstructed from a separately-resolved id), and the confirm button is
+   * a single global id shared by whichever area is pending deletion.
+   */
+  async deleteAreaInAdminModal(areaName: string): Promise<void> {
+    await this.areaRowInAdminModal(areaName).locator('button[id^="adhocAreaDeleteBtn-"]').click();
     await this.page.locator('#adhocAreaDeleteConfirmBtn').click();
   }
 
   async closeAreaAdminModal(): Promise<void> {
     await this.page.locator('#adhocAreaAdminCloseBtn').click();
-  }
-
-  /** Resolves the numeric area id from the admin modal row showing `areaName`. */
-  async areaIdInAdminModal(areaName: string): Promise<number> {
-    const row = this.page.locator('.area-row', {hasText: areaName});
-    const btnId = await row.locator('button[id^="adhocAreaRenameBtn-"]').getAttribute('id');
-    return Number(btnId!.replace('adhocAreaRenameBtn-', ''));
   }
 
   /** `labelSubstring` matches the visible "<Label> (<count>)" option text - e.g. "Løste". */

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
@@ -149,6 +149,30 @@ export class BackendConfigurationAdhocPage {
     await selectValueInNgSelector(this.page, '#toolbar-omraade', areaName);
   }
 
+  /**
+   * Opens the toolbar area filter (`#toolbar-omraade`, an `mtx-select` -
+   * itself a thin wrapper around `@ng-select/ng-select`'s `NgSelectComponent`,
+   * per `MtxSelect`'s template in `@ng-matero/extensions/fesm2022/mtxSelect.mjs`),
+   * scrapes the visible option labels straight from the real ng-select
+   * dropdown markup (`ng-dropdown-panel` > `.ng-option` - verified against
+   * `@ng-select/ng-select/fesm2022/*.mjs`, and the same tokens sibling specs
+   * already assert against, e.g. `k/time-registration-dashboard-visibility.spec.ts`'s
+   * `getAvailableSiteNames()` and `y/task-list-modal-validation.spec.ts`), then
+   * closes it with Escape (that same sibling helper's close idiom) - leaving
+   * the current selection untouched, so callers don't need a `''` "clear"
+   * step that has no precedent elsewhere in this suite.
+   */
+  async areaFilterOptions(): Promise<string[]> {
+    const filterSelect = this.page.locator('#toolbar-omraade');
+    await filterSelect.click();
+    const dropdownPanel = this.page.locator('ng-dropdown-panel');
+    await dropdownPanel.waitFor({ state: 'visible', timeout: 10000 });
+    const names = await dropdownPanel.locator('.ng-option').allInnerTexts();
+    await this.page.keyboard.press('Escape');
+    await dropdownPanel.waitFor({ state: 'hidden', timeout: 5000 });
+    return names.map((n) => n.trim());
+  }
+
   async openAreaCreateModal(): Promise<void> {
     await this.page.locator('#adhocToolbarAreaCreateBtn').click();
     await this.page.locator('#adhocAreaCreateTextarea').waitFor({state: 'visible'});

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-area-management.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-area-management.spec.ts
@@ -145,10 +145,11 @@ test.describe.serial('Adhoc area management — create, filter, rename, delete',
 
     // Verify the filter's real option list (ng-select's `ng-dropdown-panel`
     // > `.ng-option`, scraped by areaFilterOptions()) has the renamed area
-    // and no longer the old name.
-    const filterOptions = await adhocPage.areaFilterOptions();
-    expect(filterOptions).toContain(newName);
-    expect(filterOptions).not.toContain(areaNames[1]);
+    // and no longer the old name. The reload after the modal closes is
+    // async (afterClosed -> loadAreas -> HTTP -> cache -> component), so
+    // poll rather than scrape once.
+    await expect.poll(() => adhocPage.areaFilterOptions(), { timeout: 30_000 }).toContain(newName);
+    await expect.poll(() => adhocPage.areaFilterOptions(), { timeout: 30_000 }).not.toContain(areaNames[1]);
   });
 
   test('delete area and verify gone from filter', async ({ page }) => {
@@ -175,9 +176,10 @@ test.describe.serial('Adhoc area management — create, filter, rename, delete',
     await adhocPage.closeAreaAdminModal();
 
     // Verify the deleted name is gone from the filter's real option list
-    // while the other areas (Lade) remain.
-    const filterOptions = await adhocPage.areaFilterOptions();
-    expect(filterOptions).not.toContain(newName);
-    expect(filterOptions).toContain(areaNames[0]);
+    // while the other areas (Lade) remain. The reload after the modal
+    // closes is async (afterClosed -> loadAreas -> HTTP -> cache ->
+    // component), so poll rather than scrape once.
+    await expect.poll(() => adhocPage.areaFilterOptions(), { timeout: 30_000 }).not.toContain(newName);
+    await expect.poll(() => adhocPage.areaFilterOptions(), { timeout: 30_000 }).toContain(areaNames[0]);
   });
 });

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-area-management.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-area-management.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../../Page objects/Login.page';
+import { generateRandmString } from '../../../helper-functions';
+import { BackendConfigurationPropertiesPage } from '../BackendConfigurationProperties.page';
+import { BackendConfigurationAdhocPage } from '../BackendConfigurationAdhoc.page';
+
+/**
+ * Adhoc area management — create/filter/rename/delete flow (Task 5).
+ *
+ * Shard z runs without the shard-a DB dump, so it starts from a fresh
+ * database and seeds its own data via the UI: one property, then creates
+ * areas via the toolbar buttons, verifies they appear in filters and drawer,
+ * renames one, deletes one, and confirms all state changes persist across
+ * modals and filters.
+ *
+ * Runs as `admin@admin.com` throughout (`LoginPage.login()` default).
+ */
+const BASE_URL = 'http://localhost:4200';
+const rand = generateRandmString(8).toLowerCase();
+
+const property = {
+  name: `adhoc-am-prop-${rand}`,
+  chrNumber: generateRandmString(5),
+  address: generateRandmString(5),
+  cvrNumber: '1234567',
+};
+
+const areaNames = [`Lade-${rand}`, `Stald-${rand}`];
+
+async function login(page: import('@playwright/test').Page): Promise<void> {
+  await page.goto(BASE_URL);
+  await new LoginPage(page).login();
+}
+
+test.describe.serial('Adhoc area management — create, filter, rename, delete', () => {
+  test('enable area buttons after property selection', async ({ page }) => {
+    test.setTimeout(180000);
+    await login(page);
+
+    // Create one property and navigate to adhoc dashboard
+    const propertiesPage = new BackendConfigurationPropertiesPage(page);
+    await propertiesPage.goToProperties();
+    await propertiesPage.createProperty(property);
+
+    const adhocPage = new BackendConfigurationAdhocPage(page);
+    await adhocPage.goToAdhoc();
+
+    // Before property selection, area buttons should be disabled
+    const createBtn = adhocPage.page.locator('#adhocToolbarAreaCreateBtn');
+    const manageBtn = adhocPage.page.locator('#adhocToolbarAreaManageBtn');
+    await expect(createBtn).toHaveAttribute('disabled', '');
+    await expect(manageBtn).toHaveAttribute('disabled', '');
+
+    // Select the property in the filter
+    await adhocPage.selectPropertyFilter(property.name);
+
+    // After property selection, both buttons should be enabled
+    await expect(createBtn).not.toHaveAttribute('disabled', '');
+    await expect(manageBtn).not.toHaveAttribute('disabled', '');
+  });
+
+  test('create two areas and verify in filter and drawer', async ({ page }) => {
+    test.setTimeout(180000);
+    await login(page);
+    const adhocPage = new BackendConfigurationAdhocPage(page);
+    await adhocPage.goToAdhoc();
+    await adhocPage.selectPropertyFilter(property.name);
+
+    // Create two areas via the modal
+    await adhocPage.createAreas(areaNames);
+
+    // Verify both areas appear in the toolbar area filter
+    // (selectAreaFilter uses selectValueInNgSelector which opens the dropdown and verifies the option exists)
+    for (const areaName of areaNames) {
+      await adhocPage.selectAreaFilter(areaName);
+    }
+
+    // Verify both areas appear in the task drawer's area dropdown
+    await adhocPage.openNewTask();
+    await adhocPage.selectDrawerProperty(property.name);
+
+    // Both area names should be selectable in the drawer's area dropdown
+    for (const areaName of areaNames) {
+      await adhocPage.selectDrawerArea(areaName);
+    }
+
+    await adhocPage.closeDrawer();
+  });
+
+  test('deduplicate when re-creating with duplicate + new name', async ({ page }) => {
+    test.setTimeout(180000);
+    await login(page);
+    const adhocPage = new BackendConfigurationAdhocPage(page);
+    await adhocPage.goToAdhoc();
+    await adhocPage.selectPropertyFilter(property.name);
+
+    // Open create modal and add one duplicate (first area name) + one new name
+    const newAreaName = `Garage-${rand}`;
+    const mixedNames = [areaNames[0], newAreaName]; // Lade (duplicate) + Garage (new)
+    await adhocPage.openAreaCreateModal();
+    await adhocPage.page.locator('#adhocAreaCreateTextarea').fill(mixedNames.join('\n'));
+    await adhocPage.page.locator('#adhocAreaCreateSaveBtn').click();
+    await adhocPage.page.locator('#adhocAreaCreateTextarea').waitFor({state: 'hidden'});
+
+    // Open admin modal and verify exactly three areas (dedupe held)
+    await adhocPage.openAreaAdminModal();
+
+    const areaRows = adhocPage.page.locator('.area-row');
+    await expect(areaRows).toHaveCount(3);
+
+    // Verify all three expected area names are present
+    const row1 = adhocPage.page.locator('.area-row', {hasText: areaNames[0]});
+    const row2 = adhocPage.page.locator('.area-row', {hasText: areaNames[1]});
+    const row3 = adhocPage.page.locator('.area-row', {hasText: newAreaName});
+
+    await expect(row1).toBeVisible();
+    await expect(row2).toBeVisible();
+    await expect(row3).toBeVisible();
+
+    await adhocPage.closeAreaAdminModal();
+  });
+
+  test('rename area and verify in filter', async ({ page }) => {
+    test.setTimeout(180000);
+    await login(page);
+    const adhocPage = new BackendConfigurationAdhocPage(page);
+    await adhocPage.goToAdhoc();
+    await adhocPage.selectPropertyFilter(property.name);
+
+    // Open admin modal and rename Stald -> Maskinhal
+    const newName = `Maskinhal-${rand}`;
+    await adhocPage.openAreaAdminModal();
+
+    // Find the area id for "Stald-{rand}"
+    const staldId = await adhocPage.areaIdInAdminModal(areaNames[1]);
+
+    // Rename it
+    await adhocPage.renameAreaInAdminModal(staldId, newName);
+
+    // Verify the row updates (the old name should disappear, new name appears)
+    const oldRow = adhocPage.page.locator('.area-row', {hasText: areaNames[1]});
+    const newRow = adhocPage.page.locator('.area-row', {hasText: newName});
+
+    await expect(oldRow).toHaveCount(0);
+    await expect(newRow).toBeVisible();
+
+    await adhocPage.closeAreaAdminModal();
+
+    // Verify the new name appears in the filter
+    await adhocPage.selectAreaFilter(newName);
+
+    // Verify the old name is no longer in the filter
+    await adhocPage.selectAreaFilter('');
+    const filterDropdown = adhocPage.page.locator('#toolbar-omraade');
+    await filterDropdown.click();
+    const oldOption = adhocPage.page.locator('mtx-option-panel').locator('text=' + areaNames[1]);
+    await expect(oldOption).toHaveCount(0);
+  });
+
+  test('delete area and verify gone from filter', async ({ page }) => {
+    test.setTimeout(180000);
+    await login(page);
+    const adhocPage = new BackendConfigurationAdhocPage(page);
+    await adhocPage.goToAdhoc();
+    await adhocPage.selectPropertyFilter(property.name);
+
+    // Open admin modal and delete the renamed area (Maskinhal)
+    const newName = `Maskinhal-${rand}`;
+    await adhocPage.openAreaAdminModal();
+
+    const maskinhalId = await adhocPage.areaIdInAdminModal(newName);
+    await adhocPage.deleteAreaInAdminModal(maskinhalId);
+
+    // Verify its row disappears
+    const deletedRow = adhocPage.page.locator('.area-row', {hasText: newName});
+    await expect(deletedRow).toHaveCount(0);
+
+    // Remaining row count should be 2 (Lade, Garage)
+    const areaRows = adhocPage.page.locator('.area-row');
+    await expect(areaRows).toHaveCount(2);
+
+    await adhocPage.closeAreaAdminModal();
+
+    // Verify the deleted name is gone from the filter options
+    // while the other areas remain
+    await adhocPage.selectAreaFilter('');
+    const filterDropdown = adhocPage.page.locator('#toolbar-omraade');
+    await filterDropdown.click();
+    const deletedOption = adhocPage.page.locator('mtx-option-panel').locator('text=' + newName);
+    await expect(deletedOption).toHaveCount(0);
+
+    // Verify one of the remaining areas (Lade) is still in the filter
+    const remainingOption = adhocPage.page.locator('mtx-option-panel').locator('text=' + areaNames[0]);
+    await expect(remainingOption).toBeVisible();
+  });
+});

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-area-management.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-area-management.spec.ts
@@ -60,7 +60,7 @@ test.describe.serial('Adhoc area management — create, filter, rename, delete',
   });
 
   test('create two areas and verify in filter and drawer', async ({ page }) => {
-    test.setTimeout(180000);
+    test.setTimeout(120000);
     await login(page);
     const adhocPage = new BackendConfigurationAdhocPage(page);
     await adhocPage.goToAdhoc();
@@ -88,19 +88,16 @@ test.describe.serial('Adhoc area management — create, filter, rename, delete',
   });
 
   test('deduplicate when re-creating with duplicate + new name', async ({ page }) => {
-    test.setTimeout(180000);
+    test.setTimeout(120000);
     await login(page);
     const adhocPage = new BackendConfigurationAdhocPage(page);
     await adhocPage.goToAdhoc();
     await adhocPage.selectPropertyFilter(property.name);
 
-    // Open create modal and add one duplicate (first area name) + one new name
+    // Re-create with one duplicate (first area name) + one new name
     const newAreaName = `Garage-${rand}`;
     const mixedNames = [areaNames[0], newAreaName]; // Lade (duplicate) + Garage (new)
-    await adhocPage.openAreaCreateModal();
-    await adhocPage.page.locator('#adhocAreaCreateTextarea').fill(mixedNames.join('\n'));
-    await adhocPage.page.locator('#adhocAreaCreateSaveBtn').click();
-    await adhocPage.page.locator('#adhocAreaCreateTextarea').waitFor({state: 'hidden'});
+    await adhocPage.createAreas(mixedNames);
 
     // Open admin modal and verify exactly three areas (dedupe held)
     await adhocPage.openAreaAdminModal();
@@ -121,7 +118,7 @@ test.describe.serial('Adhoc area management — create, filter, rename, delete',
   });
 
   test('rename area and verify in filter', async ({ page }) => {
-    test.setTimeout(180000);
+    test.setTimeout(120000);
     await login(page);
     const adhocPage = new BackendConfigurationAdhocPage(page);
     await adhocPage.goToAdhoc();
@@ -149,16 +146,16 @@ test.describe.serial('Adhoc area management — create, filter, rename, delete',
     // Verify the new name appears in the filter
     await adhocPage.selectAreaFilter(newName);
 
-    // Verify the old name is no longer in the filter
-    await adhocPage.selectAreaFilter('');
-    const filterDropdown = adhocPage.page.locator('#toolbar-omraade');
-    await filterDropdown.click();
-    const oldOption = adhocPage.page.locator('mtx-option-panel').locator('text=' + areaNames[1]);
-    await expect(oldOption).toHaveCount(0);
+    // Verify the filter's real option list (ng-select's `ng-dropdown-panel`
+    // > `.ng-option`, scraped by areaFilterOptions()) has the renamed area
+    // and no longer the old name.
+    const filterOptions = await adhocPage.areaFilterOptions();
+    expect(filterOptions).toContain(newName);
+    expect(filterOptions).not.toContain(areaNames[1]);
   });
 
   test('delete area and verify gone from filter', async ({ page }) => {
-    test.setTimeout(180000);
+    test.setTimeout(120000);
     await login(page);
     const adhocPage = new BackendConfigurationAdhocPage(page);
     await adhocPage.goToAdhoc();
@@ -181,16 +178,10 @@ test.describe.serial('Adhoc area management — create, filter, rename, delete',
 
     await adhocPage.closeAreaAdminModal();
 
-    // Verify the deleted name is gone from the filter options
-    // while the other areas remain
-    await adhocPage.selectAreaFilter('');
-    const filterDropdown = adhocPage.page.locator('#toolbar-omraade');
-    await filterDropdown.click();
-    const deletedOption = adhocPage.page.locator('mtx-option-panel').locator('text=' + newName);
-    await expect(deletedOption).toHaveCount(0);
-
-    // Verify one of the remaining areas (Lade) is still in the filter
-    const remainingOption = adhocPage.page.locator('mtx-option-panel').locator('text=' + areaNames[0]);
-    await expect(remainingOption).toBeVisible();
+    // Verify the deleted name is gone from the filter's real option list
+    // while the other areas (Lade) remain.
+    const filterOptions = await adhocPage.areaFilterOptions();
+    expect(filterOptions).not.toContain(newName);
+    expect(filterOptions).toContain(areaNames[0]);
   });
 });

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-area-management.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-area-management.spec.ts
@@ -128,11 +128,8 @@ test.describe.serial('Adhoc area management — create, filter, rename, delete',
     const newName = `Maskinhal-${rand}`;
     await adhocPage.openAreaAdminModal();
 
-    // Find the area id for "Stald-{rand}"
-    const staldId = await adhocPage.areaIdInAdminModal(areaNames[1]);
-
-    // Rename it
-    await adhocPage.renameAreaInAdminModal(staldId, newName);
+    // Rename it (resolves the area id from its own row, keyed by name)
+    await adhocPage.renameAreaInAdminModal(areaNames[1], newName);
 
     // Verify the row updates (the old name should disappear, new name appears)
     const oldRow = adhocPage.page.locator('.area-row', {hasText: areaNames[1]});
@@ -165,8 +162,7 @@ test.describe.serial('Adhoc area management — create, filter, rename, delete',
     const newName = `Maskinhal-${rand}`;
     await adhocPage.openAreaAdminModal();
 
-    const maskinhalId = await adhocPage.areaIdInAdminModal(newName);
-    await adhocPage.deleteAreaInAdminModal(maskinhalId);
+    await adhocPage.deleteAreaInAdminModal(newName);
 
     // Verify its row disappears
     const deletedRow = adhocPage.page.locator('.area-row', {hasText: newName});

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-area-management.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-area-management.spec.ts
@@ -48,15 +48,15 @@ test.describe.serial('Adhoc area management — create, filter, rename, delete',
     // Before property selection, area buttons should be disabled
     const createBtn = adhocPage.page.locator('#adhocToolbarAreaCreateBtn');
     const manageBtn = adhocPage.page.locator('#adhocToolbarAreaManageBtn');
-    await expect(createBtn).toHaveAttribute('disabled', '');
-    await expect(manageBtn).toHaveAttribute('disabled', '');
+    await expect(createBtn).toBeDisabled();
+    await expect(manageBtn).toBeDisabled();
 
     // Select the property in the filter
     await adhocPage.selectPropertyFilter(property.name);
 
     // After property selection, both buttons should be enabled
-    await expect(createBtn).not.toHaveAttribute('disabled', '');
-    await expect(manageBtn).not.toHaveAttribute('disabled', '');
+    await expect(createBtn).toBeEnabled();
+    await expect(manageBtn).toBeEnabled();
   });
 
   test('create two areas and verify in filter and drawer', async ({ page }) => {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -634,4 +634,16 @@ export const da = {
   completed: 'Udført',
   archived: 'Arkiveret',
   commented: 'Kommenteret',
+  // Adhoc dashboard (area management) - toolbar area create/admin.
+  Add: 'Tilføj',
+  'Area name is empty or already exists': 'Områdenavnet er tomt eller findes allerede',
+  'Create areas': 'Opret områder',
+  'Create one or more areas on the selected property (one name per line)': 'Opret ét eller flere områder på den valgte ejendom (ét navn pr. linje)',
+  'Delete area': 'Slet område',
+  'Edit or delete areas for the selected property': 'Rediger eller slet områder for den valgte ejendom',
+  'Existing tasks keep their history': 'Eksisterende opgaver beholder deres historik',
+  'Manage areas': 'Administrer områder',
+  'No areas on this property yet': 'Der er endnu ingen områder på denne ejendom',
+  'One area name per line': 'Ét områdenavn pr. linje',
+  'Rename area': 'Omdøb område',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -642,6 +642,8 @@ export const da = {
   'Delete area': 'Slet område',
   'Edit or delete areas for the selected property': 'Rediger eller slet områder for den valgte ejendom',
   'Existing tasks keep their history': 'Eksisterende opgaver beholder deres historik',
+  'Failed to create areas': 'Kunne ikke oprette områder',
+  'Failed to delete area': 'Kunne ikke slette området',
   'Manage areas': 'Administrer områder',
   'No areas on this property yet': 'Der er endnu ingen områder på denne ejendom',
   'One area name per line': 'Ét områdenavn pr. linje',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -659,6 +659,8 @@ export const enUS= {
   'Delete area': 'Delete area',
   'Edit or delete areas for the selected property': 'Edit or delete areas for the selected property',
   'Existing tasks keep their history': 'Existing tasks keep their history',
+  'Failed to create areas': 'Failed to create areas',
+  'Failed to delete area': 'Failed to delete area',
   'Manage areas': 'Manage areas',
   'No areas on this property yet': 'No areas on this property yet',
   'One area name per line': 'One area name per line',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -651,4 +651,16 @@ export const enUS= {
   completed: 'Completed',
   archived: 'Archived',
   commented: 'Commented',
+  // Adhoc dashboard (area management) - toolbar area create/admin.
+  Add: 'Add',
+  'Area name is empty or already exists': 'Area name is empty or already exists',
+  'Create areas': 'Create areas',
+  'Create one or more areas on the selected property (one name per line)': 'Create one or more areas on the selected property (one name per line)',
+  'Delete area': 'Delete area',
+  'Edit or delete areas for the selected property': 'Edit or delete areas for the selected property',
+  'Existing tasks keep their history': 'Existing tasks keep their history',
+  'Manage areas': 'Manage areas',
+  'No areas on this property yet': 'No areas on this property yet',
+  'One area name per line': 'One area name per line',
+  'Rename area': 'Rename area',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/models/adhoc/adhoc-area.model.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/models/adhoc/adhoc-area.model.ts
@@ -4,3 +4,14 @@ export interface AdhocAreaModel {
   propertyId: number;
   name: string;
 }
+
+/** Mirrors C# `AdhocAreaCreateModel` (`POST areas`). */
+export interface AdhocAreaCreateModel {
+  propertyId: number;
+  names: string[];
+}
+
+/** Mirrors C# `AdhocAreaRenameModel` (`PUT areas/{id}`). */
+export interface AdhocAreaRenameModel {
+  name: string;
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/adhoc.module.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/adhoc.module.ts
@@ -19,6 +19,8 @@ import {MatChip} from '@angular/material/chips';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {AdhocRouting} from './adhoc.routing';
 import {
+  AdhocAreaAdminModalComponent,
+  AdhocAreaCreateModalComponent,
   AdhocCompleteModalComponent,
   AdhocContainerComponent,
   AdhocCopyModalComponent,
@@ -44,6 +46,8 @@ import {
     AdhocCopyModalComponent,
     AdhocCompleteModalComponent,
     AdhocHistoryComponent,
+    AdhocAreaCreateModalComponent,
+    AdhocAreaAdminModalComponent,
   ],
   imports: [
     CommonModule,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.html
@@ -1,0 +1,47 @@
+<h2 mat-dialog-title>{{ 'Manage areas' | translate }}</h2>
+<mat-dialog-content>
+  <p>{{ 'Property' | translate }}: <strong>{{ data.propertyName }}</strong></p>
+
+  <ng-container *ngIf="confirmDeleteArea === null; else deleteConfirm">
+    <p *ngIf="areas.length === 0">{{ 'No areas on this property yet' | translate }}</p>
+    <p class="error" *ngIf="errorKey">{{ errorKey | translate }}</p>
+    <div class="area-row" *ngFor="let area of areas">
+      <ng-container *ngIf="editingId !== area.id; else renameRow">
+        <span class="area-name">{{ area.name }}</span>
+        <button mat-icon-button [attr.id]="'adhocAreaRenameBtn-' + area.id"
+                [matTooltip]="'Rename area' | translate" (click)="startRename(area)">
+          <mat-icon>edit</mat-icon>
+        </button>
+        <button mat-icon-button [attr.id]="'adhocAreaDeleteBtn-' + area.id"
+                [matTooltip]="'Delete area' | translate" (click)="askDelete(area)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </ng-container>
+      <ng-template #renameRow>
+        <mat-form-field class="rename-field">
+          <input matInput [attr.id]="'adhocAreaRenameInput-' + area.id" [(ngModel)]="editName">
+        </mat-form-field>
+        <button mat-icon-button [attr.id]="'adhocAreaRenameSaveBtn-' + area.id"
+                [disabled]="busy" (click)="saveRename(area)">
+          <mat-icon>check</mat-icon>
+        </button>
+      </ng-template>
+    </div>
+  </ng-container>
+
+  <ng-template #deleteConfirm>
+    <p>{{ 'Delete area' | translate }}: <strong>{{ confirmDeleteArea!.name }}</strong>?</p>
+    <p>{{ 'Existing tasks keep their history' | translate }}</p>
+  </ng-template>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <ng-container *ngIf="confirmDeleteArea === null; else deleteActions">
+    <button mat-button id="adhocAreaAdminCloseBtn" (click)="close()">{{ 'Close' | translate }}</button>
+  </ng-container>
+  <ng-template #deleteActions>
+    <button mat-button id="adhocAreaDeleteCancelBtn" (click)="cancelDelete()">{{ 'Cancel' | translate }}</button>
+    <button mat-raised-button color="warn" id="adhocAreaDeleteConfirmBtn" [disabled]="busy" (click)="confirmDelete()">
+      {{ 'Delete' | translate }}
+    </button>
+  </ng-template>
+</mat-dialog-actions>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.html
@@ -32,6 +32,7 @@
   <ng-template #deleteConfirm>
     <p>{{ 'Delete area' | translate }}: <strong>{{ confirmDeleteArea!.name }}</strong>?</p>
     <p>{{ 'Existing tasks keep their history' | translate }}</p>
+    <p class="error" *ngIf="errorKey">{{ errorKey | translate }}</p>
   </ng-template>
 </mat-dialog-content>
 <mat-dialog-actions align="end">

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.html
@@ -19,7 +19,10 @@
       </ng-container>
       <ng-template #renameRow>
         <mat-form-field class="rename-field">
-          <input matInput [attr.id]="'adhocAreaRenameInput-' + area.id" [(ngModel)]="editName">
+          <!-- MUST be [id] (MatInput's @Input), not [attr.id]: MatInput's host
+               binding '[id]': 'id' defaults to a generated mat-input-N and
+               overwrites attribute-bound ids, so [attr.id] never reaches the DOM. -->
+          <input matInput [id]="'adhocAreaRenameInput-' + area.id" [(ngModel)]="editName">
         </mat-form-field>
         <button mat-icon-button [attr.id]="'adhocAreaRenameSaveBtn-' + area.id"
                 [disabled]="busy" (click)="saveRename(area)">

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.scss
@@ -1,0 +1,18 @@
+.area-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  .area-name {
+    flex: 1;
+  }
+
+  .rename-field {
+    flex: 1;
+  }
+}
+
+.error {
+  color: #b3261e;
+  font-size: 12px;
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.spec.ts
@@ -1,0 +1,101 @@
+import {of} from 'rxjs';
+import {AdhocAreaAdminModalComponent} from './adhoc-area-admin-modal.component';
+
+describe('AdhocAreaAdminModalComponent', () => {
+  let dialogRefSpy: any;
+  let adhocStateServiceSpy: any;
+  let component: AdhocAreaAdminModalComponent;
+
+  const areas = [
+    {id: 10, propertyId: 1, name: 'Stald 1'},
+    {id: 11, propertyId: 1, name: 'Stald 2'},
+  ];
+
+  beforeEach(() => {
+    dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+    adhocStateServiceSpy = jasmine.createSpyObj('AdhocStateService', [
+      'getAreasForProperty',
+      'getCachedAreas',
+      'renameArea',
+      'deleteArea',
+    ]);
+    adhocStateServiceSpy.getAreasForProperty.and.returnValue(of(areas));
+    component = new AdhocAreaAdminModalComponent(dialogRefSpy, {propertyId: 1, propertyName: 'Gård Nord'}, adhocStateServiceSpy);
+  });
+
+  it('ngOnInit loads areas for the property (rows render from this list)', () => {
+    component.ngOnInit();
+    expect(adhocStateServiceSpy.getAreasForProperty).toHaveBeenCalledWith(1);
+    expect(component.areas).toEqual(areas);
+  });
+
+  it('startRename seeds editingId/editName and clears any error', () => {
+    component.errorKey = 'Area name is empty or already exists';
+    component.startRename(areas[0]);
+    expect(component.editingId).toBe(10);
+    expect(component.editName).toBe('Stald 1');
+    expect(component.errorKey).toBeNull();
+  });
+
+  it('saveRename calls renameArea and refreshes areas from the cache on success', () => {
+    const refreshed = [{id: 10, propertyId: 1, name: 'Stald renamed'}, areas[1]];
+    adhocStateServiceSpy.renameArea.and.returnValue(of(true));
+    adhocStateServiceSpy.getCachedAreas.and.returnValue(refreshed);
+    component.editingId = 10;
+    component.editName = 'Stald renamed';
+    component.saveRename(areas[0]);
+    expect(adhocStateServiceSpy.renameArea).toHaveBeenCalledWith(1, 10, 'Stald renamed');
+    expect(adhocStateServiceSpy.getCachedAreas).toHaveBeenCalledWith(1);
+    expect(component.areas).toEqual(refreshed);
+    expect(component.editingId).toBeNull();
+    expect(component.changed).toBe(true);
+    expect(component.busy).toBe(false);
+  });
+
+  it('saveRename surfaces an error key and leaves editingId set on failure', () => {
+    adhocStateServiceSpy.renameArea.and.returnValue(of(false));
+    component.editingId = 10;
+    component.editName = 'Stald 2';
+    component.saveRename(areas[0]);
+    expect(component.errorKey).toBe('Area name is empty or already exists');
+    expect(component.editingId).toBe(10);
+    expect(component.changed).toBe(false);
+  });
+
+  it('saveRename is a no-op for a blank trimmed name', () => {
+    component.editName = '   ';
+    component.saveRename(areas[0]);
+    expect(adhocStateServiceSpy.renameArea).not.toHaveBeenCalled();
+  });
+
+  it('askDelete/cancelDelete toggle the inline confirm step', () => {
+    component.askDelete(areas[0]);
+    expect(component.confirmDeleteArea).toEqual(areas[0]);
+    component.cancelDelete();
+    expect(component.confirmDeleteArea).toBeNull();
+  });
+
+  it('confirmDelete calls deleteArea, refreshes from cache, and closes the confirm step on success', () => {
+    const refreshed = [areas[1]];
+    adhocStateServiceSpy.deleteArea.and.returnValue(of(true));
+    adhocStateServiceSpy.getCachedAreas.and.returnValue(refreshed);
+    component.confirmDeleteArea = areas[0];
+    component.confirmDelete();
+    expect(adhocStateServiceSpy.deleteArea).toHaveBeenCalledWith(1, 10);
+    expect(component.areas).toEqual(refreshed);
+    expect(component.confirmDeleteArea).toBeNull();
+    expect(component.changed).toBe(true);
+  });
+
+  it('confirmDelete does nothing without a pending confirm target', () => {
+    component.confirmDeleteArea = null;
+    component.confirmDelete();
+    expect(adhocStateServiceSpy.deleteArea).not.toHaveBeenCalled();
+  });
+
+  it('close() closes the dialog with the changed flag', () => {
+    component.changed = true;
+    component.close();
+    expect(dialogRefSpy.close).toHaveBeenCalledWith(true);
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.spec.ts
@@ -87,6 +87,16 @@ describe('AdhocAreaAdminModalComponent', () => {
     expect(component.changed).toBe(true);
   });
 
+  it('confirmDelete surfaces an error key and leaves the confirm step open on failure', () => {
+    adhocStateServiceSpy.deleteArea.and.returnValue(of(false));
+    component.confirmDeleteArea = areas[0];
+    component.confirmDelete();
+    expect(component.errorKey).toBe('Failed to delete area');
+    expect(component.confirmDeleteArea).toEqual(areas[0]);
+    expect(component.changed).toBe(false);
+    expect(component.busy).toBe(false);
+  });
+
   it('confirmDelete does nothing without a pending confirm target', () => {
     component.confirmDeleteArea = null;
     component.confirmDelete();

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.ts
@@ -1,4 +1,4 @@
-import {Component, Inject, OnInit} from '@angular/core';
+import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {Subscription} from 'rxjs';
 import {AutoUnsubscribe} from 'ngx-auto-unsubscribe';
@@ -25,7 +25,7 @@ export interface AdhocAreaAdminModalData {
   styleUrls: ['./adhoc-area-admin-modal.component.scss'],
   standalone: false,
 })
-export class AdhocAreaAdminModalComponent implements OnInit {
+export class AdhocAreaAdminModalComponent implements OnInit, OnDestroy {
   areas: AdhocAreaModel[] = [];
   editingId: number | null = null;
   editName = '';
@@ -46,6 +46,9 @@ export class AdhocAreaAdminModalComponent implements OnInit {
 
   ngOnInit(): void {
     this.reload();
+  }
+
+  ngOnDestroy(): void {
   }
 
   private reload(): void {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.ts
@@ -86,10 +86,12 @@ export class AdhocAreaAdminModalComponent implements OnInit, OnDestroy {
 
   askDelete(area: AdhocAreaModel): void {
     this.confirmDeleteArea = area;
+    this.errorKey = null;
   }
 
   cancelDelete(): void {
     this.confirmDeleteArea = null;
+    this.errorKey = null;
   }
 
   confirmDelete(): void {
@@ -102,10 +104,13 @@ export class AdhocAreaAdminModalComponent implements OnInit, OnDestroy {
       .deleteArea(this.data.propertyId, area.id)
       .subscribe((success) => {
         this.busy = false;
-        this.confirmDeleteArea = null;
         if (success) {
           this.changed = true;
+          this.errorKey = null;
+          this.confirmDeleteArea = null;
           this.areas = this.adhocStateService.getCachedAreas(this.data.propertyId);
+        } else {
+          this.errorKey = 'Failed to delete area';
         }
       });
   }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-admin-modal/adhoc-area-admin-modal.component.ts
@@ -1,0 +1,113 @@
+import {Component, Inject, OnInit} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {Subscription} from 'rxjs';
+import {AutoUnsubscribe} from 'ngx-auto-unsubscribe';
+import {AdhocAreaModel} from '../../../../models';
+import {AdhocStateService} from '../store';
+
+export interface AdhocAreaAdminModalData {
+  propertyId: number;
+  propertyName: string;
+}
+
+/**
+ * "Administrer områder" modal (mockup #omraade-admin-modal + inline
+ * delete confirm). Lists ALL active areas of the property (deliberate
+ * mockup deviation - `AdhocArea` has no creator field; in production every
+ * area is user-created). Delete is soft (spec decision 2): the confirm copy
+ * says tasks KEEP their history - do not "fix" it to the mockup's
+ * "cleared" wording. Closes with `true` if anything changed.
+ */
+@AutoUnsubscribe()
+@Component({
+  selector: 'app-adhoc-area-admin-modal',
+  templateUrl: './adhoc-area-admin-modal.component.html',
+  styleUrls: ['./adhoc-area-admin-modal.component.scss'],
+  standalone: false,
+})
+export class AdhocAreaAdminModalComponent implements OnInit {
+  areas: AdhocAreaModel[] = [];
+  editingId: number | null = null;
+  editName = '';
+  confirmDeleteArea: AdhocAreaModel | null = null;
+  busy = false;
+  changed = false;
+  errorKey: string | null = null;
+  loadSub$: Subscription;
+  renameSub$: Subscription;
+  deleteSub$: Subscription;
+
+  constructor(
+    public dialogRef: MatDialogRef<AdhocAreaAdminModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: AdhocAreaAdminModalData,
+    private adhocStateService: AdhocStateService,
+  ) {
+  }
+
+  ngOnInit(): void {
+    this.reload();
+  }
+
+  private reload(): void {
+    this.loadSub$ = this.adhocStateService
+      .getAreasForProperty(this.data.propertyId)
+      .subscribe((areas) => (this.areas = areas));
+  }
+
+  startRename(area: AdhocAreaModel): void {
+    this.editingId = area.id;
+    this.editName = area.name;
+    this.errorKey = null;
+  }
+
+  saveRename(area: AdhocAreaModel): void {
+    const name = this.editName.trim();
+    if (name.length === 0 || this.busy) {
+      return;
+    }
+    this.busy = true;
+    this.renameSub$ = this.adhocStateService
+      .renameArea(this.data.propertyId, area.id, name)
+      .subscribe((success) => {
+        this.busy = false;
+        if (success) {
+          this.changed = true;
+          this.editingId = null;
+          this.errorKey = null;
+          this.areas = this.adhocStateService.getCachedAreas(this.data.propertyId);
+        } else {
+          this.errorKey = 'Area name is empty or already exists';
+        }
+      });
+  }
+
+  askDelete(area: AdhocAreaModel): void {
+    this.confirmDeleteArea = area;
+  }
+
+  cancelDelete(): void {
+    this.confirmDeleteArea = null;
+  }
+
+  confirmDelete(): void {
+    const area = this.confirmDeleteArea;
+    if (!area || this.busy) {
+      return;
+    }
+    this.busy = true;
+    this.deleteSub$ = this.adhocStateService
+      .deleteArea(this.data.propertyId, area.id)
+      .subscribe((success) => {
+        this.busy = false;
+        this.confirmDeleteArea = null;
+        if (success) {
+          this.changed = true;
+          this.areas = this.adhocStateService.getCachedAreas(this.data.propertyId);
+        }
+      });
+  }
+
+  close(): void {
+    this.dialogRef.close(this.changed);
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.html
@@ -1,0 +1,16 @@
+<h2 mat-dialog-title>{{ 'Create areas' | translate }}</h2>
+<mat-dialog-content>
+  <p>{{ 'Property' | translate }}: <strong>{{ data.propertyName }}</strong></p>
+  <p class="hint">{{ 'One area name per line' | translate }}</p>
+  <mat-form-field class="full-width">
+    <mat-label>{{ 'Areas' | translate }}</mat-label>
+    <textarea matInput rows="6" id="adhocAreaCreateTextarea" [(ngModel)]="namesText"></textarea>
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button id="adhocAreaCreateCancelBtn" (click)="hide()">{{ 'Cancel' | translate }}</button>
+  <button mat-raised-button color="primary" id="adhocAreaCreateSaveBtn"
+          [disabled]="parsedNames.length === 0 || saving" (click)="save()">
+    {{ 'Add' | translate }}
+  </button>
+</mat-dialog-actions>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.html
@@ -2,6 +2,7 @@
 <mat-dialog-content>
   <p>{{ 'Property' | translate }}: <strong>{{ data.propertyName }}</strong></p>
   <p class="hint">{{ 'One area name per line' | translate }}</p>
+  <p class="error" *ngIf="errorKey">{{ errorKey | translate }}</p>
   <mat-form-field class="full-width">
     <mat-label>{{ 'Areas' | translate }}</mat-label>
     <textarea matInput rows="6" id="adhocAreaCreateTextarea" [(ngModel)]="namesText"></textarea>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.scss
@@ -6,3 +6,8 @@
   color: rgba(0, 0, 0, 0.6);
   font-size: 12px;
 }
+
+.error {
+  color: #b3261e;
+  font-size: 12px;
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.scss
@@ -1,0 +1,8 @@
+.full-width {
+  width: 100%;
+}
+
+.hint {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 12px;
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.spec.ts
@@ -38,11 +38,21 @@ describe('AdhocAreaCreateModalComponent', () => {
     expect(component.saving).toBe(true);
   });
 
-  it('save() resets saving on error and does not close', () => {
+  it('save() resets saving on error, surfaces an errorKey, and does not close', () => {
     adhocStateServiceSpy.createAreas.and.returnValue(throwError(() => new Error('fail')));
     component.namesText = 'Stald 1';
     component.save();
     expect(component.saving).toBe(false);
+    expect(component.errorKey).toBe('Failed to create areas');
+    expect(dialogRefSpy.close).not.toHaveBeenCalled();
+  });
+
+  it('save() surfaces an errorKey and keeps the modal open when the create reports failure (empty result)', () => {
+    adhocStateServiceSpy.createAreas.and.returnValue(of([]));
+    component.namesText = 'Stald 1';
+    component.save();
+    expect(component.saving).toBe(false);
+    expect(component.errorKey).toBe('Failed to create areas');
     expect(dialogRefSpy.close).not.toHaveBeenCalled();
   });
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.spec.ts
@@ -1,0 +1,55 @@
+import {of, throwError} from 'rxjs';
+import {AdhocAreaCreateModalComponent} from './adhoc-area-create-modal.component';
+
+describe('AdhocAreaCreateModalComponent', () => {
+  let dialogRefSpy: any;
+  let adhocStateServiceSpy: any;
+  let component: AdhocAreaCreateModalComponent;
+
+  beforeEach(() => {
+    dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+    adhocStateServiceSpy = jasmine.createSpyObj('AdhocStateService', ['createAreas']);
+    component = new AdhocAreaCreateModalComponent(dialogRefSpy, {propertyId: 1, propertyName: 'Gård Nord'}, adhocStateServiceSpy);
+  });
+
+  it('parsedNames trims whitespace and drops empty lines', () => {
+    component.namesText = '  Stald 1 \n\n Stald 2\n   \nStald 3';
+    expect(component.parsedNames).toEqual(['Stald 1', 'Stald 2', 'Stald 3']);
+  });
+
+  it('hide() closes with false', () => {
+    component.hide();
+    expect(dialogRefSpy.close).toHaveBeenCalledWith(false);
+  });
+
+  it('save() is a no-op when parsedNames is empty', () => {
+    component.namesText = '   \n  ';
+    component.save();
+    expect(adhocStateServiceSpy.createAreas).not.toHaveBeenCalled();
+    expect(dialogRefSpy.close).not.toHaveBeenCalled();
+  });
+
+  it('save() calls createAreas(propertyId, names) and closes with true on success', () => {
+    adhocStateServiceSpy.createAreas.and.returnValue(of([{id: 10, propertyId: 1, name: 'Stald 1'}]));
+    component.namesText = 'Stald 1';
+    component.save();
+    expect(adhocStateServiceSpy.createAreas).toHaveBeenCalledWith(1, ['Stald 1']);
+    expect(dialogRefSpy.close).toHaveBeenCalledWith(true);
+    expect(component.saving).toBe(true);
+  });
+
+  it('save() resets saving on error and does not close', () => {
+    adhocStateServiceSpy.createAreas.and.returnValue(throwError(() => new Error('fail')));
+    component.namesText = 'Stald 1';
+    component.save();
+    expect(component.saving).toBe(false);
+    expect(dialogRefSpy.close).not.toHaveBeenCalled();
+  });
+
+  it('save() does nothing while already saving', () => {
+    component.namesText = 'Stald 1';
+    component.saving = true;
+    component.save();
+    expect(adhocStateServiceSpy.createAreas).not.toHaveBeenCalled();
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.ts
@@ -1,4 +1,4 @@
-import {Component, Inject} from '@angular/core';
+import {Component, Inject, OnDestroy} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {Subscription} from 'rxjs';
 import {AutoUnsubscribe} from 'ngx-auto-unsubscribe';
@@ -22,7 +22,7 @@ export interface AdhocAreaCreateModalData {
   styleUrls: ['./adhoc-area-create-modal.component.scss'],
   standalone: false,
 })
-export class AdhocAreaCreateModalComponent {
+export class AdhocAreaCreateModalComponent implements OnDestroy {
   namesText = '';
   saving = false;
   createSub$: Subscription;
@@ -32,6 +32,9 @@ export class AdhocAreaCreateModalComponent {
     @Inject(MAT_DIALOG_DATA) public data: AdhocAreaCreateModalData,
     private adhocStateService: AdhocStateService,
   ) {
+  }
+
+  ngOnDestroy(): void {
   }
 
   get parsedNames(): string[] {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.ts
@@ -1,0 +1,61 @@
+import {Component, Inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {Subscription} from 'rxjs';
+import {AutoUnsubscribe} from 'ngx-auto-unsubscribe';
+import {AdhocStateService} from '../store';
+
+export interface AdhocAreaCreateModalData {
+  propertyId: number;
+  propertyName: string;
+}
+
+/**
+ * "Opret områder" batch modal (mockup #omraade-batch-modal): textarea, one
+ * name per line, scoped to the currently selected property. Client trims
+ * and drops empties; the server case-insensitively dedupes (silent skip,
+ * idempotent). Closes with `true` when areas were submitted.
+ */
+@AutoUnsubscribe()
+@Component({
+  selector: 'app-adhoc-area-create-modal',
+  templateUrl: './adhoc-area-create-modal.component.html',
+  styleUrls: ['./adhoc-area-create-modal.component.scss'],
+  standalone: false,
+})
+export class AdhocAreaCreateModalComponent {
+  namesText = '';
+  saving = false;
+  createSub$: Subscription;
+
+  constructor(
+    public dialogRef: MatDialogRef<AdhocAreaCreateModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: AdhocAreaCreateModalData,
+    private adhocStateService: AdhocStateService,
+  ) {
+  }
+
+  get parsedNames(): string[] {
+    return this.namesText
+      .split('\n')
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0);
+  }
+
+  hide(): void {
+    this.dialogRef.close(false);
+  }
+
+  save(): void {
+    const names = this.parsedNames;
+    if (names.length === 0 || this.saving) {
+      return;
+    }
+    this.saving = true;
+    this.createSub$ = this.adhocStateService
+      .createAreas(this.data.propertyId, names)
+      .subscribe({
+        next: () => this.dialogRef.close(true),
+        error: () => (this.saving = false),
+      });
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-area-create-modal/adhoc-area-create-modal.component.ts
@@ -13,7 +13,9 @@ export interface AdhocAreaCreateModalData {
  * "Opret områder" batch modal (mockup #omraade-batch-modal): textarea, one
  * name per line, scoped to the currently selected property. Client trims
  * and drops empties; the server case-insensitively dedupes (silent skip,
- * idempotent). Closes with `true` when areas were submitted.
+ * idempotent). Closes with `true` only once the create actually succeeded -
+ * a failed create (mirrors the admin modal's rename/delete error handling)
+ * surfaces `errorKey` and keeps the modal open instead.
  */
 @AutoUnsubscribe()
 @Component({
@@ -25,6 +27,7 @@ export interface AdhocAreaCreateModalData {
 export class AdhocAreaCreateModalComponent implements OnDestroy {
   namesText = '';
   saving = false;
+  errorKey: string | null = null;
   createSub$: Subscription;
 
   constructor(
@@ -54,11 +57,22 @@ export class AdhocAreaCreateModalComponent implements OnDestroy {
       return;
     }
     this.saving = true;
+    this.errorKey = null;
     this.createSub$ = this.adhocStateService
       .createAreas(this.data.propertyId, names)
       .subscribe({
-        next: () => this.dialogRef.close(true),
-        error: () => (this.saving = false),
+        next: (areas) => {
+          this.saving = false;
+          if (areas && areas.length > 0) {
+            this.dialogRef.close(true);
+          } else {
+            this.errorKey = 'Failed to create areas';
+          }
+        },
+        error: () => {
+          this.saving = false;
+          this.errorKey = 'Failed to create areas';
+        },
       });
   }
 }

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.html
@@ -69,18 +69,32 @@
     ></mtx-select>
   </mat-form-field>
 
-  <mat-form-field>
-    <mat-label>{{ 'Area' | translate }}</mat-label>
-    <mtx-select
-      [items]="areas"
-      bindLabel="name"
-      bindValue="id"
-      id="toolbar-omraade"
-      [disabled]="currentFilters.propertyId == null"
-      [ngModel]="currentFilters.areaId"
-      (ngModelChange)="onAreaChange($event)"
-    ></mtx-select>
-  </mat-form-field>
+  <div class="area-filter-group">
+    <mat-form-field>
+      <mat-label>{{ 'Area' | translate }}</mat-label>
+      <mtx-select
+        [items]="areas"
+        bindLabel="name"
+        bindValue="id"
+        id="toolbar-omraade"
+        [disabled]="currentFilters.propertyId == null"
+        [ngModel]="currentFilters.areaId"
+        (ngModelChange)="onAreaChange($event)"
+      ></mtx-select>
+    </mat-form-field>
+    <button mat-icon-button id="adhocToolbarAreaCreateBtn"
+            [disabled]="currentFilters.propertyId == null"
+            [matTooltip]="'Create one or more areas on the selected property (one name per line)' | translate"
+            (click)="openAreaCreateModal()">
+      <mat-icon>add</mat-icon>
+    </button>
+    <button mat-icon-button id="adhocToolbarAreaManageBtn"
+            [disabled]="currentFilters.propertyId == null"
+            [matTooltip]="'Edit or delete areas for the selected property' | translate"
+            (click)="openAreaAdminModal()">
+      <mat-icon>edit</mat-icon>
+    </button>
+  </div>
 
   <mat-form-field>
     <mat-label>{{ 'Status' | translate }}</mat-label>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.scss
@@ -69,3 +69,8 @@
   font-size: 12px;
   padding: 4px 0;
 }
+
+.area-filter-group {
+  display: flex;
+  align-items: center;
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.spec.ts
@@ -12,6 +12,7 @@ describe('AdhocFiltersComponent', () => {
   let adhocServiceSpy: any;
   let translateSpy: any;
   let elementRefSpy: any;
+  let dialogSpy: any;
 
   beforeEach(() => {
     adhocStateServiceSpy = {
@@ -33,8 +34,9 @@ describe('AdhocFiltersComponent', () => {
     };
     translateSpy = {instant: (key: string) => key};
     elementRefSpy = {nativeElement: {contains: () => true}};
+    dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
 
-    component = new AdhocFiltersComponent(adhocStateServiceSpy, adhocServiceSpy, translateSpy, elementRefSpy);
+    component = new AdhocFiltersComponent(adhocStateServiceSpy, adhocServiceSpy, translateSpy, elementRefSpy, dialogSpy);
   });
 
   describe('statusOptions', () => {
@@ -109,6 +111,50 @@ describe('AdhocFiltersComponent', () => {
       component.areas = [{id: 100, propertyId: 1, name: 'Stald 1'}];
       component.onPropertyChange(null);
       expect(component.areas).toEqual([]);
+    });
+  });
+
+  describe('area create/admin modals', () => {
+    it('openAreaCreateModal is a no-op without a selected property', () => {
+      adhocStateServiceSpy.currentFilters.propertyId = null;
+      component.openAreaCreateModal();
+      expect(dialogSpy.open).not.toHaveBeenCalled();
+    });
+
+    it('openAreaCreateModal opens with the selected property and reloads areas when changed', () => {
+      adhocStateServiceSpy.currentFilters.propertyId = 1;
+      const afterClosedSpy = jasmine.createSpyObj('MatDialogRef', ['afterClosed']);
+      afterClosedSpy.afterClosed.and.returnValue(of(true));
+      dialogSpy.open.and.returnValue(afterClosedSpy);
+
+      component.openAreaCreateModal();
+
+      expect(dialogSpy.open).toHaveBeenCalledWith(
+        jasmine.any(Function),
+        jasmine.objectContaining({data: {propertyId: 1, propertyName: 'Gård Nord'}}),
+      );
+      expect(adhocStateServiceSpy.getAreasForProperty).toHaveBeenCalledWith(1);
+    });
+
+    it('openAreaAdminModal is a no-op without a selected property', () => {
+      adhocStateServiceSpy.currentFilters.propertyId = null;
+      component.openAreaAdminModal();
+      expect(dialogSpy.open).not.toHaveBeenCalled();
+    });
+
+    it('openAreaAdminModal opens with the selected property and only reloads areas when something changed', () => {
+      adhocStateServiceSpy.currentFilters.propertyId = 1;
+      const afterClosedSpy = jasmine.createSpyObj('MatDialogRef', ['afterClosed']);
+      afterClosedSpy.afterClosed.and.returnValue(of(false));
+      dialogSpy.open.and.returnValue(afterClosedSpy);
+
+      component.openAreaAdminModal();
+
+      expect(dialogSpy.open).toHaveBeenCalledWith(
+        jasmine.any(Function),
+        jasmine.objectContaining({data: {propertyId: 1, propertyName: 'Gård Nord'}}),
+      );
+      expect(adhocStateServiceSpy.getAreasForProperty).not.toHaveBeenCalled();
     });
   });
 });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.spec.ts
@@ -13,6 +13,7 @@ describe('AdhocFiltersComponent', () => {
   let translateSpy: any;
   let elementRefSpy: any;
   let dialogSpy: any;
+  let overlaySpy: any;
 
   beforeEach(() => {
     adhocStateServiceSpy = {
@@ -35,8 +36,9 @@ describe('AdhocFiltersComponent', () => {
     translateSpy = {instant: (key: string) => key};
     elementRefSpy = {nativeElement: {contains: () => true}};
     dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+    overlaySpy = {};
 
-    component = new AdhocFiltersComponent(adhocStateServiceSpy, adhocServiceSpy, translateSpy, elementRefSpy, dialogSpy);
+    component = new AdhocFiltersComponent(adhocStateServiceSpy, adhocServiceSpy, translateSpy, elementRefSpy, dialogSpy, overlaySpy);
   });
 
   describe('statusOptions', () => {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.ts
@@ -1,12 +1,15 @@
 import {Component, ElementRef, HostListener, OnChanges, OnDestroy, OnInit, Input, SimpleChanges} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {TranslateService} from '@ngx-translate/core';
+import {MatDialog} from '@angular/material/dialog';
 import {Subscription, debounceTime, distinctUntilChanged} from 'rxjs';
 import {AutoUnsubscribe} from 'ngx-auto-unsubscribe';
 import {AdhocAreaModel, AdhocTagModel} from '../../../../models';
 import {AdhocFiltrationModel} from '../../../../state';
 import {BackendConfigurationPnAdhocService} from '../../../../services';
 import {AdhocStateService} from '../store';
+import {AdhocAreaCreateModalComponent} from '../adhoc-area-create-modal/adhoc-area-create-modal.component';
+import {AdhocAreaAdminModalComponent} from '../adhoc-area-admin-modal/adhoc-area-admin-modal.component';
 
 interface AdhocStatusOption {
   value: AdhocFiltrationModel['status'];
@@ -69,6 +72,7 @@ export class AdhocFiltersComponent implements OnInit, OnChanges, OnDestroy {
     private adhocService: BackendConfigurationPnAdhocService,
     private translate: TranslateService,
     private elementRef: ElementRef,
+    private dialog: MatDialog,
   ) {
   }
 
@@ -132,6 +136,46 @@ export class AdhocFiltersComponent implements OnInit, OnChanges, OnDestroy {
 
   onAreaChange(areaId: number | null): void {
     this.adhocStateService.updateFilters({areaId});
+  }
+
+  openAreaCreateModal(): void {
+    const propertyId = this.currentFilters.propertyId;
+    if (propertyId == null) {
+      return;
+    }
+    this.dialog
+      .open(AdhocAreaCreateModalComponent, {
+        minWidth: 400,
+        data: {propertyId, propertyName: this.propertyName(propertyId)},
+      })
+      .afterClosed()
+      .subscribe((changed) => {
+        if (changed) {
+          this.loadAreas(propertyId);
+        }
+      });
+  }
+
+  openAreaAdminModal(): void {
+    const propertyId = this.currentFilters.propertyId;
+    if (propertyId == null) {
+      return;
+    }
+    this.dialog
+      .open(AdhocAreaAdminModalComponent, {
+        minWidth: 440,
+        data: {propertyId, propertyName: this.propertyName(propertyId)},
+      })
+      .afterClosed()
+      .subscribe((changed) => {
+        if (changed) {
+          this.loadAreas(propertyId);
+        }
+      });
+  }
+
+  private propertyName(propertyId: number): string {
+    return this.adhocStateService.properties.find((p) => p.id === propertyId)?.name ?? '';
   }
 
   onStatusChange(status: AdhocFiltrationModel['status']): void {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.ts
@@ -2,6 +2,8 @@ import {Component, ElementRef, HostListener, OnChanges, OnDestroy, OnInit, Input
 import {FormControl} from '@angular/forms';
 import {TranslateService} from '@ngx-translate/core';
 import {MatDialog} from '@angular/material/dialog';
+import {Overlay} from '@angular/cdk/overlay';
+import {dialogConfigHelper} from 'src/app/common/helpers';
 import {Subscription, debounceTime, distinctUntilChanged} from 'rxjs';
 import {AutoUnsubscribe} from 'ngx-auto-unsubscribe';
 import {AdhocAreaModel, AdhocTagModel} from '../../../../models';
@@ -73,6 +75,7 @@ export class AdhocFiltersComponent implements OnInit, OnChanges, OnDestroy {
     private translate: TranslateService,
     private elementRef: ElementRef,
     private dialog: MatDialog,
+    private overlay: Overlay,
   ) {
   }
 
@@ -145,8 +148,8 @@ export class AdhocFiltersComponent implements OnInit, OnChanges, OnDestroy {
     }
     this.dialog
       .open(AdhocAreaCreateModalComponent, {
+        ...dialogConfigHelper(this.overlay, {propertyId, propertyName: this.propertyName(propertyId)}),
         minWidth: 400,
-        data: {propertyId, propertyName: this.propertyName(propertyId)},
       })
       .afterClosed()
       .subscribe((changed) => {
@@ -163,8 +166,8 @@ export class AdhocFiltersComponent implements OnInit, OnChanges, OnDestroy {
     }
     this.dialog
       .open(AdhocAreaAdminModalComponent, {
+        ...dialogConfigHelper(this.overlay, {propertyId, propertyName: this.propertyName(propertyId)}),
         minWidth: 440,
-        data: {propertyId, propertyName: this.propertyName(propertyId)},
       })
       .afterClosed()
       .subscribe((changed) => {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-filters/adhoc-filters.component.ts
@@ -2,6 +2,7 @@ import {Component, ElementRef, HostListener, OnChanges, OnDestroy, OnInit, Input
 import {FormControl} from '@angular/forms';
 import {TranslateService} from '@ngx-translate/core';
 import {MatDialog} from '@angular/material/dialog';
+import {ComponentType} from '@angular/cdk/portal';
 import {Overlay} from '@angular/cdk/overlay';
 import {dialogConfigHelper} from 'src/app/common/helpers';
 import {Subscription, debounceTime, distinctUntilChanged} from 'rxjs';
@@ -142,32 +143,22 @@ export class AdhocFiltersComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   openAreaCreateModal(): void {
-    const propertyId = this.currentFilters.propertyId;
-    if (propertyId == null) {
-      return;
-    }
-    this.dialog
-      .open(AdhocAreaCreateModalComponent, {
-        ...dialogConfigHelper(this.overlay, {propertyId, propertyName: this.propertyName(propertyId)}),
-        minWidth: 400,
-      })
-      .afterClosed()
-      .subscribe((changed) => {
-        if (changed) {
-          this.loadAreas(propertyId);
-        }
-      });
+    this.openAreaModal(AdhocAreaCreateModalComponent, 400);
   }
 
   openAreaAdminModal(): void {
+    this.openAreaModal(AdhocAreaAdminModalComponent, 440);
+  }
+
+  private openAreaModal(component: ComponentType<unknown>, minWidth: number): void {
     const propertyId = this.currentFilters.propertyId;
     if (propertyId == null) {
       return;
     }
     this.dialog
-      .open(AdhocAreaAdminModalComponent, {
+      .open(component, {
         ...dialogConfigHelper(this.overlay, {propertyId, propertyName: this.propertyName(propertyId)}),
-        minWidth: 440,
+        minWidth,
       })
       .afterClosed()
       .subscribe((changed) => {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/index.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/index.ts
@@ -6,3 +6,5 @@ export * from './adhoc-delete-modal/adhoc-delete-modal.component';
 export * from './adhoc-copy-modal/adhoc-copy-modal.component';
 export * from './adhoc-complete-modal/adhoc-complete-modal.component';
 export * from './adhoc-history/adhoc-history.component';
+export * from './adhoc-area-create-modal/adhoc-area-create-modal.component';
+export * from './adhoc-area-admin-modal/adhoc-area-admin-modal.component';

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/store/adhoc-state.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/store/adhoc-state.service.spec.ts
@@ -44,6 +44,9 @@ describe('AdhocStateService', () => {
       'getTags',
       'getAreas',
       'getWorkers',
+      'createAreas',
+      'renameArea',
+      'deleteArea',
     ]);
     service = buildService();
   });
@@ -185,6 +188,73 @@ describe('AdhocStateService', () => {
       expect(service.properties).toEqual([]);
       expect(service.tags).toEqual([]);
       expect(service.getCachedAreas(1)).toEqual([]);
+    });
+  });
+
+  describe('area mutations (active cache refresh)', () => {
+    it('createAreas overwrites the cache from the create response (not merely invalidating it)', () => {
+      adhocServiceSpy.getAreas.and.returnValue(of({success: true, model: [{id: 10, propertyId: 1, name: 'Stald 1'}]}));
+      service.getAreasForProperty(1).subscribe();
+      expect(service.getCachedAreas(1)).toEqual([{id: 10, propertyId: 1, name: 'Stald 1'}]);
+
+      adhocServiceSpy.createAreas.and.returnValue(
+        of({success: true, model: [{id: 10, propertyId: 1, name: 'Stald 1'}, {id: 11, propertyId: 1, name: 'Stald 2'}]})
+      );
+      service.createAreas(1, ['Stald 2']).subscribe();
+
+      expect(adhocServiceSpy.createAreas).toHaveBeenCalledWith(1, ['Stald 2']);
+      expect(service.getCachedAreas(1)).toEqual([
+        {id: 10, propertyId: 1, name: 'Stald 1'},
+        {id: 11, propertyId: 1, name: 'Stald 2'},
+      ]);
+    });
+
+    it('renameArea re-fetches via getAreas and overwrites the cache with the fresh list (active refresh, not invalidate-only)', () => {
+      adhocServiceSpy.getAreas.and.returnValue(of({success: true, model: [{id: 10, propertyId: 1, name: 'Stald 1'}]}));
+      service.getAreasForProperty(1).subscribe();
+      expect(service.getCachedAreas(1)).toEqual([{id: 10, propertyId: 1, name: 'Stald 1'}]);
+
+      adhocServiceSpy.renameArea.and.returnValue(of({success: true, model: {id: 10, propertyId: 1, name: 'Stald renamed'}}));
+      adhocServiceSpy.getAreas.and.returnValue(of({success: true, model: [{id: 10, propertyId: 1, name: 'Stald renamed'}]}));
+
+      let result: boolean | undefined;
+      service.renameArea(1, 10, 'Stald renamed').subscribe((success) => (result = success));
+
+      expect(adhocServiceSpy.renameArea).toHaveBeenCalledWith(10, 'Stald renamed');
+      // Cache is not merely cleared - it is repopulated with the re-fetched entities.
+      expect(adhocServiceSpy.getAreas).toHaveBeenCalledWith(1);
+      expect(service.getCachedAreas(1)).toEqual([{id: 10, propertyId: 1, name: 'Stald renamed'}]);
+      expect(result).toBeTrue();
+    });
+
+    it('deleteArea re-fetches via getAreas and overwrites the cache with the fresh list (active refresh, not invalidate-only)', () => {
+      adhocServiceSpy.getAreas.and.returnValue(
+        of({success: true, model: [{id: 10, propertyId: 1, name: 'Stald 1'}, {id: 11, propertyId: 1, name: 'Stald 2'}]})
+      );
+      service.getAreasForProperty(1).subscribe();
+      expect(service.getCachedAreas(1).length).toBe(2);
+
+      adhocServiceSpy.deleteArea.and.returnValue(of({success: true}));
+      adhocServiceSpy.getAreas.and.returnValue(of({success: true, model: [{id: 11, propertyId: 1, name: 'Stald 2'}]}));
+
+      let result: boolean | undefined;
+      service.deleteArea(1, 10).subscribe((success) => (result = success));
+
+      expect(adhocServiceSpy.deleteArea).toHaveBeenCalledWith(10);
+      expect(adhocServiceSpy.getAreas).toHaveBeenCalledWith(1);
+      expect(service.getCachedAreas(1)).toEqual([{id: 11, propertyId: 1, name: 'Stald 2'}]);
+      expect(result).toBeTrue();
+    });
+
+    it('renameArea propagates failure while still refreshing the cache', () => {
+      adhocServiceSpy.renameArea.and.returnValue(of({success: false}));
+      adhocServiceSpy.getAreas.and.returnValue(of({success: true, model: [{id: 10, propertyId: 1, name: 'Stald 1'}]}));
+
+      let result: boolean | undefined;
+      service.renameArea(1, 10, 'x').subscribe((success) => (result = success));
+
+      expect(result).toBeFalse();
+      expect(service.getCachedAreas(1)).toEqual([{id: 10, propertyId: 1, name: 'Stald 1'}]);
     });
   });
 });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/store/adhoc-state.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/store/adhoc-state.service.spec.ts
@@ -209,6 +209,19 @@ describe('AdhocStateService', () => {
       ]);
     });
 
+    it('createAreas leaves the cache untouched (does not poison it with []) when the create reports failure', () => {
+      adhocServiceSpy.getAreas.and.returnValue(of({success: true, model: [{id: 10, propertyId: 1, name: 'Stald 1'}]}));
+      service.getAreasForProperty(1).subscribe();
+      expect(service.getCachedAreas(1)).toEqual([{id: 10, propertyId: 1, name: 'Stald 1'}]);
+
+      adhocServiceSpy.createAreas.and.returnValue(of({success: false, model: null}));
+      let emitted: any;
+      service.createAreas(1, ['Stald 2']).subscribe((areas) => (emitted = areas));
+
+      expect(emitted).toEqual([]);
+      expect(service.getCachedAreas(1)).toEqual([{id: 10, propertyId: 1, name: 'Stald 1'}]);
+    });
+
     it('renameArea re-fetches via getAreas and overwrites the cache with the fresh list (active refresh, not invalidate-only)', () => {
       adhocServiceSpy.getAreas.and.returnValue(of({success: true, model: [{id: 10, propertyId: 1, name: 'Stald 1'}]}));
       service.getAreasForProperty(1).subscribe();

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/store/adhoc-state.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/store/adhoc-state.service.ts
@@ -141,10 +141,21 @@ export class AdhocStateService {
   // leave stale dropdowns (spec, Angular design).
   // -----------------------------------------------------------------
 
+  /**
+   * Only overwrites the cache when the create actually succeeded - unlike
+   * `refreshAreas`, this maps a raw create response, so a `success: false`
+   * reply must not poison the cache with `[]` (mirrors renameArea/deleteArea,
+   * which never write a failure result into the cache either).
+   */
   createAreas(propertyId: number, names: string[]): Observable<AdhocAreaModel[]> {
     return this.service.createAreas(propertyId, names).pipe(
-      map((res) => (res && res.success && res.model) || []),
-      tap((areas) => this.areasByProperty.set(propertyId, areas))
+      map((res) => (res && res.success && res.model) || null),
+      tap((areas) => {
+        if (areas) {
+          this.areasByProperty.set(propertyId, areas);
+        }
+      }),
+      map((areas) => areas || [])
     );
   }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/store/adhoc-state.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/store/adhoc-state.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable, of} from 'rxjs';
-import {map, tap} from 'rxjs/operators';
+import {map, switchMap, tap} from 'rxjs/operators';
 import {updateTableSort} from 'src/app/common/helpers';
 import {CommonPaginationState, OperationDataResult, PaginationModel} from 'src/app/common/models';
 import {BackendConfigurationPnAdhocService} from '../../../../services';
@@ -132,6 +132,42 @@ export class AdhocStateService {
       return [];
     }
     return this.workersByProperty.get(propertyId) ?? [];
+  }
+
+  // -----------------------------------------------------------------
+  // Area mutations (area-management spec 2026-07-30). Each one ACTIVELY
+  // refreshes the property's cache entry: adhoc-filters and the task
+  // drawer hold one-shot-subscribed copies, so invalidate-only would
+  // leave stale dropdowns (spec, Angular design).
+  // -----------------------------------------------------------------
+
+  createAreas(propertyId: number, names: string[]): Observable<AdhocAreaModel[]> {
+    return this.service.createAreas(propertyId, names).pipe(
+      map((res) => (res && res.success && res.model) || []),
+      tap((areas) => this.areasByProperty.set(propertyId, areas))
+    );
+  }
+
+  renameArea(propertyId: number, areaId: number, name: string): Observable<boolean> {
+    return this.service.renameArea(areaId, name).pipe(
+      map((res) => !!(res && res.success)),
+      switchMap((success) => this.refreshAreas(propertyId).pipe(map(() => success)))
+    );
+  }
+
+  deleteArea(propertyId: number, areaId: number): Observable<boolean> {
+    return this.service.deleteArea(areaId).pipe(
+      map((res) => !!(res && res.success)),
+      switchMap((success) => this.refreshAreas(propertyId).pipe(map(() => success)))
+    );
+  }
+
+  /** Unconditional re-fetch that overwrites the cache entry (unlike `getAreasForProperty`, which returns the cache when present). */
+  private refreshAreas(propertyId: number): Observable<AdhocAreaModel[]> {
+    return this.service.getAreas(propertyId).pipe(
+      map((res) => (res && res.success && res.model) || []),
+      tap((areas) => this.areasByProperty.set(propertyId, areas))
+    );
   }
 
   // -----------------------------------------------------------------

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-adhoc.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-adhoc.service.spec.ts
@@ -163,6 +163,36 @@ describe('BackendConfigurationPnAdhocService', () => {
     });
   });
 
+  describe('createAreas', () => {
+    it('POSTs {propertyId, names} to the areas route', () => {
+      service.createAreas(3, ['Stald 1', 'Stald 2']).subscribe();
+
+      expect(apiBaseServiceSpy.post).toHaveBeenCalledWith(
+        BackendConfigurationPnAdhocMethods.Areas,
+        {propertyId: 3, names: ['Stald 1', 'Stald 2']}
+      );
+    });
+  });
+
+  describe('renameArea', () => {
+    it('PUTs {name} to areas/{id}', () => {
+      service.renameArea(10, 'Renamed stald').subscribe();
+
+      expect(apiBaseServiceSpy.put).toHaveBeenCalledWith(
+        `${BackendConfigurationPnAdhocMethods.Areas}/10`,
+        {name: 'Renamed stald'}
+      );
+    });
+  });
+
+  describe('deleteArea', () => {
+    it('DELETEs areas/{id}', () => {
+      service.deleteArea(10).subscribe();
+
+      expect(apiBaseServiceSpy.delete).toHaveBeenCalledWith(`${BackendConfigurationPnAdhocMethods.Areas}/10`);
+    });
+  });
+
   describe('getWorkers', () => {
     it('GETs the workers route with propertyId as a query param', () => {
       service.getWorkers(3).subscribe();

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-adhoc.service.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/services/backend-configuration-pn-adhoc.service.ts
@@ -3,7 +3,9 @@ import {Observable} from 'rxjs';
 import {OperationDataResult, OperationResult, Paged} from 'src/app/common/models';
 import {ApiBaseService} from 'src/app/common/services';
 import {
+  AdhocAreaCreateModel,
   AdhocAreaModel,
+  AdhocAreaRenameModel,
   AdhocCommentCreateModel,
   AdhocCopyTaskModel,
   AdhocHistoryFiltersModel,
@@ -113,6 +115,20 @@ export class BackendConfigurationPnAdhocService {
 
   getAreas(propertyId: number): Observable<OperationDataResult<AdhocAreaModel[]>> {
     return this.apiBaseService.get(BackendConfigurationPnAdhocMethods.Areas, {propertyId});
+  }
+
+  createAreas(propertyId: number, names: string[]): Observable<OperationDataResult<AdhocAreaModel[]>> {
+    const body: AdhocAreaCreateModel = {propertyId, names};
+    return this.apiBaseService.post(BackendConfigurationPnAdhocMethods.Areas, body);
+  }
+
+  renameArea(id: number, name: string): Observable<OperationDataResult<AdhocAreaModel>> {
+    const body: AdhocAreaRenameModel = {name};
+    return this.apiBaseService.put(`${BackendConfigurationPnAdhocMethods.Areas}/${id}`, body);
+  }
+
+  deleteArea(id: number): Observable<OperationResult> {
+    return this.apiBaseService.delete(`${BackendConfigurationPnAdhocMethods.Areas}/${id}`);
   }
 
   getWorkers(propertyId: number): Observable<OperationDataResult<AdhocWorkerModel[]>> {


### PR DESCRIPTION
Batch create / rename / soft-delete for adhoc areas + the mockup's toolbar/modals cluster in the Angular adhoc module. Spec: flutter-adhoc docs/superpowers/specs/2026-07-30-adhoc-area-management-design.md. Tasks land incrementally; dual review gate before ready-for-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)