### PR TITLE
feat(property-workers): show the pay-rule-set selector to non-admins

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/property-workers-nonadmin-no-logout.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/r/property-workers-nonadmin-no-logout.spec.ts
@@ -10,11 +10,17 @@ import { generateRandmString } from '../../../helper-functions';
 // device-users/tags permissions could create/edit workers and manage tags on
 // /plugins/backend-configuration-pn/property-workers. The pay-rule-set
 // selector feature (3903669b) added an unconditional
-// GET api/time-planning-pn/pay-rule-sets ([Authorize(Roles = Admin)]) in the
-// create/edit modal's ngOnInit; for non-admins that 403s and the global
-// HttpErrorInterceptor escalates it (refresh token -> retry -> still 403)
-// into a forced logout. The fix gates the fetch behind selectAuthIsAdmin$,
-// matching the template's existing admin-only payroll-rules block.
+// GET api/time-planning-pn/pay-rule-sets in the create/edit modal's ngOnInit,
+// but the endpoint was [Authorize(Roles = Admin)]; for non-admins that 403s and
+// the global HttpErrorInterceptor escalates it (refresh token -> retry -> still
+// 403) into a forced logout.
+//
+// The fix opened up the READ side instead of gating the call: listing and
+// reading pay rule sets is now allowed for any authenticated user, so a
+// non-admin can actually select a pay rule set for a worker. Creating, editing
+// and deleting pay rule sets stays admin-only. This spec therefore guards that
+// the modal's fetch runs for BOTH roles and that the endpoint answers 200 for a
+// non-admin instead of the 403 that used to end the session.
 
 const BASE_URL = 'http://localhost:4200';
 const USER_PASSWORD = 'Secret_password_2026!';
@@ -189,8 +195,9 @@ test.describe.serial('Property-workers as non-admin (backend + timeregistration)
     });
 
     // Positive direction: for an ADMIN the create-worker modal must still
