### PR TITLE
fix(calendar): make Month and Compliance views available to all users

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-admin-gating.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-admin-gating.spec.ts
@@ -3,15 +3,17 @@ import { CalendarUiEnhancementsPage } from '../calendar-ui-enhancements.page';
 import { generateRandmString } from '../../../helper-functions';
 
 /**
- * Calendar MONTH VIEW admin-gating suite (calendar month-view feature).
+ * Calendar view-mode dropdown — "Måned"/Month and "Compliance" are available
+ * to every user (regression guard).
  *
- * The view-mode dropdown's two admin-only options ("Måned"/Month and
- * "Compliance") are built conditionally on `isAdmin` in
- * calendar-header.component.ts's `buildViewModeOptions()` — the same flag
- * that already gated "Compliance" pre-month-view (see
- * `q/calendar-month-view.spec.ts`, MV1, for the ADMIN dropdown order:
- * Dag, Uge, Måned, Tidsplan, Compliance). A NON-ADMIN user must see exactly
- * ['Dag', 'Uge', 'Tidsplan'] — never 'Måned' or 'Compliance'.
+ * These two options used to be built conditionally on `isAdmin` in
+ * calendar-header.component.ts's `buildViewModeOptions()`. That gating was
+ * removed: all five options are now unconditional, so a NON-ADMIN user must
+ * see the full list ['Dag', 'Uge', 'Måned', 'Tidsplan', 'Compliance'] — the
+ * same order the ADMIN suite asserts (see `q/calendar-month-view.spec.ts`,
+ * MV1). The endpoints these views call (calendar/tasks/week,
+ * calendar/compliance-report) are `[Authorize]`-only, so non-admins are
+ * served.
  *
  * `loginViaApi`/`loginAs`/`setupNonAdminUser` are copied VERBATIM from
  * `r/property-workers-nonadmin-no-logout.spec.ts` (lines 23-166) — the same
@@ -171,7 +173,7 @@ async function setupNonAdminUser(page: Page, rand: string): Promise<string> {
   return userEmail;
 }
 
-test.describe.serial('Calendar month view — non-admin dropdown gating', () => {
+test.describe.serial('Calendar view-mode dropdown — non-admin sees all options', () => {
   const rand = generateRandmString(8).toLowerCase();
   let userEmail = '';
 
@@ -190,9 +192,10 @@ test.describe.serial('Calendar month view — non-admin dropdown gating', () => 
   });
 
   // =======================================================================
-  // Non-admin dropdown gating — neither Måned nor Compliance is present.
+  // Non-admin dropdown — all five options are present, including Måned and
+  // Compliance (same list and order the admin suite asserts).
   // =======================================================================
-  test('non-admin sees neither Måned nor Compliance', async ({ page }) => {
+  test('non-admin sees all five options including Måned and Compliance', async ({ page }) => {
     test.setTimeout(300000);
     expect(userEmail).not.toBe('');
 
@@ -205,6 +208,6 @@ test.describe.serial('Calendar month view — non-admin dropdown gating', () => 
     await page.waitForTimeout(2000);
     await page.locator('#calendarViewModeSelect').click();
     const options = page.locator('.ng-dropdown-panel .ng-option');
-    await expect(options).toHaveText(['Dag', 'Uge', 'Tidsplan']);
+    await expect(options).toHaveText(['Dag', 'Uge', 'Måned', 'Tidsplan', 'Compliance']);
   });
 });

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-month-view.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-month-view.spec.ts
@@ -14,11 +14,11 @@ import {
 /**
  * Calendar MONTH VIEW suite (calendar month-view feature).
  *
- * The view-mode dropdown (`#calendarViewModeSelect`) gains a third,
- * admin-only option — "Måned" — between "Uge" and "Tidsplan". For an ADMIN
- * the full order is: Dag, Uge, Måned, Tidsplan, Compliance (see
- * `q/calendar-admin-gating.spec.ts` for the non-admin variant, which lacks
- * both Måned and Compliance).
+ * The view-mode dropdown (`#calendarViewModeSelect`) gains a third
+ * option — "Måned" — between "Uge" and "Tidsplan". The full order is: Dag,
+ * Uge, Måned, Tidsplan, Compliance — available to every user, not just
+ * admins (see `q/calendar-admin-gating.spec.ts`, a regression guard
+ * asserting a NON-ADMIN user sees the same full five-option list).
  *
  * Month view renders 6 `.month-week-row` rows, 6 `.wk-cell` week-number
  * buttons, and `.month-day-cell` cells (each carrying a `.day-number`

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.html
@@ -33,7 +33,6 @@
       [viewMode]="viewMode"
       [sidebarOpen]="sidebarOpen"
       [propertyName]="selectedPropertyName"
-      [isAdmin]="isAdmin"
       [scheduleScope]="scheduleScope"
       (navigate)="onNavigate($event)"
       (goToToday)="onGoToToday()"
@@ -91,7 +90,6 @@
 
       <ng-container *ngSwitchCase="'month'">
         <app-calendar-month-view
-          *ngIf="isAdmin"
           [monthDate]="currentDate"
           [tasksByDate]="monthTasksByDate"
           (weekClicked)="onMonthWeekClicked($event)"
@@ -102,7 +100,6 @@
 
       <ng-container *ngSwitchCase="'compliance'">
         <app-calendar-compliance-view
-          *ngIf="isAdmin"
           #complianceView
           [properties]="properties"
           [boards]="boards"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -125,17 +125,12 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
     private store: Store,
     private router: Router,
   ) {
+    // isAdmin still gates the admin-only controls in the week/day grid
+    // (see the [isAdmin] bindings in the template); the month and compliance
+    // views are available to every user, so no view-mode guard is applied.
     this.store.select(selectCurrentUserIsAdmin).pipe(takeUntil(this.destroy$))
       .subscribe(isAdmin => {
         this.isAdmin = isAdmin;
-        // isAdmin resolves async from the store after init — if it turns out
-        // the user is not an admin while compliance view is still active
-        // (e.g. deep link, or a stale admin session), force back to week
-        // view so a non-admin can never remain in the admin-only mode.
-        if (!isAdmin && (this.viewMode === 'compliance' || this.viewMode === 'month')) {
-          this.stateService.updateViewMode('week');
-          this.loadTasks();
-        }
       });
   }
 
@@ -149,19 +144,6 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       this.activeTeamIds = filters.activeTeamIds;
       this.activeTagNames = filters.activeTagNames;
       this.sidebarOpen = filters.sidebarOpen;
-
-      // Defense in depth (mirrors the constructor's isAdmin-subscription
-      // guard): NgRx calendar state persists across in-app navigations, so
-      // a non-admin can land on this component with a stale 'compliance'
-      // viewMode inherited from a previous admin session, with no admin
-      // check ever having run. Force back to week — the updateViewMode
-      // dispatch re-emits filters$ with 'week', which this same
-      // subscription then processes normally, so no extra loadTasks() call
-      // is needed here.
-      if ((this.viewMode === 'compliance' || this.viewMode === 'month') && !this.isAdmin) {
-        this.stateService.updateViewMode('week');
-        return;
-      }
     });
 
     this.loadProperties();

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.spec.ts
@@ -1,0 +1,29 @@
+import {TranslateService} from '@ngx-translate/core';
+import {CalendarHeaderComponent} from './calendar-header.component';
+
+// Class-level instantiation (matching the module's other specs, e.g.
+// calendar-layout.service.spec.ts): the assertion is on the options array
+// produced by buildViewModeOptions, which needs no Angular TestBed.
+function makeTranslate(): TranslateService {
+  // instant passthrough — the label is the key itself, which is all the
+  // option-list assertions rely on.
+  return {instant: (key: string) => key} as unknown as TranslateService;
+}
+
+describe('CalendarHeaderComponent', () => {
+  let component: CalendarHeaderComponent;
+
+  beforeEach(() => {
+    component = new CalendarHeaderComponent(makeTranslate());
+  });
+
+  it('offers all five view-mode options to every user', () => {
+    // ngOnInit builds the option list.
+    component.ngOnInit();
+
+    const values = component.viewModeOptions.map(o => o.value);
+    // Month and Compliance are available to everyone, exactly like
+    // day/week/schedule — no admin gating.
+    expect(values).toEqual(['day', 'week', 'month', 'schedule', 'compliance']);
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {TranslateService} from '@ngx-translate/core';
 import {getCurrentLocale} from '../../services/calendar-locale.helper';
 
@@ -8,12 +8,11 @@ import {getCurrentLocale} from '../../services/calendar-locale.helper';
   templateUrl: './calendar-header.component.html',
   styleUrls: ['./calendar-header.component.scss'],
 })
-export class CalendarHeaderComponent implements OnInit, OnChanges {
+export class CalendarHeaderComponent implements OnInit {
   @Input() currentDate: string = '';
   @Input() viewMode: 'week' | 'day' | 'schedule' | 'month' | 'compliance' = 'week';
   @Input() sidebarOpen = true;
   @Input() propertyName: string = '';
-  @Input() isAdmin = false;
   @Input() scheduleScope: 'week' | 'month' = 'week';
 
   viewModeOptions: {value: string; label: string}[] = [];
@@ -30,23 +29,13 @@ export class CalendarHeaderComponent implements OnInit, OnChanges {
     this.buildViewModeOptions();
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    // isAdmin arrives asynchronously from the store after this component has
-    // already initialised, so the option list must be rebuilt whenever it
-    // changes (not just once in ngOnInit).
-    if (changes['isAdmin']) {
-      this.buildViewModeOptions();
-    }
-  }
-
   private buildViewModeOptions() {
     this.viewModeOptions = [
       {value: 'day', label: this.translate.instant('Day')},
       {value: 'week', label: this.translate.instant('Week')},
-      // Month is admin-only, mirroring the Compliance gating below.
-      ...(this.isAdmin ? [{value: 'month', label: this.translate.instant('Month')}] : []),
+      {value: 'month', label: this.translate.instant('Month')},
       {value: 'schedule', label: this.translate.instant('List')},
-      ...(this.isAdmin ? [{value: 'compliance', label: this.translate.instant('Compliance')}] : []),
+      {value: 'compliance', label: this.translate.instant('Compliance')},
     ];
   }
 


### PR DESCRIPTION
## Summary
The calendar view-mode dropdown's "Måned" (Month) and "Compliance" options were admin-only. They now behave exactly like the other options (Day/Week/List) — available to every user.

Removed all five client-side gates:
- `calendar-header.component.ts`: the two `isAdmin`-conditional spreads in `buildViewModeOptions()`; the now-unused `isAdmin` `@Input` + `ngOnChanges` (options were its only consumer).
- `calendar-container.component.html`: `*ngIf="isAdmin"` on the month and compliance view bodies (and the now-removed `[isAdmin]` header binding).
- `calendar-container.component.ts`: both non-admin force-back-to-`week` guards (isAdmin subscription + filters$ defense-in-depth).

Deliberately KEPT admin-gated: the export/aux button block and the week/day grid's task-id display (container `isAdmin` remains for those).

## Server-side check
The endpoints these views call (`calendar/tasks/week`, `calendar/compliance-report`, `compliances/delete/{id}`) are `[Authorize]`-only — no role/policy/claim restrictions — so non-admin access works end to end without C# changes.

## Tests
- New `calendar-header.component.spec.ts` (class-level): asserts the options array is `['day','week','month','schedule','compliance']` for all users.
- `q/calendar-admin-gating.spec.ts` converted from asserting the old admin-only behavior into a regression guard: a non-admin sees the full five-option list. (Stale doc comment in `q/calendar-month-view.spec.ts` updated to match.)

Client toolchain gates (lint/tests) run in CI via the host toolchain per repo convention — no local Angular toolchain in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)