### PR TITLE
feat(property-workers): add Shifts-across-midnight toggle to the worker modal

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationAssignmentWorkerServiceHelperTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationAssignmentWorkerServiceHelperTest.cs
@@ -538,6 +538,172 @@ public class BackendConfigurationAssignmentWorkerServiceHelperTest : TestBaseSet
         Assert.That(propertyWorkers.Count, Is.EqualTo(0));
     }
 
+    // Should test the CreateDeviceUser method with TimeRegistrationEnabled and OverMidnight set,
+    // verifying the flag passes through onto the created AssignedSite
+    [Test]
+    public async Task
+        BackendConfigurationAssignmentWorkerServiceHelper_CreateDeviceUser_TimeRegistrationEnabled_OverMidnight_ReturnsSuccess()
+    {
+        // Arrange
+        var core = await GetCore();
+
+        var deviceUserModel = new DeviceUserModel
+        {
+            CustomerNo = 0,
+            HasWorkOrdersAssigned = false,
+            IsBackendUser = false,
+            IsLocked = false,
+            LanguageCode = "da",
+            TimeRegistrationEnabled = true,
+            OverMidnight = true,
+            UserFirstName = Guid.NewGuid().ToString(),
+            UserLastName = Guid.NewGuid().ToString(),
+            WorkerEmail = $"{Guid.NewGuid()}@test.com"
+        };
+
+        // Act
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        var userManager = IdentityTestUtils.CreateRealUserManager(BaseDbContext!);
+
+        var result = await BackendConfigurationAssignmentWorkerServiceHelper.CreateDeviceUser(deviceUserModel, core, 1,
+            TimePlanningPnDbContext!, BaseDbContext!,
+        userService,
+        userManager);
+
+        // Assert
+        var sites = await MicrotingDbContext!.Sites.ToListAsync();
+        var timeregistrationSiteAssignments = await TimePlanningPnDbContext!.AssignedSites.ToListAsync();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(sites.Count, Is.EqualTo(3));
+
+        // Assert timeregistrationSiteAssignments
+        Assert.That(timeregistrationSiteAssignments.Count, Is.EqualTo(31));
+        Assert.That(timeregistrationSiteAssignments[30].SiteId, Is.EqualTo(sites[2].MicrotingUid));
+
+        // Newly-created AssignedSite must pass through OverMidnight from the DeviceUserModel
+        Assert.That(timeregistrationSiteAssignments[30].OverMidnight, Is.True);
+    }
+
+    // Should test the UpdateDeviceUser method with OverMidnight: the create-from-update path must
+    // pass the flag onto the new AssignedSite, a later update without the flag must clear it
+    [Test]
+    public async Task
+        BackendConfigurationAssignmentWorkerServiceHelper_UpdateDeviceUser_OverMidnight_PersistsAndClears()
+    {
+        // Arrange
+        var core = await GetCore();
+        var logger = Substitute.For<ILogger>();
+
+        var propertyCreateModel = new PropertyCreateModel
+        {
+            Address = Guid.NewGuid().ToString(),
+            Chr = Guid.NewGuid().ToString(),
+            IndustryCode = Guid.NewGuid().ToString(),
+            Cvr = Guid.NewGuid().ToString(),
+            IsFarm = true,
+            LanguagesIds = [1],
+            MainMailAddress = Guid.NewGuid().ToString(),
+            Name = Guid.NewGuid().ToString(),
+            WorkorderEnable = false
+        };
+
+        await BackendConfigurationPropertiesServiceHelper.Create(propertyCreateModel, core, 1,
+            BackendConfigurationPnDbContext!, ItemsPlanningPnDbContext!, 1, 1);
+
+        var deviceUserModel = new DeviceUserModel
+        {
+            CustomerNo = 0,
+            HasWorkOrdersAssigned = false,
+            IsBackendUser = false,
+            IsLocked = false,
+            LanguageCode = "da",
+            TimeRegistrationEnabled = false,
+            UserFirstName = Guid.NewGuid().ToString(),
+            UserLastName = Guid.NewGuid().ToString(),
+            WorkerEmail = $"{Guid.NewGuid()}@test.com"
+        };
+
+        // Act
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        var userManager = IdentityTestUtils.CreateRealUserManager(BaseDbContext!);
+
+        await BackendConfigurationAssignmentWorkerServiceHelper.CreateDeviceUser(deviceUserModel, core, 1,
+            TimePlanningPnDbContext!, BaseDbContext!,
+        userService,
+        userManager);
+
+        var currentSite = await MicrotingDbContext!.Sites.OrderByDescending(x => x.Id).FirstAsync();
+
+        // First update: enable time registration with OverMidnight set — the
+        // create-from-update path must carry the flag onto the new AssignedSite.
+        var newDeviceUserModel = new DeviceUserModel
+        {
+            SiteMicrotingUid = (int)currentSite.MicrotingUid!,
+            CustomerNo = 0,
+            HasWorkOrdersAssigned = false,
+            IsBackendUser = false,
+            IsLocked = false,
+            LanguageCode = "da",
+            TimeRegistrationEnabled = true,
+            OverMidnight = true,
+            UserFirstName = Guid.NewGuid().ToString(),
+            UserLastName = Guid.NewGuid().ToString(),
+            WorkerEmail = $"{Guid.NewGuid()}@test.com"
+        };
+
+        var result = await BackendConfigurationAssignmentWorkerServiceHelper.UpdateDeviceUser(newDeviceUserModel, core,
+            1,
+            userService,
+            userManager,
+            BackendConfigurationPnDbContext!,
+            TimePlanningPnDbContext!, BaseDbContext!, logger, ItemsPlanningPnDbContext!);
+
+        // Assert first update
+        var sites = await MicrotingDbContext!.Sites.AsNoTracking().ToListAsync();
+        var timeregistrationSiteAssignments = await TimePlanningPnDbContext!.AssignedSites.AsNoTracking().ToListAsync();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(timeregistrationSiteAssignments.Count, Is.EqualTo(31));
+        Assert.That(timeregistrationSiteAssignments[30].SiteId, Is.EqualTo(sites[2].MicrotingUid));
+        Assert.That(timeregistrationSiteAssignments[30].OverMidnight, Is.True);
+
+        // Second update: OverMidnight not set on the model — the existing
+        // AssignedSite update path must clear it (null coalesces to false).
+        var clearDeviceUserModel = new DeviceUserModel
+        {
+            SiteMicrotingUid = (int)currentSite.MicrotingUid!,
+            CustomerNo = 0,
+            HasWorkOrdersAssigned = false,
+            IsBackendUser = false,
+            IsLocked = false,
+            LanguageCode = "da",
+            TimeRegistrationEnabled = true,
+            UserFirstName = Guid.NewGuid().ToString(),
+            UserLastName = Guid.NewGuid().ToString(),
+            WorkerEmail = $"{Guid.NewGuid()}@test.com"
+        };
+
+        var clearResult = await BackendConfigurationAssignmentWorkerServiceHelper.UpdateDeviceUser(clearDeviceUserModel,
+            core,
+            1,
+            userService,
+            userManager,
+            BackendConfigurationPnDbContext!,
+            TimePlanningPnDbContext!, BaseDbContext!, logger, ItemsPlanningPnDbContext!);
+
+        // Assert second update
+        timeregistrationSiteAssignments = await TimePlanningPnDbContext!.AssignedSites.AsNoTracking().ToListAsync();
+
+        Assert.That(clearResult, Is.Not.Null);
+        Assert.That(timeregistrationSiteAssignments.Count, Is.EqualTo(31));
+        Assert.That(timeregistrationSiteAssignments[30].OverMidnight, Is.False);
+        // The sibling punch-clock flag must be unaffected by the OverMidnight writes
+        Assert.That(timeregistrationSiteAssignments[30].UsePunchClockWithAllowRegisteringInHistory, Is.False);
+    }
+
     // Should test the Create method and return success
     [Test]
     public async Task BackendConfigurationAssignmentWorkerServiceHelper_Create_ReturnsSuccess()

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationAssignmentWorkerServiceHelper.cs
@@ -803,6 +803,7 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                                     assignments.First().AllowEditOfRegistrations = deviceUserModel.AllowEditOfRegistrations ?? false;
                                     assignments.First().UsePunchClock = deviceUserModel.UsePunchClock ?? false;
                                     assignments.First().UsePunchClockWithAllowRegisteringInHistory = deviceUserModel.UsePunchClockWithAllowRegisteringInHistory ?? false;
