### PR TITLE
Raise the column-picker panel above the table's sticky cells

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-table/adhoc-table.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-table/adhoc-table.component.scss
@@ -6,7 +6,9 @@
   position: absolute;
   right: 0;
   top: 100%;
-  z-index: 10;
+  // Must clear the mtx-grid's sticky header row (Material sticky cells sit
+  // at z-index 100) so the picker paints above the table it overlaps.
+  z-index: 110;
   min-width: 220px;
   background: var(--mdc-theme-surface, #fff);
   border: 1px solid rgba(0, 0, 0, 0.12);


### PR DESCRIPTION
## Root cause

The "Kolonner" column-picker panel (`.column-picker-panel` in `adhoc-table.component.scss`) is absolutely positioned with `z-index: 10`, but mtx-grid's sticky header row and pinned cells sit at z-index ~100 in this workspace's Material theme. Wherever the panel and the table overlapped, the table painted over the panel, hiding the picker.

## Fix

One-line stacking fix: bump `.column-picker-panel` from `z-index: 10` to `z-index: 110`, with an explanatory comment. This matches the sibling precedent in `adhoc-filters.component.scss`, where `.tag-filter-panel` fixed the identical bug the same way (`z-index: 110` clearing the Material sticky cells at 100).

## Test plan

- Pure SCSS stacking fix — no spec surface per repo convention (class-level authored specs, no TestBed/DOM rendering); covered by the existing CI suite.
- Stylesheet compile verified locally with dart-sass against the edited file.

Fixes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)
