### PR TITLE
Rename the drawer photos heading from "Indhold" to "Billeder"

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
@@ -121,7 +121,7 @@
         <div class="gcal-row">
           <mat-icon class="gcal-icon gcal-icon--top">image</mat-icon>
           <div class="gcal-row-content adhoc-drawer__photos" id="ny-sektion-komm-billeder">
-            <div class="adhoc-drawer__section-title">{{ 'Content' | translate }}</div>
+            <div class="adhoc-drawer__section-title">{{ 'Pictures' | translate }}</div>
             <div class="d-flex flex-wrap gap-8">
               <div class="photo-thumb" *ngFor="let photo of visiblePhotos" (click)="onViewPhotos(photo)">
                 <img [src]="photoUrl(photo) | authImage | async" alt="">


### PR DESCRIPTION
Repoints the photos heading in the adhoc task drawer from the 'Content' translate key (da "Indhold") to the existing 'Pictures' key (da "Billeder"), which is defined in all 26 language files, so no new translations are needed.

The 'Content' key is intentionally kept: contrary to the issue's "drawer-only" finding, it is still used as the adhoc table's column header key (`adhoc-table.component.ts`). The comments block keeps its own 'Comments' subtitle, unchanged.

## Test plan

Template-only translate-key swap with no class-level logic changed; covered by the existing CI suite.

Fixes #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)
