### PR TITLE
fix(adhoc): align task drawer intro and complete button

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
@@ -9,15 +9,20 @@
     </button>
   </div>
 
-  <div class="adhoc-drawer__intro d-flex align-items-center justify-content-between" *ngIf="!isCreate">
-    <div>
-      <span>{{ 'Created by' | translate }}: {{ workerName(task?.createdByWorkerId) }}</span>
-      ·
-      <span>{{ propertyName(task?.propertyId) }}</span>
-      ·
-      <span>{{ task?.createdAt | date: 'dd.MM.yyyy' }}</span>
-    </div>
-    <button type="button" mat-stroked-button id="adhoc-drawer-complete" *ngIf="canComplete" (click)="onCompleteTask()">
+  <!--
+    Intro text is indented to the content column (icon gutter of the gcal
+    rows below), and the complete button sits on its own row, right-aligned
+    to the content gutter the fields end at (#1101 / #1102).
+  -->
+  <div class="adhoc-drawer__intro" *ngIf="!isCreate">
+    <span>{{ 'Created by' | translate }}: {{ workerName(task?.createdByWorkerId) }}</span>
+    ·
+    <span>{{ propertyName(task?.propertyId) }}</span>
+    ·
+    <span>{{ task?.createdAt | date: 'dd.MM.yyyy' }}</span>
+  </div>
+  <div class="adhoc-drawer__complete-row" *ngIf="!isCreate && canComplete">
+    <button type="button" mat-stroked-button id="adhoc-drawer-complete" (click)="onCompleteTask()">
       <mat-icon fontSet="material-symbols-outlined">task_alt</mat-icon>
       {{ 'Complete task' | translate }}
     </button>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.scss
@@ -32,10 +32,22 @@
   padding: 8px 8px 0 16px;
 }
 
+// Left padding = the content column's left edge: 16px `.gcal-modal`
+// padding + 20px `.gcal-icon` + 16px icon margin, so the intro text lines
+// up with the task text / form fields below (#1101).
 .adhoc-drawer__intro {
-  padding: 0 16px 8px;
+  padding: 0 16px 8px 52px;
   font-size: 12px;
   color: rgba(0, 0, 0, 0.6);
+}
+
+// Complete-task button on its own row, right-aligned to the content
+// gutter (`.gcal-modal` padding-right: 24px) so it shares the Property
+// dropdown's right edge (#1102).
+.adhoc-drawer__complete-row {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 24px 8px 52px;
 }
 
 .adhoc-drawer__content {


### PR DESCRIPTION
Fixes two adhoc task-drawer layout issues (base = stable, so these do not auto-close — close manually after merge):

- #1101 — the "Oprettet af" line is now indented 52px (16px modal padding + 20px icon width + 16px icon margin) so it aligns with the left edge of the task text column.
- #1102 — the "Færdiggør opgaven" button moved out of the intro row into its own `adhoc-drawer__complete-row` flex row, right-aligned with a 24px right gutter matching the Ejendom dropdown's right edge. Visibility gate is unchanged (`!isCreate && canComplete`, previously expressed by nesting), and the `#adhoc-drawer-complete` id used by the Playwright page object's `drawerCompleteBtn()` is preserved.

No behavior changes beyond layout. Dual code-review + code-simplifier gate ran on the final diff; the review caught and we fixed a ViewEncapsulation.None class collision with the Cancel/Save footer (new row class renamed to `adhoc-drawer__complete-row`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)