### PR TITLE
Label the drawer intro row's creator name with "Oprettet af:"

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
@@ -11,7 +11,7 @@
 
   <div class="adhoc-drawer__intro d-flex align-items-center justify-content-between" *ngIf="!isCreate">
     <div>
-      <span>{{ workerName(task?.createdByWorkerId) }}</span>
+      <span>{{ 'Created by' | translate }}: {{ workerName(task?.createdByWorkerId) }}</span>
       ·
       <span>{{ propertyName(task?.propertyId) }}</span>
       ·


### PR DESCRIPTION
Prefixes the adhoc task drawer's intro-row creator name with the existing 'Created by' translation key (da "Oprettet af"; colon outside the key), per decided Option C — the intro row stays the single place the creator appears, no new line under the description.

## Test plan

Template-only change with no class-level logic, so there is no new spec surface; covered by the existing CI suite.

Fixes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)