+                                    assignments.First().OverMidnight = deviceUserModel.OverMidnight ?? false;
                                     assignments.First().AllowAcceptOfPlannedHours = deviceUserModel.AllowAcceptOfPlannedHours ?? false;
                                     assignments.First().DaysBackInTimeAllowedEditingEnabled = deviceUserModel.DaysBackInTimeAllowedEditingEnabled ?? false;
                                     assignments.First().DaysBackInTimeAllowedEditing = deviceUserModel.DaysBackInTimeAllowedEditing ?? 2;
@@ -855,6 +856,7 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                                         AllowEditOfRegistrations = deviceUserModel.AllowEditOfRegistrations ?? false,
                                         UsePunchClock = deviceUserModel.UsePunchClock ?? false,
                                         UsePunchClockWithAllowRegisteringInHistory = deviceUserModel.UsePunchClockWithAllowRegisteringInHistory ?? false,
+                                        OverMidnight = deviceUserModel.OverMidnight ?? false,
                                         AllowAcceptOfPlannedHours = deviceUserModel.AllowAcceptOfPlannedHours ?? false,
                                         DaysBackInTimeAllowedEditingEnabled = deviceUserModel.DaysBackInTimeAllowedEditingEnabled ?? false,
                                         DaysBackInTimeAllowedEditing = deviceUserModel.DaysBackInTimeAllowedEditing ?? 2,
@@ -1151,6 +1153,7 @@ public static class BackendConfigurationAssignmentWorkerServiceHelper
                             AllowEditOfRegistrations = deviceUserModel.AllowEditOfRegistrations ?? false,
                             UsePunchClock = deviceUserModel.UsePunchClock ?? false,
                             UsePunchClockWithAllowRegisteringInHistory = deviceUserModel.UsePunchClockWithAllowRegisteringInHistory ?? false,
+                            OverMidnight = deviceUserModel.OverMidnight ?? false,
                             AllowAcceptOfPlannedHours = deviceUserModel.AllowAcceptOfPlannedHours ?? false,
                             DaysBackInTimeAllowedEditingEnabled = deviceUserModel.DaysBackInTimeAllowedEditingEnabled ?? false,
                             DaysBackInTimeAllowedEditing = deviceUserModel.DaysBackInTimeAllowedEditing ?? 2,

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/DeviceUserModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/DeviceUserModel.cs
@@ -125,6 +125,7 @@ public class DeviceUserModel
     public bool? AllowEditOfRegistrations { get; set; }
     public bool? UsePunchClock { get; set; }
     public bool? UsePunchClockWithAllowRegisteringInHistory { get; set; }
+    public bool? OverMidnight { get; set; }
     public bool? AllowAcceptOfPlannedHours { get; set; }
     public bool? DaysBackInTimeAllowedEditingEnabled { get; set; }
     public int? DaysBackInTimeAllowedEditing { get; set; }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAssignmentWorkerService/BackendConfigurationAssignmentWorkerService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAssignmentWorkerService/BackendConfigurationAssignmentWorkerService.cs
