### PR TITLE
Rename the drawer tags heading to "Etiketter" and hide the section when untagged

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -603,7 +603,6 @@ export const da = {
   'Task can be seen and completed by': 'Opgave kan ses og udføres af',
   'Assigned only': 'Kun tildelte',
   Everyone: 'Alle',
-  'Selected tags': 'Valgte tags',
   'Execute no later than and first display': 'Udfør senest og visning første gang',
   'Last 30 days': 'Sidste 30 dage',
   'Last 60 days': 'Sidste 60 dage',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -620,7 +620,6 @@ export const enUS= {
   'Task can be seen and completed by': 'Task can be seen and completed by',
   'Assigned only': 'Assigned only',
   Everyone: 'Everyone',
-  'Selected tags': 'Selected tags',
   'Execute no later than and first display': 'Execute no later than and first display',
   'Last 30 days': 'Last 30 days',
   'Last 60 days': 'Last 60 days',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
@@ -87,11 +87,13 @@
           </div>
         </div>
 
-        <!-- Tags row -->
-        <div class="gcal-row">
+        <!-- Tags row (#1086: hidden entirely for an untagged task in view
+             mode - no heading, no empty chip box; always shown when editable
+             so the picker stays reachable) -->
+        <div class="gcal-row" *ngIf="showTagsSection">
           <mat-icon class="gcal-icon gcal-icon--top">label</mat-icon>
           <div class="gcal-row-content adhoc-drawer__tags" id="ny-sektion-tags">
-            <div class="adhoc-drawer__section-title">{{ 'Selected tags' | translate }}</div>
+            <div class="adhoc-drawer__section-title">{{ 'Tags' | translate }}</div>
             <div class="d-flex flex-wrap gap-4" id="ny-tags-valgt-wrap">
               <mat-chip
                 *ngFor="let tagId of tagIds"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.spec.ts
@@ -104,6 +104,13 @@ describe('AdhocTaskDrawerComponent', () => {
       component.onSave();
       expect(adhocServiceSpy.createTask).not.toHaveBeenCalled();
     });
+
+    // #1086: the tag picker must stay available while creating, even though
+    // a fresh task has no tags yet.
+    it('showTagsSection is true in create mode despite tagIds being empty', () => {
+      expect(component.tagIds).toEqual([]);
+      expect(component.showTagsSection).toBeTrue();
+    });
   });
 
   describe('view mode', () => {
@@ -114,6 +121,18 @@ describe('AdhocTaskDrawerComponent', () => {
       expect(component.tagIds).toEqual([1000]);
       expect(component.assignedWorkerIds).toEqual([100]);
       expect(component.visiblePhotos).toEqual([{id: 5000, contentType: 'image/png'}]);
+    });
+
+    // #1086: the "Etiketter" heading and the (empty) chip container must not
+    // render at all when a read-only task has no tags - no heading, no grey box.
+    it('showTagsSection is false when the task has no tags', () => {
+      const component = buildComponent({mode: 'view', task: {...existingTask, tagIds: []}});
+      expect(component.showTagsSection).toBeFalse();
+    });
+
+    it('showTagsSection is true when the task has tags', () => {
+      const component = buildComponent({mode: 'view', task: existingTask});
+      expect(component.showTagsSection).toBeTrue();
     });
   });
 
@@ -135,6 +154,14 @@ describe('AdhocTaskDrawerComponent', () => {
       expect(component.tagIds).toEqual([]);
       component.onToggleTag(1000);
       expect(component.tagIds).toEqual([1000]);
+    });
+
+    // #1086: in edit mode the picker stays visible even after the last tag
+    // is removed, so the user can still add tags back.
+    it('showTagsSection stays true in edit mode after removing the last tag', () => {
+      component.onToggleTag(1000);
+      expect(component.tagIds).toEqual([]);
+      expect(component.showTagsSection).toBeTrue();
     });
 
     // #1088: executionRule and assignedWorkerIds are independent fields -

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.ts
@@ -126,6 +126,15 @@ export class AdhocTaskDrawerComponent implements OnInit, OnDestroy {
     return (this.task?.photos ?? []).filter((p) => !this.removedPhotoIds.has(p.id));
   }
 
+  /**
+   * #1086: the tags row (heading + chips + picker) renders only when there is
+   * something to show or edit - always in create/edit mode (the picker must
+   * stay reachable), but in view mode only when the task actually has tags.
+   */
+  get showTagsSection(): boolean {
+    return this.tagIds.length > 0 || !this.readonly;
+  }
+
   /** "Udfør opgave" (M5/F8) is offered from view/edit mode on any open (not completed, not archived) task. */
   get canComplete(): boolean {
     return !this.isCreate && !!this.task && !this.task.completed && !this.task.archived;


### PR DESCRIPTION
Two changes to the adhoc task drawer's tags section (`AdhocTaskDrawerComponent`):

- **Heading key repoint:** the section title now uses the existing `Tags` translation key ("Etiketter" in Danish, already present in every language file) instead of `Selected tags` ("Valgte tags"). No new translations needed.
- **Visibility gate:** the whole tags row (icon, heading, chip wrap, picker, create-tag input) is wrapped in `*ngIf="showTagsSection"`, a new getter (`tagIds.length > 0 || !readonly`). In view mode an untagged task now renders nothing — no heading, no empty grey box. In create/edit mode the section is always visible so the tag picker stays reachable.

The now-unused `'Selected tags'` i18n key is retired — it only ever existed in `da.ts` and `enUS.ts`, and its sole usage was this heading.

## Test plan

- 4 new class-level specs for the `showTagsSection` getter in `adhoc-task-drawer.component.spec.ts`, run in CI:
  - create mode: true despite empty `tagIds`
  - view mode without tags: false
  - view mode with tags: true
  - edit mode: stays true after removing the last tag

Fixes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)
