### PR TITLE
Show person chips together with the "Alle" chip in the adhoc table

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/adhoc-display.util.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/adhoc-display.util.ts
@@ -67,17 +67,18 @@ export function resolveTagNames(
 }
 
 export interface AssignedToDisplay {
-  /** true when the task's `executionRule` is "everyone" (mockup: ALLE pill; no concrete assignees to resolve). */
+  /** true when the task's `executionRule` is "everyone" (mockup: ALLE pill; may coexist with named assignees). */
   everyone: boolean;
   names: string[];
 }
 
 /**
  * Mirrors the mockup's `renderTildeltCell`/mobile's assignment display:
- * `executionRule` 1 ("everyone") means the task has no concrete assignees
- * and renders as a single "Alle"/"Everyone" pill; 0 ("assignedOnly") means
- * one pill per assigned worker's resolved name. NO teams (deviation from
- * the mockup/mobile, which also has a team concept - out of scope per the
+ * `executionRule` (1 = "everyone") and `assignedWorkerIds` are independent
+ * (issue #1085) - a task can carry named assignees AND "everyone", so the
+ * resolved names always render one pill each, plus an "Alle"/"Everyone"
+ * pill when `executionRule` is 1. NO teams (deviation from the
+ * mockup/mobile, which also has a team concept - out of scope per the
  * M5 plan).
  */
 export function assignedToDisplay(
@@ -85,10 +86,10 @@ export function assignedToDisplay(
   assignedWorkerIds: number[] | null | undefined,
   workers: AdhocWorkerModel[]
 ): AssignedToDisplay {
-  if (executionRule === 1) {
-    return {everyone: true, names: []};
-  }
-  return {everyone: false, names: resolveWorkerNames(workers, assignedWorkerIds)};
+  return {
+    everyone: executionRule === 1,
+    names: resolveWorkerNames(workers, assignedWorkerIds),
+  };
 }
 
 export type DeadlineBand = 'none' | 'overdue' | 'today' | 'soon' | 'far';

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-table/adhoc-table.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-table/adhoc-table.component.html
@@ -91,12 +91,10 @@
 </ng-template>
 
 <ng-template #assignedToTpl let-row>
-  <div class="cell-assigned d-flex flex-wrap gap-4">
-    <mat-chip class="assigned-chip--everyone" *ngIf="assignedToFor(row).everyone">{{ 'Everyone' | translate }}</mat-chip>
-    <ng-container *ngIf="!assignedToFor(row).everyone">
-      <mat-chip *ngFor="let name of assignedToFor(row).names">{{ name }}</mat-chip>
-      <span *ngIf="!assignedToFor(row).names.length">—</span>
-    </ng-container>
+  <div class="cell-assigned d-flex flex-wrap gap-4" *ngIf="assignedToFor(row) as assigned">
+    <mat-chip *ngFor="let name of assigned.names">{{ name }}</mat-chip>
+    <mat-chip class="assigned-chip--everyone" *ngIf="assigned.everyone">{{ 'Everyone' | translate }}</mat-chip>
+    <span *ngIf="!assigned.everyone && !assigned.names.length">—</span>
   </div>
 </ng-template>
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-table/adhoc-table.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-table/adhoc-table.component.spec.ts
@@ -55,10 +55,23 @@ describe('adhoc-display.util', () => {
   });
 
   describe('assignedToDisplay', () => {
-    it('executionRule 1 (everyone) returns everyone:true with no names, regardless of assignedWorkerIds', () => {
+    // Issue #1085: executionRule and assignedWorkerIds are independent, so a
+    // task can be assigned to named workers AND "everyone" at the same time -
+    // both the name chips and the "Alle" chip must render.
+    it('executionRule 1 (everyone) with assignedWorkerIds returns everyone:true AND the resolved names', () => {
       const result = assignedToDisplay(1, [100, 101], workers);
       expect(result.everyone).toBeTrue();
+      expect(result.names).toEqual(['Mette Hansen', 'Erik Eriksen']);
+    });
+
+    it('executionRule 1 (everyone) with no assignees returns everyone:true with no names', () => {
+      const result = assignedToDisplay(1, [], workers);
+      expect(result.everyone).toBeTrue();
       expect(result.names).toEqual([]);
+
+      const nullResult = assignedToDisplay(1, null, workers);
+      expect(nullResult.everyone).toBeTrue();
+      expect(nullResult.names).toEqual([]);
     });
 
     it('executionRule 0 (assignedOnly) resolves the assigned worker names', () => {


### PR DESCRIPTION
## Summary

The table's "Tildelt" column only ever showed the "Alle"/Everyone chip for tasks with `executionRule === 1`, even when the task also had named assignees. `executionRule` and `assignedWorkerIds` are independent fields (mobile-created tasks carry both), but `assignedToDisplay()` in `adhoc-display.util.ts` hard-returned `{everyone: true, names: []}` for `executionRule === 1`, discarding the worker ids, and the table template gated the name chips behind `!everyone`.

Fix:
- `assignedToDisplay()` now resolves and returns worker names regardless of `executionRule`; `everyone` is simply `executionRule === 1` (doc comments updated to state person + everyone coexist).
- `adhoc-table.component.html` renders the Everyone chip additively next to the name chips (single `assignedToFor(row) as assigned` binding); the em-dash placeholder shows only when there is neither.

Everyone-only and assigned-only tasks render exactly as before.

## Test plan

- New/updated regression specs in `adhoc-table.component.spec.ts` (pure-function specs for `adhoc-display.util`), run in CI:
  - `executionRule=1` + `assignedWorkerIds` returns `everyone: true` AND the resolved names (pins #1085)
  - `executionRule=1` with `[]`/`null` assignees returns `everyone: true`, `names: []`
  - `executionRule=0` behavior unchanged (existing cases)

Fixes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)