### PR TITLE
Keep assignees visible and intact when "Alle" is active in the task drawer

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -255,6 +255,7 @@ export const bgBG = {
   'Edit tag': 'Редактиране на етикет',
   'Delete tag': 'Изтриване на етикет',
   'Assigned to': 'Възложено на',
+  'Task assigned to': 'Възложено на',
   'Edit task': 'Редактиране на задача',
   Every: 'Всеки',
   'Copy task': 'Копиране на задача',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -255,6 +255,7 @@ export const csCZ = {
   'Edit tag': 'Upravit značku',
   'Delete tag': 'Smazat značku',
   'Assigned to': 'Přiřazen',
+  'Task assigned to': 'Přiřazen',
   'Edit task': 'Upravit úkol',
   Every: 'Každý',
   'Copy task': 'Kopírovat úkol',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -260,6 +260,7 @@ export const da = {
   'Edit tag': 'Rediger tag',
   'Delete tag': 'Slet tag',
   'Assigned to': 'Tildelt',
+  'Task assigned to': 'Tildelt til',
   'Edit task': 'Rediger opgave',
   Every: 'Hver',
   'Copy task': 'Kopiér opgave',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -116,6 +116,7 @@ export const deDE = {
   'View areas': 'Bereiche anzeigen',
   Task: 'Aufgabe',
   'Assigned to': 'Zugewiesen an',
+  'Task assigned to': 'Zugewiesen an',
   'View compliance': 'Überwachung anzeigen',
   'View compliance 30 days': 'Überwachung anzeigen 30 Tage',
   'Compliance 30 days': 'Überwachung 30 Tage',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -255,6 +255,7 @@ export const elGR = {
   'Edit tag': 'Επεξεργασία ετικέτας',
   'Delete tag': 'Διαγραφή ετικέτας',
   'Assigned to': 'Ανατεθεί',
+  'Task assigned to': 'Ανατεθεί',
   'Edit task': 'Επεξεργασία εργασίας',
   Every: 'Κάθε',
   'Copy task': 'Αντιγραφή εργασίας',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -278,6 +278,7 @@ export const enUS= {
   'Edit tag': 'Edit tag',
   'Delete tag': 'Delete tag',
   'Assigned to': 'Assigned to',
+  'Task assigned to': 'Assigned to',
   'Edit task': 'Edit task',
   'Every': 'Every',
   'Copy task': 'Copy task',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -255,6 +255,7 @@ export const esES = {
   'Edit tag': 'Editar etiqueta',
   'Delete tag': 'Eliminar etiqueta',
   'Assigned to': 'Asignado a',
+  'Task assigned to': 'Asignado a',
   'Edit task': 'Editar tarea',
   Every: 'Cada',
   'Copy task': 'Copiar tarea',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -255,6 +255,7 @@ export const etET = {
   'Edit tag': 'Muuda silti',
   'Delete tag': 'Kustuta silt',
   'Assigned to': 'Määratud',
+  'Task assigned to': 'Määratud',
   'Edit task': 'Redigeeri ülesannet',
   Every: 'Iga',
   'Copy task': 'Kopeeri ülesanne',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -255,6 +255,7 @@ export const fiFI = {
   'Edit tag': 'Muokkaa tunnistetta',
   'Delete tag': 'Poista tunniste',
   'Assigned to': 'Määritetty',
+  'Task assigned to': 'Määritetty',
   'Edit task': 'Muokkaa tehtävää',
   Every: 'Joka',
   'Copy task': 'Kopioi tehtävä',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -252,6 +252,7 @@ export const frFR = {
   'Edit tag': 'Modifier la balise',
   'Delete tag': 'Supprimer la balise',
   'Assigned to': 'Assigné à',
+  'Task assigned to': 'Assigné à',
   'Edit task': 'Modifier la tâche',
   Every: 'Chaque',
   'Copy task': 'Tâche de copie',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -255,6 +255,7 @@ export const hrHR = {
   'Edit tag': 'Uredi oznaku',
   'Delete tag': 'Izbriši oznaku',
   'Assigned to': 'Dodijeljena',
+  'Task assigned to': 'Dodijeljena',
   'Edit task': 'Uredi zadatak',
   Every: 'Svaki',
   'Copy task': 'Kopiraj zadatak',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -255,6 +255,7 @@ export const huHU = {
   'Edit tag': 'Címke szerkesztése',
   'Delete tag': 'Címke törlése',
   'Assigned to': 'Hozzárendelve',
+  'Task assigned to': 'Hozzárendelve',
   'Edit task': 'Feladat szerkesztése',
   Every: 'Minden',
   'Copy task': 'Feladat másolása',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -255,6 +255,7 @@ export const isIS = {
   'Edit tag': 'Breyta merki',
   'Delete tag': 'Eyða merki',
   'Assigned to': 'Úthlutað til',
+  'Task assigned to': 'Úthlutað til',
   'Edit task': 'Breyta verkefni',
   Every: 'Hvert',
   'Copy task': 'Afrita verkefni',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -251,6 +251,7 @@ export const itIT = {
   'Edit tag': 'Modifica etichetta',
   'Delete tag': 'Elimina etichetta',
   'Assigned to': 'Assegnato a',
+  'Task assigned to': 'Assegnato a',
   'Edit task': 'Modifica attività',
   Every: 'Ogni',
   'Copy task': 'Copia attività',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -255,6 +255,7 @@ export const ltLT = {
   'Edit tag': 'Redaguoti žymą',
   'Delete tag': 'Ištrinti žymą',
   'Assigned to': 'Priskirtas',
+  'Task assigned to': 'Priskirtas',
   'Edit task': 'Redaguoti užduotį',
   Every: 'kas',
   'Copy task': 'Kopijuoti užduotį',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -255,6 +255,7 @@ export const lvLV = {
   'Edit tag': 'Rediģēt tagu',
   'Delete tag': 'Dzēst tagu',
   'Assigned to': 'Piešķirts',
+  'Task assigned to': 'Piešķirts',
   'Edit task': 'Rediģēt uzdevumu',
   Every: 'Katrs',
   'Copy task': 'Kopēt uzdevumu',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -255,6 +255,7 @@ export const nlNL = {
   'Edit tag': 'Bewerk label',
   'Delete tag': 'Label verwijderen',
   'Assigned to': 'Toegewezen aan',
+  'Task assigned to': 'Toegewezen aan',
   'Edit task': 'Taak bewerken',
   Every: 'Elk',
   'Copy task': 'Kopieer taak',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -255,6 +255,7 @@ export const noNO = {
   'Edit tag': 'Rediger tag',
   'Delete tag': 'Slett tag',
   'Assigned to': 'Tilordnet',
+  'Task assigned to': 'Tilordnet',
   'Edit task': 'Rediger oppgave',
   Every: 'Hver',
   'Copy task': 'Kopier oppgave',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -255,6 +255,7 @@ export const plPL = {
   'Edit tag': 'Edytuj tag',
   'Delete tag': 'Usuń tag',
   'Assigned to': 'Przypisane do',
+  'Task assigned to': 'Przypisane do',
   'Edit task': 'Edytuj zadanie',
   Every: 'Każdy',
   'Copy task': 'Skopiuj zadanie',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -255,6 +255,7 @@ export const ptBR = {
   'Edit tag': 'Editar etiqueta',
   'Delete tag': 'Excluir etiqueta',
   'Assigned to': 'Atribuído a',
+  'Task assigned to': 'Atribuído a',
   'Edit task': 'Editar tarefa',
   Every: 'Todo',
   'Copy task': 'Copiar tarefa',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -255,6 +255,7 @@ export const ptPT = {
   'Edit tag': 'Editar etiqueta',
   'Delete tag': 'Excluir etiqueta',
   'Assigned to': 'Atribuído a',
+  'Task assigned to': 'Atribuído a',
   'Edit task': 'Editar tarefa',
   Every: 'Todo',
   'Copy task': 'Copiar tarefa',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -255,6 +255,7 @@ export const roRO = {
   'Edit tag': 'Editați eticheta',
   'Delete tag': 'Ștergeți eticheta',
   'Assigned to': 'Atribuit',
+  'Task assigned to': 'Atribuit',
   'Edit task': 'Editați sarcina',
   Every: 'Fiecare',
   'Copy task': 'Sarcina de copiere',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -255,6 +255,7 @@ export const skSK = {
   'Edit tag': 'Upraviť značku',
   'Delete tag': 'Odstrániť značku',
   'Assigned to': 'Priradený',
+  'Task assigned to': 'Priradený',
   'Edit task': 'Upraviť úlohu',
   Every: 'Každý',
   'Copy task': 'Kopírovať úlohu',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -255,6 +255,7 @@ export const slSL = {
   'Edit tag': 'Uredi oznako',
   'Delete tag': 'Izbriši oznako',
   'Assigned to': 'Dodeljena',
+  'Task assigned to': 'Dodeljena',
   'Edit task': 'Uredi nalogo',
   Every: 'vsak',
   'Copy task': 'Kopiraj opravilo',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -255,6 +255,7 @@ export const svSE = {
   'Edit tag': 'Redigera tagg',
   'Delete tag': 'Ta bort tagg',
   'Assigned to': 'Tilldelats',
+  'Task assigned to': 'Tilldelats',
   'Edit task': 'Redigera uppgift',
   Every: 'Varje',
   'Copy task': 'Kopiera uppgift',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -252,6 +252,7 @@ export const ukUA = {
   'Edit tag': 'Редагувати тег',
   'Delete tag': 'Видалити тег',
   'Assigned to': 'Присвоєно',
+  'Task assigned to': 'Присвоєно',
   'Edit task': 'Редагувати завдання',
   Every: 'кожен',
   'Copy task': 'Копіювати завдання',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
@@ -161,7 +161,7 @@
         <div class="gcal-row">
           <mat-icon class="gcal-icon gcal-icon--top">people</mat-icon>
           <div class="gcal-row-content">
-            <div class="adhoc-drawer__section-title">{{ 'Assigned to' | translate }}</div>
+            <div class="adhoc-drawer__section-title">{{ 'Task assigned to' | translate }}</div>
             <div class="btn-group d-flex gap-8" role="group">
               <button
                 type="button"
@@ -181,14 +181,17 @@
               </button>
             </div>
 
-            <div class="d-flex flex-wrap gap-4" *ngIf="executionRule === 0">
+            <!-- #1088: person chips + checkbox list stay visible/selectable
+                 regardless of executionRule - persons and "Everyone" coexist
+                 (mobile parity). -->
+            <div class="d-flex flex-wrap gap-4">
               <mat-chip
                 *ngFor="let workerId of assignedWorkerIds"
                 [removable]="!readonly"
                 (removed)="onToggleWorker(workerId)"
               >{{ workerName(workerId) }}</mat-chip>
             </div>
-            <div class="d-flex flex-wrap gap-4" *ngIf="executionRule === 0 && !readonly">
+            <div class="d-flex flex-wrap gap-4" *ngIf="!readonly">
               <mat-checkbox
                 *ngFor="let worker of workers"
                 [checked]="isWorkerAssigned(worker.workerId)"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.spec.ts
@@ -137,11 +137,32 @@ describe('AdhocTaskDrawerComponent', () => {
       expect(component.tagIds).toEqual([1000]);
     });
 
-    it('onExecutionRuleChange(1) clears assignedWorkerIds', () => {
+    // #1088: executionRule and assignedWorkerIds are independent fields -
+    // toggling "Everyone"/"Assigned only" must never mutate the assignees,
+    // otherwise a single toggle click during an edit session silently
+    // deletes named assignees server-side on save.
+    it('onExecutionRuleChange(1) ("Everyone") preserves a non-empty assignedWorkerIds', () => {
       expect(component.assignedWorkerIds).toEqual([100]);
       component.onExecutionRuleChange(1);
       expect(component.executionRule).toBe(1);
-      expect(component.assignedWorkerIds).toEqual([]);
+      expect(component.assignedWorkerIds).toEqual([100]);
+    });
+
+    it('onExecutionRuleChange back to 0 ("Assigned only") also preserves assignedWorkerIds', () => {
+      component.onExecutionRuleChange(1);
+      component.onExecutionRuleChange(0);
+      expect(component.executionRule).toBe(0);
+      expect(component.assignedWorkerIds).toEqual([100]);
+    });
+
+    it('onSave after toggling to "Everyone" sends executionRule 1 AND the original assignedWorkerIds', () => {
+      adhocServiceSpy.updateTask.and.returnValue(of({success: true}));
+      component.onExecutionRuleChange(1);
+      component.onSave();
+
+      const sentModel = adhocServiceSpy.updateTask.calls.mostRecent().args[1];
+      expect(sentModel.executionRule).toBe(1);
+      expect(sentModel.assignedWorkerIds).toEqual([100]);
     });
 
     it('removeExistingPhoto excludes the photo from visiblePhotos and the saved photoIds', () => {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.ts
@@ -239,11 +239,12 @@ export class AdhocTaskDrawerComponent implements OnInit, OnDestroy {
       : [...this.assignedWorkerIds, workerId];
   }
 
+  // #1088: executionRule and assignedWorkerIds are independent fields (a
+  // task can be assigned to persons AND visible to everyone, mobile
+  // parity). Toggling the rule must never mutate the assignees - clearing
+  // them here would silently delete named assignees server-side on save.
   onExecutionRuleChange(rule: number): void {
     this.executionRule = rule;
-    if (rule === 1) {
-      this.assignedWorkerIds = [];
-    }
   }
 
   // -----------------------------------------------------------------


### PR DESCRIPTION
## Root cause

The adhoc task drawer treated `executionRule` and `assignedWorkerIds` as mutually exclusive, but they are independent fields — mobile-created tasks carry both (a task can be assigned to named persons AND visible to everyone). This caused a silent data-loss bug: while editing a person+Alle task, a single click on the "Alle" toggle emptied `assignedWorkerIds`, and `buildModel()` sends both fields on save, so the named assignees were deleted server-side.

## Changes (three parts)

- **Drawer-specific heading key**: the drawer heading now uses a new translation key `'Task assigned to'` (da "Tildelt til", en "Assigned to") added to all 26 language files in the plugin i18n directory; every other language reuses its existing `'Assigned to'` translation. The table column header keeps the untouched `'Assigned to'` key ("Tildelt").
- **Visibility gates removed (mobile parity)**: the assigned-worker chip block and the worker checkbox list were wrapped in `*ngIf="executionRule === 0"` — the gates are removed so person chips render and the checkbox list stays selectable regardless of executionRule.
- **Silent data-loss fix**: `onExecutionRuleChange` no longer clears `assignedWorkerIds` when "Alle" (executionRule 1) is picked — toggling the rule never mutates the assignees.

## Test plan

Specs in `adhoc-task-drawer.component.spec.ts` run in CI. The spec asserting the old clearing behavior was replaced with three cases:

- `onExecutionRuleChange(1)` ("Alle") preserves a non-empty `assignedWorkerIds` — the mandatory regression pinning the data-loss bug (fails against the old code)
- `onExecutionRuleChange(0)` back to "Kun tildelte" also preserves `assignedWorkerIds`
- `onSave` after toggling to "Alle" sends `executionRule: 1` AND the original `assignedWorkerIds` (edit-save round-trip of a person+Alle task)

Fixes #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)