### PR TITLE
fix(report): don't abort report when a planning's property is unresolvable

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationReportService/BackendConfigurationReportService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationReportService/BackendConfigurationReportService.cs
@@ -318,8 +318,15 @@ public class BackendConfigurationReportService(
 
                         if (areaRulePlanning != null)
                         {
-                            propertyName = backendConfigurationPnDbContext.Properties
-                                .First(x => x.Id == areaRulePlanning.PropertyId).Name;
+                            var property = await backendConfigurationPnDbContext.Properties
+                                .FirstOrDefaultAsync(x => x.Id == areaRulePlanning.PropertyId);
+                            if (property == null)
+                            {
+                                logger.LogWarning(
+                                    $"Could not find property with id {areaRulePlanning.PropertyId} for planning {planningCase.PlanningId}");
+                            }
+
+                            propertyName = property?.Name ?? "";
                         }
                         else
                         {
@@ -331,8 +338,15 @@ public class BackendConfigurationReportService(
 
                             if (areaRulePlanningVersion != null)
                             {
-                                propertyName = backendConfigurationPnDbContext.Properties
-                                    .First(x => x.Id == areaRulePlanningVersion.PropertyId).Name;
+                                var property = await backendConfigurationPnDbContext.Properties
+                                    .FirstOrDefaultAsync(x => x.Id == areaRulePlanningVersion.PropertyId);
+                                if (property == null)
+                                {
+                                    logger.LogWarning(
+                                        $"Could not find property with id {areaRulePlanningVersion.PropertyId} for planning {planningCase.PlanningId}");
+                                }
+
+                                propertyName = property?.Name ?? "";
                             }
                         }
 
@@ -737,8 +751,15 @@ public class BackendConfigurationReportService(
 
                         if (areaRulePlanning != null)
                         {
-                            propertyName = backendConfigurationPnDbContext.Properties
-                                .First(x => x.Id == areaRulePlanning.PropertyId).Name;
+                            var property = await backendConfigurationPnDbContext.Properties
+                                .FirstOrDefaultAsync(x => x.Id == areaRulePlanning.PropertyId);
+                            if (property == null)
+                            {
+                                logger.LogWarning(
+                                    $"Could not find property with id {areaRulePlanning.PropertyId} for planning {planningCase.PlanningId}");
+                            }
+
+                            propertyName = property?.Name ?? "";
                         }
                         else
                         {
@@ -750,8 +771,15 @@ public class BackendConfigurationReportService(
 
                             if (areaRulePlanningVersion != null)
                             {
-                                propertyName = backendConfigurationPnDbContext.Properties
-                                    .First(x => x.Id == areaRulePlanningVersion.PropertyId).Name;
+                                var property = await backendConfigurationPnDbContext.Properties
+                                    .FirstOrDefaultAsync(x => x.Id == areaRulePlanningVersion.PropertyId);
+                                if (property == null)
+                                {
+                                    logger.LogWarning(
+                                        $"Could not find property with id {areaRulePlanningVersion.PropertyId} for planning {planningCase.PlanningId}");
+                                }
+
+                                propertyName = property?.Name ?? "";
                             }
                         }
 


### PR DESCRIPTION
## Problem

Customer 879 could not generate a report for 2019-01-01 → 2026-07-30:

```
fail: BackendConfigurationReportService[0] Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.Execute[TResult](Expression query)
   at ...GenerateReport(GenerateReportModel model, Boolean isDocx)
```

(The `:line 519` in the trace is misleading — in the deployed build that line is `catch (Exception e)`, not the throw site.)

## Root cause

Both `GenerateReport` and `GenerateReportV2` resolved a planning case's property name with:

```csharp
propertyName = backendConfigurationPnDbContext.Properties
    .First(x => x.Id == areaRulePlanningVersion.PropertyId).Name;
```

When `PropertyId` has no matching `Properties` row this throws. Both methods wrap their entire body in a single `try/catch`, so **one bad row aborts the whole report**.

This is reachable with ordinary data:

- `AreaRulePlannings.ItemPlanningId` is mutated in place to `0` when a planning is unplanned (`BackendConfigurationAreaRulePlanningsServiceHelper.cs:146,735,878,914`), so historical plannings have no live row and always take the `AreaRulesPlanningVersions` fallback.
- Migration `20220101103446_AddingPropertyIdToAreaRulePlanning` added `PropertyId` as `nullable: false, defaultValue: 0` to **both** tables.
- The 2022-01-03 backfill set `PropertyId = 1` on live rows only. Version rows whose `ItemPlanningId` had already been zeroed before that backfill still carry `PropertyId = 0`.

Verified against a restored copy of 879's database: `ItemPlanningId` 5 and 6 resolve to a version row with `PropertyId = 0`, and `Properties` holds only `Id = 1`. Those two planning cases were completed **2021-12-08**, so every report whose range covered that day failed — which is why narrower ranges worked.

## Fix

`FirstOrDefaultAsync` + fall back to the blank `propertyName` the block already initialises, at all four sites (`GenerateReport` and `GenerateReportV2`, live-row and version-fallback branches each). The case still appears in the report with an empty property cell; `PropertyName` is display-only. A `LogWarning` keeps the underlying data problem visible instead of silently blanking it.

## Verification

- `dotnet build BackendConfiguration.Pn.csproj` → 0 errors, 92 warnings (byte-identical to the pre-change baseline)
- Simulated the code path in SQL over 879's data: exactly 2 of 124 completed cases hit the throw; both now degrade to a blank cell
- Reviewed by subagent — no Critical or Important issues. Confirmed the sync→async conversion is safe: both call sites sit inside `foreach (....ToList())` over materialized lists, and the statement immediately above each already awaits `FirstOrDefaultAsync` on the same DbContext

## Known follow-ups (not in this PR)

- `GenerateReportV2:758-767` dereferences `dbCase.SiteId` before its own null check at `:763`, plus `SiteWorkers.First(...)` and unguarded `worker.EmployeeNo` at `:785`
- `CheckListTranslations…First(x => x.LanguageId == language.Id)` and `Languages.Single(...)` are also synchronous and throw the identical message — the next suspects if 879 reports another failure
- The report service has no test coverage at all in either test project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9DDHNWkLapbuXHjFSqFt9