@@ -484,6 +484,7 @@ public class BackendConfigurationAssignmentWorkerService(
                     deviceUserModel.AllowEditOfRegistrations = assignedSite.AllowEditOfRegistrations;
                     deviceUserModel.UsePunchClock = assignedSite.UsePunchClock;
                     deviceUserModel.UsePunchClockWithAllowRegisteringInHistory = assignedSite.UsePunchClockWithAllowRegisteringInHistory;
+                    deviceUserModel.OverMidnight = assignedSite.OverMidnight;
                     deviceUserModel.AllowAcceptOfPlannedHours = assignedSite.AllowAcceptOfPlannedHours;
                     deviceUserModel.DaysBackInTimeAllowedEditingEnabled = assignedSite.DaysBackInTimeAllowedEditingEnabled;
                     deviceUserModel.DaysBackInTimeAllowedEditing = assignedSite.DaysBackInTimeAllowedEditing;

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/property-worker-over-midnight.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/property-worker-over-midnight.spec.ts
@@ -39,8 +39,20 @@ const workerFullName = `${worker.name} ${worker.surname}`;
 
 async function openEditModal(page: Page): Promise<void> {
   const row = page.locator('.mat-mdc-row').filter({ hasText: workerFullName }).first();
-  await row.locator('#actionMenu').click();
-  await page.locator('[id^=editDeviceUserBtn]').click();
+  const editBtn = page.locator('[id^=editDeviceUserBtn]');
+  // A table refresh can re-render the row and close a just-opened action
+  // menu, so retry the menu open until the edit item is actually visible.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await row.locator('#actionMenu').click();
+    try {
+      await editBtn.waitFor({ state: 'visible', timeout: 5000 });
+      break;
+    } catch {
+      await page.keyboard.press('Escape');
+      await page.waitForTimeout(1000);
+    }
+  }
+  await editBtn.click();
   await expect(page.locator('form[data-form-ready]')).toHaveAttribute(
     'data-form-ready',
     'true',
@@ -111,6 +123,11 @@ test.describe.serial('Property-worker overMidnight toggle', () => {
         r.url().includes('/api/time-planning-pn/settings/assigned-site') &&
         r.request().method() === 'PUT'
     );
+    const indexPromise = page.waitForResponse(
+      r =>
+        r.url().includes('/api/backend-configuration-pn/properties/assignment/index-device-user') &&
+        r.request().method() === 'POST'
+    );
     await page.locator('#saveEditBtn').click();
     const updateDeviceUserResponse = await updateDeviceUserPromise;
     const assignedSiteResponse = await assignedSitePromise;
@@ -120,7 +137,11 @@ test.describe.serial('Property-worker overMidnight toggle', () => {
     expect(updateBody.overMidnight).toBe(true);
     const putBody = JSON.parse(assignedSiteResponse.request().postData() || '{}');
     expect(putBody.overMidnight).toBe(true);
+    // Wait for the post-save table refresh to finish before touching the row
+    // again — reopening the menu mid-refresh detaches it.
+    await indexPromise;
     await workersPage.newDeviceUserBtn().waitFor({ state: 'visible' });
+    await page.waitForTimeout(1000);
 
     // Round-trip: reopen and the value must have come back from the DB.
     await openEditModal(page);

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/property-worker-over-midnight.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/property-worker-over-midnight.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect, Page } from '@playwright/test';
+import { LoginPage } from '../../../Page objects/Login.page';
+import { generateRandmString } from '../../../helper-functions';
+import {
+  BackendConfigurationPropertiesPage,
+  PropertyCreateUpdate,
+} from '../BackendConfigurationProperties.page';
+import {
+  BackendConfigurationPropertyWorkersPage,
+  PropertyWorker,
+} from '../BackendConfigurationPropertyWorkers.page';
+
+// "Shifts across midnight" (overMidnight) in the property-worker edit modal.
+//
+// The AssignedSite.OverMidnight flag was already persisted by the
+// time-planning assigned-site dialog; this spec covers the same toggle in the
+// backend-configuration "edit worker" modal:
+// 1. It only renders as a sub-option of punch-clock mode.
+// 2. Saving persists it through both save calls (update-device-user POST and
+//    time-planning assigned-site PUT) and it survives a modal reopen.
+// 3. Leaving punch-clock mode hides AND clears it (no stale hidden value).
+
+const property: PropertyCreateUpdate = {
+  name: 'OverMidnight ' + generateRandmString(4),
+  chrNumber: generateRandmString(5),
+  address: generateRandmString(5),
+  cvrNumber: '1111111',
+};
+
+const worker: PropertyWorker = {
+  name: `Om${generateRandmString(4)}`,
+  surname: 'Midnight',
+  language: 'Dansk',
+  properties: [property.name],
+  workerEmail: generateRandmString(5) + '@test.com',
+  timeRegistrationEnabled: true,
+};
+const workerFullName = `${worker.name} ${worker.surname}`;
+
+async function openEditModal(page: Page): Promise<void> {
+  const row = page.locator('.mat-mdc-row').filter({ hasText: workerFullName }).first();
+  await row.locator('#actionMenu').click();
+  await page.locator('[id^=editDeviceUserBtn]').click();
+  await expect(page.locator('form[data-form-ready]')).toHaveAttribute(
+    'data-form-ready',
+    'true',
+    { timeout: 30000 }
+  );
+}
+
+async function openTimeRegistrationTab(page: Page): Promise<void> {
+  await page
+    .locator('mat-dialog-container .mat-mdc-tab')
+    .filter({ hasText: 'Timeregistrering' })
+    .first()
+    .click();
+  await page.waitForTimeout(500);
+}
+
+test.describe.serial('Property-worker overMidnight toggle', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4200');
+    await new LoginPage(page).login();
+    await page.waitForTimeout(3000);
+  });
+
+  test('seed: property and time-registration worker', async ({ page }) => {
+    test.setTimeout(600000);
+
+    const propertiesPage = new BackendConfigurationPropertiesPage(page);
+    await propertiesPage.goToProperties();
+    await propertiesPage.createProperty(property);
+
+    const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+    await workersPage.goToPropertyWorkers();
+    await workersPage.create(worker);
+    await expect(
+      page.locator('.mat-mdc-row').filter({ hasText: workerFullName })
+    ).toHaveCount(1);
+  });
+
+  test('overMidnight renders under punch clock only, persists, and clears on mode change', async ({ page }) => {
+    test.setTimeout(600000);
+
+    const workersPage = new BackendConfigurationPropertyWorkersPage(page);
+    await workersPage.goToPropertyWorkers();
+    await openEditModal(page);
+    await openTimeRegistrationTab(page);
+
+    // Turn on mobile time registration; default entry method is manual, so
+    // the punch-clock sub-options must not be rendered yet.
+    await page.locator('#allowPersonalTimeRegistration input').check();
+    await page.waitForTimeout(500);
+    await expect(page.locator('#overMidnight')).toHaveCount(0);
+
+    // Punch clock mode reveals the sub-option, unchecked by default.
+    await page.locator('#entryMethodPunchClock input').check();
+    await page.waitForTimeout(500);
+    await expect(page.locator('#overMidnight')).toBeVisible();
+    await expect(page.locator('#overMidnight input')).not.toBeChecked();
+
+    // Check it and save; both persistence calls must succeed.
+    await page.locator('#overMidnight input').check();
+    const updateDeviceUserPromise = page.waitForResponse(
+      r =>
+        r.url().includes('/api/backend-configuration-pn/properties/assignment/update-device-user') &&
+        r.request().method() === 'POST'
+    );
+    const assignedSitePromise = page.waitForResponse(
+      r =>
+        r.url().includes('/api/time-planning-pn/settings/assigned-site') &&
+        r.request().method() === 'PUT'
+    );
+    await page.locator('#saveEditBtn').click();
+    const updateDeviceUserResponse = await updateDeviceUserPromise;
+    const assignedSiteResponse = await assignedSitePromise;
+    expect(updateDeviceUserResponse.status()).toBe(200);
+    expect(assignedSiteResponse.status()).toBe(200);
+    const updateBody = JSON.parse(updateDeviceUserResponse.request().postData() || '{}');
+    expect(updateBody.overMidnight).toBe(true);
+    const putBody = JSON.parse(assignedSiteResponse.request().postData() || '{}');
+    expect(putBody.overMidnight).toBe(true);
+    await workersPage.newDeviceUserBtn().waitFor({ state: 'visible' });
+
+    // Round-trip: reopen and the value must have come back from the DB.
+    await openEditModal(page);
+    await openTimeRegistrationTab(page);
+    await expect(page.locator('#entryMethodPunchClock input')).toBeChecked();
+    await expect(page.locator('#overMidnight input')).toBeChecked();
+
+    // Leaving punch clock hides the sub-option; returning shows it cleared.
+    await page.locator('#entryMethodManual input').check();
+    await page.waitForTimeout(500);
+    await expect(page.locator('#overMidnight')).toHaveCount(0);
+    await page.locator('#entryMethodAcceptPlanned input').check();
+    await page.waitForTimeout(500);
+    await expect(page.locator('#overMidnight')).toHaveCount(0);
+    await page.locator('#entryMethodPunchClock input').check();
+    await page.waitForTimeout(500);
+    await expect(page.locator('#overMidnight input')).not.toBeChecked();
+
+    await page.locator('#cancelEditBtn').click();
+    await workersPage.newDeviceUserBtn().waitFor({ state: 'visible' });
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -327,6 +327,8 @@ export const bgBG = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Планираните работни часове могат да бъдат одобрени с едно щракване. Планираните работни часове не могат да бъдат редактирани.',
   'Allow entry of forgotten days': 'Позволете въвеждане на забравени дни',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Служителят може да регистрира със задна дата работните часове, за които е забравил да се яви/напусне.',
+  'Shifts across midnight': 'Смени през полунощ',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Смяната се затваря автоматично в 00:00 и продължава като нова регистрация на следващия ден (напр. ден 1: 22:00–00:00, ден 2: 00:00–06:00). Приложението обработва това автоматично.',
   'May the employee edit past registrations?': 'Може ли служителят да редактира минали регистрации?',
   'No editing allowed': 'Редактирането не е разрешено',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'След като регистрацията бъде запазена, служителят вече не може да я променя. Грешките трябва да бъдат коригирани от мениджър.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -327,6 +327,8 @@ export const csCZ = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Naplánovanou pracovní dobu lze schválit jediným kliknutím. Naplánovanou pracovní dobu nelze upravovat.',
   'Allow entry of forgotten days': 'Povolit zadávání zapomenutých dnů',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Zaměstnanec si může zpětně zaregistrovat pracovní dobu, na kterou se zapomněl přihlásit/odhlásit.',
+  'Shifts across midnight': 'Směny přes půlnoc',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Směna se automaticky uzavře v 00:00 a pokračuje jako nová registrace následující den (např. den 1: 22:00–00:00, den 2: 00:00–06:00). Aplikace to řeší automaticky.',
   'May the employee edit past registrations?': 'Může zaměstnanec upravovat minulé registrace?',
   'No editing allowed': 'Úpravy nejsou povoleny',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Jakmile je registrace uložena, zaměstnanec ji již nemůže změnit. Chyby musí opravit manažer.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -333,6 +333,8 @@ export const da = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Planlagte arbejdstider kan godkendes med et enkelt klik. Planlagte arbejdstider kan ikke redigeres.',
   'Allow entry of forgotten days': 'Tillad indtastning af glemte dage',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Medarbejderen kan med tilbagevirkende kraft registrere arbejdstimer, de har glemt at stemple ind/ud på.',
+  'Shifts across midnight': 'Vagter over midnat',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Vagten lukkes automatisk kl. 00:00 og fortsætter som en ny registrering næste dag (fx dag 1: 22:00–00:00, dag 2: 00:00–06:00). Appen håndterer dette automatisk.',
   'May the employee edit past registrations?': 'Må medarbejderen redigere tidligere registreringer?',
   'No editing allowed': 'Ingen redigering tilladt',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Når en registrering er gemt, kan medarbejderen ikke længere ændre den. Fejl skal rettes af en leder.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -388,6 +388,8 @@ export const deDE = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Geplante Arbeitszeiten können mit einem Klick genehmigt werden. Geplante Arbeitszeiten können nicht bearbeitet werden.',
   'Allow entry of forgotten days': 'Erlauben Sie die Eingabe vergessener Tage',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Der Mitarbeiter kann Arbeitsstunden, die er beim Ein- und Ausstempeln vergessen hat, nachträglich erfassen.',
+  'Shifts across midnight': 'Schichten über Mitternacht',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Die Schicht wird um 00:00 Uhr automatisch geschlossen und am nächsten Tag als neue Registrierung fortgesetzt (z. B. Tag 1: 22:00–00:00, Tag 2: 00:00–06:00). Die App übernimmt dies automatisch.',
   'May the employee edit past registrations?': 'Darf der Mitarbeiter frühere Registrierungen bearbeiten?',
   'No editing allowed': 'Keine Bearbeitung erlaubt',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Sobald eine Registrierung gespeichert ist, kann der Mitarbeiter sie nicht mehr ändern. Fehler müssen von einem Vorgesetzten korrigiert werden.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -327,6 +327,8 @@ export const elGR = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Οι προγραμματισμένες ώρες εργασίας μπορούν να εγκριθούν με ένα μόνο κλικ. Δεν είναι δυνατή η επεξεργασία των προγραμματισμένων ωρών εργασίας.',
   'Allow entry of forgotten days': 'Επιτρέψτε την εισαγωγή ξεχασμένων ημερών',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Ο εργαζόμενος μπορεί να καταχωρίσει αναδρομικά τις ώρες εργασίας που ξέχασε να καταχωρίσει.',
+  'Shifts across midnight': 'Βάρδιες που περνούν τα μεσάνυχτα',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Η βάρδια κλείνει αυτόματα στις 00:00 και συνεχίζεται ως νέα καταχώριση την επόμενη ημέρα (π.χ. ημέρα 1: 22:00–00:00, ημέρα 2: 00:00–06:00). Η εφαρμογή το χειρίζεται αυτόματα.',
   'May the employee edit past registrations?': 'Μπορεί ο εργαζόμενος να επεξεργαστεί προηγούμενες εγγραφές;',
   'No editing allowed': 'Δεν επιτρέπεται η επεξεργασία',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Μόλις αποθηκευτεί μια εγγραφή, ο εργαζόμενος δεν μπορεί πλέον να την αλλάξει. Τα σφάλματα πρέπει να διορθώνονται από έναν διευθυντή.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -353,6 +353,8 @@ export const enUS= {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.',
   'Allow entry of forgotten days': 'Allow entry of forgotten days',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'The employee can retroactively register work hours they forgot to clock in/out on.',
+  'Shifts across midnight': 'Shifts across midnight',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.',
   'May the employee edit past registrations?': 'May the employee edit past registrations?',
   'No editing allowed': 'No editing allowed',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -327,6 +327,8 @@ export const esES = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Las horas de trabajo programadas se pueden aprobar con un solo clic. Las horas de trabajo programadas no se pueden editar.',
   'Allow entry of forgotten days': 'Permitir la entrada de días olvidados',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'El empleado puede registrar retroactivamente las horas de trabajo que olvidó fichar al entrar o al salir.',
+  'Shifts across midnight': 'Turnos que cruzan la medianoche',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'El turno se cierra automáticamente a las 00:00 y continúa como un nuevo registro al día siguiente (p. ej., día 1: 22:00–00:00, día 2: 00:00–06:00). La aplicación lo gestiona automáticamente.',
   'May the employee edit past registrations?': '¿Puede el empleado editar registros anteriores?',
   'No editing allowed': 'No se permite la edición.',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Una vez guardado un registro, el empleado ya no puede modificarlo. Los errores deben ser corregidos por un supervisor.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -327,6 +327,8 @@ export const etET = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Planeeritud tööaega saab kinnitada ühe klõpsuga. Planeeritud tööaega ei saa muuta.',
   'Allow entry of forgotten days': 'Unustatud päevade sisestamise lubamine',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Töötaja saab tagasiulatuvalt registreerida töötunde, mille registreerimine ununeb.',
+  'Shifts across midnight': 'Vahetused üle kesköö',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Vahetus suletakse automaatselt kell 00:00 ja jätkub uue registreeringuna järgmisel päeval (nt päev 1: 22:00–00:00, päev 2: 00:00–06:00). Rakendus haldab seda automaatselt.',
   'May the employee edit past registrations?': 'Kas töötaja saab varasemaid registreeringuid muuta?',
   'No editing allowed': 'Redigeerimine pole lubatud',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Kui registreering on salvestatud, ei saa töötaja seda enam muuta. Vead peab parandama juht.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -327,6 +327,8 @@ export const fiFI = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Suunnitellut työajat voidaan hyväksyä yhdellä napsautuksella. Suunniteltuja työaikoja ei voi muokata.',
   'Allow entry of forgotten days': 'Salli unohdettujen päivien syöttö',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Työntekijä voi jälkikäteen rekisteröidä työtunnit, jotka hän on unohtanut tehdä sisään-/uloskirjautumisen yhteydessä.',
+  'Shifts across midnight': 'Keskiyön yli ulottuvat vuorot',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Vuoro suljetaan automaattisesti klo 00:00 ja se jatkuu uutena kirjauksena seuraavana päivänä (esim. päivä 1: 22:00–00:00, päivä 2: 00:00–06:00). Sovellus hoitaa tämän automaattisesti.',
   'May the employee edit past registrations?': 'Voiko työntekijä muokata aiempia ilmoittautumisiaan?',
   'No editing allowed': 'Muokkaus kielletty',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Kun rekisteröinti on tallennettu, työntekijä ei voi enää muuttaa sitä. Esimiehen on korjattava virheet.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -423,6 +423,8 @@ export const frFR = {
   'Allow receipt for standard time on mobile': 'Autoriser la réception pour l&#39;heure standard sur mobile',
   'Allow entry of forgotten days': 'Autoriser l&#39;entrée des jours oubliés',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'L&#39;employé peut enregistrer rétroactivement les heures de travail qu&#39;il a oublié de pointer à l&#39;arrivée ou au départ.',
+  'Shifts across midnight': 'Postes à cheval sur minuit',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Le poste est automatiquement clôturé à 00:00 et continue comme un nouvel enregistrement le jour suivant (par ex. jour 1 : 22:00–00:00, jour 2 : 00:00–06:00). L&#39;application gère cela automatiquement.',
   'May the employee edit past registrations?': 'L&#39;employé peut-il modifier les inscriptions précédentes ?',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Une fois l&#39;inscription enregistrée, l&#39;employé ne peut plus la modifier. Les erreurs doivent être corrigées par un responsable.',
   'Yes, until the last payroll run': 'Oui, jusqu&#39;au dernier traitement de la paie',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -327,6 +327,8 @@ export const hrHR = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Planirano radno vrijeme može se odobriti jednim klikom. Planirano radno vrijeme ne može se uređivati.',
   'Allow entry of forgotten days': 'Dopusti unos zaboravljenih dana',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Zaposlenik može retroaktivno prijaviti radne sate koje je zaboravio prijaviti/odjaviti.',
+  'Shifts across midnight': 'Smjene preko ponoći',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Smjena se automatski zatvara u 00:00 i nastavlja kao nova registracija sljedećeg dana (npr. dan 1: 22:00–00:00, dan 2: 00:00–06:00). Aplikacija to obrađuje automatski.',
   'May the employee edit past registrations?': 'Može li zaposlenik uređivati prethodne registracije?',
   'No editing allowed': 'Uređivanje nije dopušteno',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Nakon što je registracija spremljena, zaposlenik je više ne može mijenjati. Pogreške mora ispraviti voditelj.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -327,6 +327,8 @@ export const huHU = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'A beütemezett munkaórák egyetlen kattintással jóváhagyhatók. A beütemezett munkaórák nem szerkeszthetők.',
   'Allow entry of forgotten days': 'Elfeledett napok bevitelének engedélyezése',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'A munkavállaló visszamenőlegesen regisztrálhatja azokat a munkaórákat, amelyeket elfelejtett be- és kijelentkezni.',
+  'Shifts across midnight': 'Éjfélen átnyúló műszakok',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'A műszak automatikusan lezárul 00:00-kor, és új regisztrációként folytatódik a következő napon (pl. 1. nap: 22:00–00:00, 2. nap: 00:00–06:00). Az alkalmazás ezt automatikusan kezeli.',
   'May the employee edit past registrations?': 'Módosíthatja-e a munkavállaló a korábbi regisztrációit?',
   'No editing allowed': 'Szerkesztés nem engedélyezett',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'A regisztráció mentése után az alkalmazott már nem módosíthatja azt. A hibákat a vezetőnek kell kijavítania.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -327,6 +327,8 @@ export const isIS = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Hægt er að samþykkja áætlaða vinnutíma með einum smelli. Ekki er hægt að breyta áætluðum vinnutíma.',
   'Allow entry of forgotten days': 'Leyfa innslátt gleymdra daga',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Starfsmaðurinn getur skráð vinnutíma sem hann gleymdi að stimpla sig inn/út fyrir afturvirkt.',
+  'Shifts across midnight': 'Vaktir yfir miðnætti',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Vaktinni er sjálfkrafa lokað kl. 00:00 og heldur áfram sem ný skráning næsta dag (t.d. dagur 1: 22:00–00:00, dagur 2: 00:00–06:00). Appið sér um þetta sjálfkrafa.',
   'May the employee edit past registrations?': 'Má starfsmaður breyta fyrri skráningum?',
   'No editing allowed': 'Engin ritstjórn leyfð',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Þegar skráning hefur verið vistuð getur starfsmaður ekki lengur breytt henni. Villur verða að vera leiðréttar af stjórnanda.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -314,6 +314,8 @@ export const itIT = {
   'Manual entry': 'Inserimento manuale',
   'Start/Stop buttons record work and breaks automatically as the day progresses.': 'I pulsanti Avvia/Arresta registrano automaticamente il lavoro e le pause durante la giornata.',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Il dipendente può registrare retroattivamente le ore di lavoro che si era dimenticato di timbrare in entrata o in uscita.',
+  'Shifts across midnight': 'Turni a cavallo della mezzanotte',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Il turno viene chiuso automaticamente alle 00:00 e continua come nuova registrazione il giorno successivo (ad es. giorno 1: 22:00–00:00, giorno 2: 00:00–06:00). L&#39;app gestisce tutto questo automaticamente.',
   'May the employee edit past registrations?': 'Il dipendente può modificare le registrazioni precedenti?',
   'No editing allowed': 'Modifica vietata',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Una volta salvata la registrazione, il dipendente non può più modificarla. Gli errori devono essere corretti da un responsabile.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -327,6 +327,8 @@ export const ltLT = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Suplanuotas darbo valandas galima patvirtinti vienu spustelėjimu. Suplanuotų darbo valandų redaguoti negalima.',
   'Allow entry of forgotten days': 'Leisti įrašyti pamirštas dienas',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Darbuotojas gali atgaline data užregistruoti darbo valandas, kurias pamiršo užregistruoti.',
+  'Shifts across midnight': 'Pamainos per vidurnaktį',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Pamaina automatiškai uždaroma 00:00 val. ir tęsiama kaip nauja registracija kitą dieną (pvz., 1 diena: 22:00–00:00, 2 diena: 00:00–06:00). Programėlė tai tvarko automatiškai.',
   'May the employee edit past registrations?': 'Ar darbuotojas gali redaguoti ankstesnes registracijas?',
   'No editing allowed': 'Redaguoti draudžiama',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Įrašius registraciją, darbuotojas jos nebegali keisti. Klaidas turi ištaisyti vadovas.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -327,6 +327,8 @@ export const lvLV = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Plānotās darba stundas var apstiprināt ar vienu klikšķi. Plānotās darba stundas nevar rediģēt.',
   'Allow entry of forgotten days': 'Atļaut aizmirsto dienu ievadīšanu',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Darbinieks var retrospektīvi reģistrēt darba stundas, kuras viņš ir aizmirsis reģistrēt.',
+  'Shifts across midnight': 'Maiņas pāri pusnaktij',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Maiņa tiek automātiski slēgta plkst. 00:00 un turpinās kā jauna reģistrācija nākamajā dienā (piem., 1. diena: 22:00–00:00, 2. diena: 00:00–06:00). Lietotne to apstrādā automātiski.',
   'May the employee edit past registrations?': 'Vai darbinieks drīkst rediģēt iepriekšējās reģistrācijas?',
   'No editing allowed': 'Rediģēšana nav atļauta',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Kad reģistrācija ir saglabāta, darbinieks to vairs nevar mainīt. Kļūdas ir jālabo vadītājam.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -326,6 +326,8 @@ export const nlNL = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Geplande werkuren kunnen met één klik worden goedgekeurd. Geplande werkuren kunnen niet worden gewijzigd.',
   'Allow entry of forgotten days': 'Sta invoer van vergeten dagen toe.',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'De werknemer kan de gewerkte uren die hij of zij vergeten is in/uit te klokken, alsnog registreren.',
+  'Shifts across midnight': 'Diensten over middernacht',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'De dienst wordt automatisch afgesloten om 00:00 uur en gaat de volgende dag verder als een nieuwe registratie (bijv. dag 1: 22:00–00:00, dag 2: 00:00–06:00). De app regelt dit automatisch.',
   'May the employee edit past registrations?': 'Mag de medewerker eerdere registraties wijzigen?',
   'No editing allowed': 'Bewerken is niet toegestaan.',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Zodra een registratie is opgeslagen, kan de medewerker deze niet meer wijzigen. Fouten moeten door een manager worden gecorrigeerd.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -329,6 +329,8 @@ export const noNO = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Planlagte arbeidstider kan godkjennes med et enkelt klikk. Planlagte arbeidstider kan ikke redigeres.',
   'Allow entry of forgotten days': 'Tillat inntasting av glemte dager',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Den ansatte kan med tilbakevirkende kraft registrere arbeidstimer de har glemt å stemple inn/ut på.',
+  'Shifts across midnight': 'Vakter over midnatt',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Vakten avsluttes automatisk kl. 00:00 og fortsetter som en ny registrering neste dag (f.eks. dag 1: 22:00–00:00, dag 2: 00:00–06:00). Appen håndterer dette automatisk.',
   'May the employee edit past registrations?': 'Kan den ansatte redigere tidligere registreringer?',
   'No editing allowed': 'Ingen redigering tillatt',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Når en registrering er lagret, kan ikke den ansatte lenger endre den. Feil må rettes av en leder.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -327,6 +327,8 @@ export const plPL = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Zaplanowane godziny pracy można zatwierdzić jednym kliknięciem. Zaplanowanych godzin pracy nie można edytować.',
   'Allow entry of forgotten days': 'Zezwól na wprowadzanie zapomnianych dni',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Pracownik może wstecznie rejestrować godziny pracy, których rozpoczęcia i zakończenia zapomniał zarejestrować.',
+  'Shifts across midnight': 'Zmiany przechodzące przez północ',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Zmiana jest automatycznie zamykana o 00:00 i kontynuowana jako nowa rejestracja następnego dnia (np. dzień 1: 22:00–00:00, dzień 2: 00:00–06:00). Aplikacja obsługuje to automatycznie.',
   'May the employee edit past registrations?': 'Czy pracownik może edytować wcześniejsze rejestracje?',
   'No editing allowed': 'Edycja niedozwolona',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Po zapisaniu rejestracji pracownik nie może jej już zmienić. Błędy musi poprawić kierownik.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -327,6 +327,8 @@ export const ptBR = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'O horário de trabalho agendado pode ser aprovado com um único clique. O horário de trabalho agendado não pode ser editado.',
   'Allow entry of forgotten days': 'Permitir a entrada de dias esquecidos',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'O funcionário pode registrar retroativamente as horas de trabalho que esqueceu de registrar a entrada/saída.',
+  'Shifts across midnight': 'Turnos que atravessam a meia-noite',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'O turno é encerrado automaticamente às 00:00 e continua como um novo registro no dia seguinte (por ex. dia 1: 22:00–00:00, dia 2: 00:00–06:00). O aplicativo cuida disso automaticamente.',
   'May the employee edit past registrations?': 'O funcionário pode editar cadastros anteriores?',
   'No editing allowed': 'Não é permitida a edição.',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Uma vez salvo o cadastro, o funcionário não poderá mais alterá-lo. Erros devem ser corrigidos por um gerente.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -327,6 +327,8 @@ export const ptPT = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'O horário de trabalho agendado pode ser aprovado com um único clique. O horário de trabalho agendado não pode ser editado.',
   'Allow entry of forgotten days': 'Permitir a entrada de dias esquecidos',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'O funcionário pode registrar retroativamente as horas de trabalho que esqueceu de registrar a entrada/saída.',
+  'Shifts across midnight': 'Turnos que atravessam a meia-noite',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'O turno é encerrado automaticamente às 00:00 e continua como um novo registo no dia seguinte (por ex. dia 1: 22:00–00:00, dia 2: 00:00–06:00). A aplicação trata disto automaticamente.',
   'May the employee edit past registrations?': 'O funcionário pode editar cadastros anteriores?',
   'No editing allowed': 'Não é permitida a edição.',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Uma vez salvo o cadastro, o funcionário não poderá mais alterá-lo. Erros devem ser corrigidos por um gerente.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -327,6 +327,8 @@ export const roRO = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Orele de lucru programate pot fi aprobate cu un singur clic. Orele de lucru programate nu pot fi editate.',
   'Allow entry of forgotten days': 'Permiteți introducerea zilelor uitate',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Angajatul poate înregistra retroactiv orele de lucru pentru care a uitat să le înregistreze.',
+  'Shifts across midnight': 'Ture care trec de miezul nopții',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Tura se închide automat la 00:00 și continuă ca o nouă înregistrare în ziua următoare (de ex. ziua 1: 22:00–00:00, ziua 2: 00:00–06:00). Aplicația gestionează acest lucru automat.',
   'May the employee edit past registrations?': 'Poate angajatul să modifice înregistrările anterioare?',
   'No editing allowed': 'Nu este permisă editarea',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Odată ce o înregistrare este salvată, angajatul nu o mai poate modifica. Erorile trebuie corectate de către un manager.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -327,6 +327,8 @@ export const skSK = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Naplánovaný pracovný čas je možné schváliť jedným kliknutím. Naplánovaný pracovný čas nie je možné upravovať.',
   'Allow entry of forgotten days': 'Povoliť zadanie zabudnutých dní',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Zamestnanec si môže spätne zaregistrovať pracovné hodiny, na ktoré zabudol prísť/odísť.',
+  'Shifts across midnight': 'Zmeny cez polnoc',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Zmena sa automaticky uzavrie o 00:00 a pokračuje ako nová registrácia nasledujúci deň (napr. deň 1: 22:00–00:00, deň 2: 00:00–06:00). Aplikácia to rieši automaticky.',
   'May the employee edit past registrations?': 'Môže zamestnanec upravovať predchádzajúce registrácie?',
   'No editing allowed': 'Úpravy nie sú povolené',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Po uložení registrácie ju zamestnanec už nemôže zmeniť. Chyby musí opraviť manažér.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -327,6 +327,8 @@ export const slSL = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Načrtovane delovne ure je mogoče odobriti z enim samim klikom. Načrtovanih delovnih ur ni mogoče urejati.',
   'Allow entry of forgotten days': 'Dovoli vnos pozabljenih dni',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Zaposleni lahko retroaktivno prijavi delovne ure, ki jih je pozabil prijaviti/odjaviti.',
+  'Shifts across midnight': 'Izmene čez polnoč',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Izmena se samodejno zapre ob 00:00 in se nadaljuje kot nova registracija naslednji dan (npr. dan 1: 22:00–00:00, dan 2: 00:00–06:00). Aplikacija to obravnava samodejno.',
   'May the employee edit past registrations?': 'Ali lahko zaposleni ureja pretekle registracije?',
   'No editing allowed': 'Urejanje ni dovoljeno',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Ko je registracija shranjena, je zaposleni ne more več spreminjati. Napake mora popraviti vodja.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -329,6 +329,8 @@ export const svSE = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Schemalagda arbetstider kan godkännas med ett enda klick. Schemalagda arbetstider kan inte redigeras.',
   'Allow entry of forgotten days': 'Tillåt inmatning av glömda dagar',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Medarbetaren kan retroaktivt registrera arbetstimmar som de glömt att stämpla in/ut på.',
+  'Shifts across midnight': 'Skift över midnatt',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Skiftet stängs automatiskt kl. 00:00 och fortsätter som en ny registrering nästa dag (t.ex. dag 1: 22:00–00:00, dag 2: 00:00–06:00). Appen hanterar detta automatiskt.',
   'May the employee edit past registrations?': 'Får den anställde redigera tidigare registreringar?',
   'No editing allowed': 'Ingen redigering tillåten',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'När en registrering har sparats kan medarbetaren inte längre ändra den. Fel måste korrigeras av en chef.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -323,6 +323,8 @@ export const ukUA = {
   'Scheduled working hours can be approved with a single click. Scheduled working hours cannot be edited.': 'Запланований робочий час можна затвердити одним клацанням миші. Запланований робочий час не можна редагувати.',
   'Allow entry of forgotten days': 'Дозволити введення забутих днів',
   'The employee can retroactively register work hours they forgot to clock in/out on.': 'Працівник може заднім числом зареєструвати робочі години, в які він забув прийти/вийти.',
+  'Shifts across midnight': 'Зміни через північ',
+  'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.': 'Зміна автоматично закривається о 00:00 і продовжується як нова реєстрація наступного дня (напр. день 1: 22:00–00:00, день 2: 00:00–06:00). Застосунок обробляє це автоматично.',
   'May the employee edit past registrations?': 'Чи може працівник редагувати попередні реєстрації?',
   'No editing allowed': 'Редагування заборонено',
   'Once a registration is saved, the employee can no longer change it. Errors must be corrected by a manager.': 'Після збереження реєстрації працівник більше не може її змінити. Помилки має виправити керівник.',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.html
@@ -350,6 +350,18 @@
                       </div>
                     </mat-checkbox>
                   </div>
+
+                  <!-- Sub-option under punch clock -->
+                  <div class="sub-option" *ngIf="form.value.usePunchClock">
+                    <mat-checkbox class="p-1"
+                                  id="overMidnight"
+                                  formControlName="overMidnight">
+                      <div>
+                        <div>{{ 'Shifts across midnight' | translate }}</div>
+                        <small class="checkbox-description">{{ 'The shift is automatically closed at 00:00 and continues as a new registration on the next day (e.g. day 1: 22:00–00:00, day 2: 00:00–06:00). The app handles this automatically.' | translate }}</small>
+                      </div>
+                    </mat-checkbox>
+                  </div>
                 </div>
 
                 <!-- Axis 2: Editing policy (not applicable under "accept planned hours" mode) -->

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.ts
@@ -239,6 +239,7 @@ export class PropertyWorkerCreateEditModalComponent implements OnInit, OnDestroy
       allowEditOfRegistrations: false,
       usePunchClock: false,
       usePunchClockWithAllowRegisteringInHistory: false,
+      overMidnight: false,
       allowAcceptOfPlannedHours: false,
       daysBackInTimeAllowedEditingEnabled: false,
       daysBackInTimeAllowedEditing: 2,
@@ -289,6 +290,7 @@ export class PropertyWorkerCreateEditModalComponent implements OnInit, OnDestroy
               allowEditOfRegistrations: this.selectedAssignedSite.allowEditOfRegistrations || false,
               usePunchClock: this.selectedAssignedSite.usePunchClock || false,
               usePunchClockWithAllowRegisteringInHistory: this.selectedAssignedSite.usePunchClockWithAllowRegisteringInHistory || false,
+              overMidnight: this.selectedAssignedSite.overMidnight || false,
               allowAcceptOfPlannedHours: this.selectedAssignedSite.allowAcceptOfPlannedHours || false,
               daysBackInTimeAllowedEditingEnabled: this.selectedAssignedSite.daysBackInTimeAllowedEditingEnabled || false,
               daysBackInTimeAllowedEditing: this.selectedAssignedSite.daysBackInTimeAllowedEditing || 2,
@@ -821,6 +823,7 @@ export class PropertyWorkerCreateEditModalComponent implements OnInit, OnDestroy
     // The "allow entry of forgotten days" sub-option only makes sense under punch clock
     if (!punch) {
       patch.usePunchClockWithAllowRegisteringInHistory = false;
+      patch.overMidnight = false;
     }
     this.form.patchValue(patch, { emitEvent: opts.emitEvent !== false });
   }


### PR DESCRIPTION
## What

Adds the **"Vagter over midnat" / Shifts-across-midnight** checkbox to the backend-configuration property-worker create/edit modal, as a punch-clock sub-option directly below "Allow entry of forgotten days" — mirroring the existing toggle in the time-planning assigned-site dialog.

The underlying `AssignedSite.OverMidnight` column and the time-planning `assigned-site` PUT already existed (Microting.TimePlanningBase 10.0.56); this PR only surfaces the toggle in the BC modal and carries it through the BC save paths. No base changes, no migrations.

## Changes

- **Frontend modal**: `overMidnight` form control (default / load-patch from assigned site / cleared on leaving punch-clock mode) + sub-option checkbox gated on `usePunchClock`
- **i18n**: the two existing keys copied per-locale from time-planning-pn into all 26 BC locale files (real translations, no MT)
- **Backend**: `OverMidnight` on `DeviceUserModel` + all three `BackendConfigurationAssignmentWorkerServiceHelper` write paths + read-back, exactly mirroring `UsePunchClockWithAllowRegisteringInHistory` — this makes the **create**-worker flow persist the flag too (the assigned-site PUT only fires on edit)

## Tests

- **Integration** (`BackendConfigurationAssignmentWorkerServiceHelperTest`): CreateDeviceUser pass-through, create-from-update pass-through, clear-on-update (plus sibling-flag isolation assert)
- **Playwright e2e** (shard `r`): renders under punch clock only, persists through both save calls with request-body asserts, survives modal reopen, hidden+cleared under manual and accept-planned modes

## Verified locally

Full-solution build clean; manually verified in the browser: checkbox appears/persists/round-trips for an existing worker, and both save endpoints return 200 with `overMidnight` in the payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)