-    // fetch the pay rule sets (the fix gates the call on isAdmin — this
-    // guards against over-gating).
+    // fetch the pay rule sets. The fix opened the read endpoint up rather than
+    // gating the call, so the fetch has to keep firing for every role — this
+    // guards against "fixing" it by suppressing the request instead.
     const adminPayRuleSetRequests: string[] = [];
     page.on('request', (req) => {
       if (req.url().includes(PAY_RULE_SETS_URL)) {
@@ -210,7 +217,8 @@ test.describe.serial('Property-workers as non-admin (backend + timeregistration)
     test.setTimeout(300000);
     expect(userEmail).not.toBe('');
 
-    // Track any (forbidden-for-this-user) pay-rule-sets requests.
+    // Track the modal's pay-rule-sets requests — this user is a non-admin, and
+    // the endpoint is expected to answer them (200), not 403.
     const payRuleSetRequests: string[] = [];
     page.on('request', (req) => {
       if (req.url().includes(PAY_RULE_SETS_URL)) {
@@ -253,7 +261,37 @@ test.describe.serial('Property-workers as non-admin (backend + timeregistration)
     expect(page.url()).not.toContain('/auth');
     expect(page.url()).toContain('/plugins/backend-configuration-pn/property-workers');
     await expect(page.locator('mat-dialog-container')).toBeVisible();
-    // And the admin-only endpoint was never called for this non-admin.
-    expect(payRuleSetRequests).toEqual([]);
+
+    // The fetch now DOES happen for a non-admin: listing pay rule sets is no
+    // longer [Authorize(Roles = Admin)], so a non-admin can pick one for a
+    // worker. The point of this spec is that it returns 200 instead of the 403
+    // that used to be escalated into a logout — hence the assertions above.
+    expect(payRuleSetRequests.length).toBeGreaterThan(0);
+  });
+
+  test('the pay-rule-sets list returns 200 for a non-admin (no longer admin-only)', async ({ page }) => {
+    test.setTimeout(300000);
+    expect(userEmail).not.toBe('');
+
+    // Straight at the API: this endpoint used to be [Authorize(Roles = Admin)]
+    // and answered 403 for this exact group, which the HttpErrorInterceptor
+    // turned into a forced logout. Asserting the status directly is what pins
+    // the authorization change; the UI consequence is covered by the test
+    // above (the modal fetches it and the user stays logged in).
+    const token = await loginViaApi(page, userEmail, USER_PASSWORD);
+    expect(token).not.toBe('');
+    const res = await page.request.get(
+      `${BASE_URL}/api/time-planning-pn/pay-rule-sets?offset=0&pageSize=1000`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    expect(res.status()).toBe(200);
+    expect((await res.json())?.success).toBe(true);
+
+    // Authoring pay rule sets stays admin-only for the same user.
+    const createRes = await page.request.post(`${BASE_URL}/api/time-planning-pn/pay-rule-sets`, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: { name: `nonadmin-should-not-create-${rand}`, payDayRules: [], payDayTypeRules: [] },
+    });
+    expect(createRes.status()).toBe(403);
   });
 });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.html
@@ -257,9 +257,9 @@
               <div class="d-flex flex-column" id="timeRegistrationColumn">
 
                 <!-- ========= Payroll rules ========= -->
-                <h3 class="section-header" *ngIf="!selectedDeviceUser.resigned && availablePayRuleSets.length > 0 && (selectAuthIsAdmin$ | async)">{{ 'Payroll rules' | translate }}</h3>
+                <h3 class="section-header" *ngIf="!selectedDeviceUser.resigned && availablePayRuleSets.length > 0">{{ 'Payroll rules' | translate }}</h3>
 
-                <div class="d-flex flex-row align-items-center pay-rule-set-row" *ngIf="!selectedDeviceUser.resigned && availablePayRuleSets.length > 0 && (selectAuthIsAdmin$ | async)">
+                <div class="d-flex flex-row align-items-center pay-rule-set-row" *ngIf="!selectedDeviceUser.resigned && availablePayRuleSets.length > 0">
                   <mat-form-field class="p-1 flex-grow-1">
                     <mat-label>{{ 'Pay Rule Set' | translate }}</mat-label>
                     <mtx-select

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/property-workers/components/property-worker-create-edit-modal/property-worker-create-edit-modal.component.ts
@@ -641,19 +641,9 @@ export class PropertyWorkerCreateEditModalComponent implements OnInit, OnDestroy
   }
 
   loadPayRuleSets(): void {
-    // GET api/time-planning-pn/pay-rule-sets is admin-only
-    // ([Authorize(Roles = Admin)] on PayRuleSetController.Index). Calling it as
-    // a non-admin returns 403, which the global HttpErrorInterceptor escalates
-    // into a forced logout (refresh token → retry → still 403 → logout) — the
-    // local error callback below never runs. The template already hides the
-    // whole payroll-rules block behind selectAuthIsAdmin$, so for non-admins
-    // we skip the fetch entirely; an admin-assigned payRuleSetId is still
-    // preserved on save via the assigned-site form patch.
-    this.selectAuthIsAdmin$.pipe(
-      first(),
-      filter((isAdmin) => isAdmin),
-      switchMap(() => this.payRuleSetsService.getPayRuleSets({offset: 0, pageSize: 1000}))
-    ).subscribe({
+    // GET api/time-planning-pn/pay-rule-sets is readable by any authenticated
+    // user, so non-admins can pick a pay rule set for an assigned site too.
+    this.payRuleSetsService.getPayRuleSets({offset: 0, pageSize: 1000}).subscribe({
       next: (result) => {
         if (result && result.success) {
           this.availablePayRuleSets = result.model?.payRuleSets || [];


### PR DESCRIPTION
Companion to microting/eform-angular-timeplanning-plugin#1674, already merged to stable.

## Why

Listing and reading pay rule sets used to require the Admin role. A non-admin's 403 was escalated by the global HttpErrorInterceptor into a forced logout, so the modal hid the selector and skipped the fetch entirely — meaning a non-admin could never set a worker's pay rule set.

The TimePlanning change opened up the read side (Index and Read); creating, editing and deleting rule sets stays admin-only. This PR removes the now-unnecessary client gate so the selector renders for everyone.

## Changes

- loadPayRuleSets() fetches unconditionally (the selectAuthIsAdmin gate is gone).
- The Payroll rules section header and the selector row drop their admin term; availablePayRuleSets.length > 0 remains the visibility condition.

## Test

The regression spec that guarded the original logout bug asserted a non-admin made zero pay-rule-sets requests — the opposite of the intended behaviour now. It asserts instead that the modal's fetch does happen and the user stays logged in (original regression still covered), that the endpoint answers 200 where it used to answer 403, and that creating a pay rule set still returns 403 for that user.

## Dependency

This repo's CI checks out eform-angular-timeplanning-plugin at ref stable and builds it into the test container, so this PR could not pass before #1674 landed. That is now merged, so this is safe to run and merge.

Generated with Claude Code