### PR TITLE
fix(adhoc): include user-scoped tags in dashboard tag list

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceReferenceDataTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceReferenceDataTests.cs
@@ -301,6 +301,53 @@ public class AdhocServiceReferenceDataTests : TestBaseSetup
     }
 
     [Test]
+    public async Task ListTags_IsAdmin_ReturnsEveryWorkersPersonalTags()
+    {
+        // Regression for microting/flutter-adhoc#43: a tag created on mobile
+        // (gRPC CreateTag, always OwnerWorkerId = the caller's real SDK site
+        // id) must be visible to a dashboard admin's Etiketter list, which
+        // queries through the synthetic DashboardWorkerId (0) - a worker id
+        // no mobile-created tag is ever owned by.
+        var globalTag = new AdhocTag { Name = "global" };
+        await globalTag.Create(BackendConfigurationPnDbContext!);
+        var mobileTagWorkerOne = new AdhocTag { Name = "mobile-one", OwnerWorkerId = 1 };
+        await mobileTagWorkerOne.Create(BackendConfigurationPnDbContext!);
+        var mobileTagWorkerTwo = new AdhocTag { Name = "mobile-two", OwnerWorkerId = 2 };
+        await mobileTagWorkerTwo.Create(BackendConfigurationPnDbContext!);
+
+        var sut = CreateSut();
+
+        // DashboardWorkerId (0), mirroring AdhocController.ListTags.
+        var result = await sut.ListTags(0, isAdmin: true);
+
+        Assert.That(
+            result.Select(t => t.Id),
+            Is.EquivalentTo(new[] { globalTag.Id, mobileTagWorkerOne.Id, mobileTagWorkerTwo.Id }));
+        Assert.That(result.Single(t => t.Id == globalTag.Id).IsUserTag, Is.False);
+        Assert.That(result.Single(t => t.Id == mobileTagWorkerOne.Id).IsUserTag, Is.True);
+        Assert.That(result.Single(t => t.Id == mobileTagWorkerTwo.Id).IsUserTag, Is.True);
+    }
+
+    [Test]
+    public async Task ListTags_NonAdmin_DashboardWorkerId_OnlySeesGlobalTags()
+    {
+        // Documents the chosen policy: non-admin dashboard callers keep the
+        // pre-fix "global tags only" view. DashboardWorkerId (0) owns
+        // nothing, so this is unchanged behavior, not a new restriction.
+        var globalTag = new AdhocTag { Name = "global" };
+        await globalTag.Create(BackendConfigurationPnDbContext!);
+        var mobileTag = new AdhocTag { Name = "mobile-one", OwnerWorkerId = 1 };
+        await mobileTag.Create(BackendConfigurationPnDbContext!);
+
+        var sut = CreateSut();
+
+        var result = await sut.ListTags(0);
+
+        Assert.That(result.Select(t => t.Id), Is.EquivalentTo(new[] { globalTag.Id }));
+        Assert.That(result.Select(t => t.Id), Does.Not.Contain(mobileTag.Id));
+    }
+
+    [Test]
     public async Task CreateTag_AlwaysCreatesUserTag_OwnedByCaller()
     {
         var sut = CreateSut();

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/AdhocController.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/AdhocController.cs
@@ -256,8 +256,13 @@ public class AdhocController : Controller
     [Route("tags")]
     public async Task<OperationDataResult<List<AdhocTagModel>>> ListTags()
     {
+        // Admins see every non-removed tag customer-wide (global + every
+        // worker's personal tags, including mobile-created ones) so they
+        // show up in the web Etiketter list; non-admins keep the
+        // global-only view the synthetic DashboardWorkerId already implied
+        // (worker 0 owns nothing).
         return await ExecuteAsync(
-            () => _adhocService.ListTags(DashboardWorkerId),
+            () => _adhocService.ListTags(DashboardWorkerId, IsAdmin),
             "ErrorWhileGettingAdhocTags");
     }
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/BackendConfigurationAdhocService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/BackendConfigurationAdhocService.cs
@@ -653,11 +653,17 @@ public class BackendConfigurationAdhocService(
             .ToList();
     }
 
-    public async Task<List<AdhocTagModel>> ListTags(int workerId)
+    public async Task<List<AdhocTagModel>> ListTags(int workerId, bool isAdmin = false)
     {
-        return await dbContext.AdhocTags
-            .Where(t => t.WorkflowState != Constants.WorkflowStates.Removed
-                        && (t.OwnerWorkerId == null || t.OwnerWorkerId == workerId))
+        var query = dbContext.AdhocTags
+            .Where(t => t.WorkflowState != Constants.WorkflowStates.Removed);
+
+        if (!isAdmin)
+        {
+            query = query.Where(t => t.OwnerWorkerId == null || t.OwnerWorkerId == workerId);
+        }
+
+        return await query
             .OrderBy(t => t.Name)
             .Select(t => new AdhocTagModel { Id = t.Id, Name = t.Name, IsUserTag = t.OwnerWorkerId != null })
             .ToListAsync();

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/IBackendConfigurationAdhocService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/IBackendConfigurationAdhocService.cs
@@ -179,9 +179,13 @@ public interface IBackendConfigurationAdhocService
 
     /// <summary>
     /// Global tags (<c>OwnerWorkerId == null</c>) plus <paramref name="workerId"/>'s
-    /// own personal tags.
+    /// own personal tags. When <paramref name="isAdmin"/> is true the owner
+    /// filter is skipped entirely - the dashboard admin sees every
+    /// non-removed tag customer-wide, including every worker's personal
+    /// tags (mobile-created tags included), so they show up in the web
+    /// Etiketter list rather than being silently hidden.
     /// </summary>
-    Task<List<AdhocTagModel>> ListTags(int workerId);
+    Task<List<AdhocTagModel>> ListTags(int workerId, bool isAdmin = false);
 
     /// <summary>
     /// Creates a personal tag owned by <paramref name="workerId"/>, unless


### PR DESCRIPTION
The web Etiketter list (`GET .../adhoc/tags`) called `ListTags(DashboardWorkerId)` with the synthetic worker id 0 and never passed `IsAdmin`, so the `OwnerWorkerId == null || OwnerWorkerId == workerId` filter hid every mobile-created (user-scoped) tag from all web users.

`ListTags` now takes `isAdmin` and bypasses the ownership filter for admins, mirroring the existing `ListAreas`/`ListWorkers` precedent; the controller passes `IsAdmin` through. `IsUserTag` flagging and the gRPC/mobile path are unchanged.

Fixes microting/flutter-adhoc#43 (web-visibility defect; the app-side offline-creation gap is tracked separately in that issue).

Tests: service-layer regression tests in `AdhocServiceReferenceDataTests` — admin sees every worker's personal tags with `IsUserTag=true`; non-admin dashboard behavior locked to global-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)