### PR TITLE
feat(adhoc): visible delete button and confirm modal for task photos

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
@@ -47,6 +47,13 @@ import { selectValueInNgSelector, selectDateOnNewDatePicker } from '../../helper
  *     (deadline/reminders). `expandSection()` is retained as a no-op-safe
  *     helper (it only clicks when a `mat-expansion-panel-header` actually
  *     exists) so specs keep passing against either markup.
+ *   - Drawer photos (#1099/#1100): thumbnails carry
+ *     `data-e2e="adhoc-photo-thumb"` (existing/server-side) /
+ *     `"adhoc-photo-thumb-queued"` (create-mode previews), each with a
+ *     `data-e2e="adhoc-photo-delete-btn"` delete-X (design-spec thumbnail
+ *     Variant C). Clicking the X opens the "Slet billede?" confirm modal
+ *     (`#adhocPhotoDeleteConfirmBtn`/`-CancelBtn`) - NOTHING is removed
+ *     until confirm; cancel/ESC/scrim-click keeps the photo.
  *   - Modals: delete (`#adhocDeleteConfirmBtn`/`-CancelBtn`), copy
  *     (`#adhocCopyWithCommentsBtn`/`-WithoutCommentsBtn`/`-CancelBtn`),
  *     complete (`#adhocCompletePerformerSelect` - optional, no PIN field per
@@ -463,6 +470,61 @@ export class BackendConfigurationAdhocPage {
       .click();
     await this.page.locator('.mat-datepicker-content').waitFor({ state: 'visible', timeout: 5000 });
     await selectDateOnNewDatePicker(this.page, year, month, day);
+  }
+
+  // ----- Drawer photos (#1099/#1100) -----------------------------------------
+
+  /** Existing (server-side) photo thumbnails in the open drawer. */
+  photoThumbs(): Locator {
+    return this.page.locator('.adhoc-drawer [data-e2e="adhoc-photo-thumb"]');
+  }
+
+  /** Queued (create-mode, not yet uploaded) photo preview thumbnails. */
+  queuedPhotoThumbs(): Locator {
+    return this.page.locator('.adhoc-drawer [data-e2e="adhoc-photo-thumb-queued"]');
+  }
+
+  /** The always-visible delete-X on the `index`-th existing photo thumbnail. */
+  photoDeleteBtn(index = 0): Locator {
+    return this.photoThumbs().nth(index).locator('[data-e2e="adhoc-photo-delete-btn"]');
+  }
+
+  /** The delete-X on the `index`-th queued (create-mode) preview thumbnail. */
+  queuedPhotoDeleteBtn(index = 0): Locator {
+    return this.queuedPhotoThumbs().nth(index).locator('[data-e2e="adhoc-photo-delete-btn"]');
+  }
+
+  /** "Slet" in the "Slet billede?" confirm modal. */
+  photoDeleteConfirmBtn(): Locator {
+    return this.page.locator('#adhocPhotoDeleteConfirmBtn');
+  }
+
+  /** "Annuller" in the "Slet billede?" confirm modal. */
+  photoDeleteCancelBtn(): Locator {
+    return this.page.locator('#adhocPhotoDeleteCancelBtn');
+  }
+
+  /**
+   * Clicks the delete-X on a photo thumbnail and confirms the "Slet
+   * billede?" modal. Existing-photo removal is only STAGED here - it is
+   * applied server-side when the drawer is saved (`saveDrawer()`); queued
+   * previews disappear immediately.
+   */
+  async deletePhoto(index = 0, kind: 'existing' | 'queued' = 'existing'): Promise<void> {
+    const deleteBtn = kind === 'queued' ? this.queuedPhotoDeleteBtn(index) : this.photoDeleteBtn(index);
+    await deleteBtn.click();
+    await this.photoDeleteConfirmBtn().waitFor({ state: 'visible', timeout: 5000 });
+    await this.photoDeleteConfirmBtn().click();
+    await this.photoDeleteConfirmBtn().waitFor({ state: 'detached', timeout: 5000 });
+  }
+
+  /** Clicks the delete-X but cancels the confirm modal - the photo must survive. */
+  async cancelPhotoDelete(index = 0, kind: 'existing' | 'queued' = 'existing'): Promise<void> {
+    const deleteBtn = kind === 'queued' ? this.queuedPhotoDeleteBtn(index) : this.photoDeleteBtn(index);
+    await deleteBtn.click();
+    await this.photoDeleteCancelBtn().waitFor({ state: 'visible', timeout: 5000 });
+    await this.photoDeleteCancelBtn().click();
+    await this.photoDeleteCancelBtn().waitFor({ state: 'detached', timeout: 5000 });
   }
 
   drawerSaveBtn(): Locator {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/bgBG.ts
@@ -583,4 +583,8 @@ export const bgBG = {
   Tasks: 'Задачи',
   'Batch action': 'Групово действие',
   'Select batch action': 'Изберете действие за пакет',
+  'Delete photo': 'Изтриване на снимката',
+  'Delete photo?': 'Да се изтрие ли снимката?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Снимката ще бъде премахната от задачата. Действието не може да бъде отменено.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/csCZ.ts
@@ -583,4 +583,8 @@ export const csCZ = {
   Tasks: 'Úkoly',
   'Batch action': 'Dávková akce',
   'Select batch action': 'Vyberte dávkovou akci',
+  'Delete photo': 'Smazat fotografii',
+  'Delete photo?': 'Smazat fotografii?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Fotografie bude z úkolu odstraněna. Tuto akci nelze vrátit zpět.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/da.ts
@@ -707,4 +707,9 @@ export const da = {
   'No areas on this property yet': 'Der er endnu ingen områder på denne ejendom',
   'One area name per line': 'Ét områdenavn pr. linje',
   'Rename area': 'Omdøb område',
+  // Adhoc drawer photo-delete UX (#1099 aria-label, #1100 confirm modal).
+  'Delete photo': 'Slet billede',
+  'Delete photo?': 'Slet billede?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Billedet fjernes fra opgaven. Handlingen kan ikke fortrydes.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/deDE.ts
@@ -631,4 +631,8 @@ export const deDE = {
   Tasks: 'Aufgaben',
   'Batch action': 'Stapelverarbeitung',
   'Select batch action': 'Stapelaktion auswählen',
+  'Delete photo': 'Foto löschen',
+  'Delete photo?': 'Foto löschen?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Das Foto wird aus der Aufgabe entfernt. Diese Aktion kann nicht rückgängig gemacht werden.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/elGR.ts
@@ -583,4 +583,8 @@ export const elGR = {
   Tasks: 'Εργασίες',
   'Batch action': 'Μαζική ενέργεια',
   'Select batch action': 'Επιλογή μαζικής ενέργειας',
+  'Delete photo': 'Διαγραφή φωτογραφίας',
+  'Delete photo?': 'Διαγραφή φωτογραφίας;',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Η φωτογραφία θα αφαιρεθεί από την εργασία. Η ενέργεια δεν μπορεί να αναιρεθεί.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/enUS.ts
@@ -722,4 +722,9 @@ export const enUS= {
   'No areas on this property yet': 'No areas on this property yet',
   'One area name per line': 'One area name per line',
   'Rename area': 'Rename area',
+  // Adhoc drawer photo-delete UX (#1099 aria-label, #1100 confirm modal).
+  'Delete photo': 'Delete photo',
+  'Delete photo?': 'Delete photo?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'The photo will be removed from the task. This action cannot be undone.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/esES.ts
@@ -583,4 +583,8 @@ export const esES = {
   Tasks: 'Tareas',
   'Batch action': 'Acción por lotes',
   'Select batch action': 'Seleccione la acción por lotes',
+  'Delete photo': 'Eliminar foto',
+  'Delete photo?': '¿Eliminar foto?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'La foto se eliminará de la tarea. Esta acción no se puede deshacer.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/etET.ts
@@ -583,4 +583,8 @@ export const etET = {
   Tasks: 'Ülesanded',
   'Batch action': 'Paketttoiming',
   'Select batch action': 'Valige partiitoiming',
+  'Delete photo': 'Kustuta foto',
+  'Delete photo?': 'Kas kustutada foto?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Foto eemaldatakse ülesandest. Toimingut ei saa tagasi võtta.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/fiFI.ts
@@ -583,4 +583,8 @@ export const fiFI = {
   Tasks: 'Tehtävät',
   'Batch action': 'Erätoiminto',
   'Select batch action': 'Valitse erätoiminto',
+  'Delete photo': 'Poista kuva',
+  'Delete photo?': 'Poistetaanko kuva?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Kuva poistetaan tehtävästä. Toimintoa ei voi kumota.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/frFR.ts
@@ -582,4 +582,8 @@ export const frFR = {
   Tasks: 'Tâches',
   'Batch action': 'Action par lots',
   'Select batch action': 'Sélectionner l\'action par lots',
+  'Delete photo': 'Supprimer la photo',
+  'Delete photo?': 'Supprimer la photo ?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'La photo sera retirée de la tâche. Cette action est irréversible.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/hrHR.ts
@@ -583,4 +583,8 @@ export const hrHR = {
   Tasks: 'Zadaci',
   'Batch action': 'Skupna radnja',
   'Select batch action': 'Odaberite skupnu radnju',
+  'Delete photo': 'Izbriši fotografiju',
+  'Delete photo?': 'Izbrisati fotografiju?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Fotografija će biti uklonjena iz zadatka. Radnja se ne može poništiti.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/huHU.ts
@@ -583,4 +583,8 @@ export const huHU = {
   Tasks: 'Feladatok',
   'Batch action': 'Kötegelt művelet',
   'Select batch action': 'Kötegelt művelet kiválasztása',
+  'Delete photo': 'Fénykép törlése',
+  'Delete photo?': 'Törli a fényképet?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'A fénykép eltávolításra kerül a feladatból. A művelet nem vonható vissza.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/isIS.ts
@@ -583,4 +583,8 @@ export const isIS = {
   Tasks: 'Verkefni',
   'Batch action': 'Hópaaðgerð',
   'Select batch action': 'Veldu hópaðgerð',
+  'Delete photo': 'Eyða mynd',
+  'Delete photo?': 'Eyða mynd?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Myndin verður fjarlægð úr verkefninu. Ekki er hægt að afturkalla þessa aðgerð.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/itIT.ts
@@ -583,4 +583,8 @@ export const itIT = {
   Tasks: 'Compiti',
   'Batch action': 'Azione batch',
   'Select batch action': 'Seleziona l\'azione batch',
+  'Delete photo': 'Elimina foto',
+  'Delete photo?': 'Eliminare la foto?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'La foto verrà rimossa dall\'attività. Questa azione non può essere annullata.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ltLT.ts
@@ -583,4 +583,8 @@ export const ltLT = {
   Tasks: 'Užduotys',
   'Batch action': 'Paketinis veiksmas',
   'Select batch action': 'Pasirinkite paketinį veiksmą',
+  'Delete photo': 'Ištrinti nuotrauką',
+  'Delete photo?': 'Ištrinti nuotrauką?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Nuotrauka bus pašalinta iš užduoties. Šio veiksmo negalima atšaukti.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/lvLV.ts
@@ -583,4 +583,8 @@ export const lvLV = {
   Tasks: 'Uzdevumi',
   'Batch action': 'Partijas darbība',
   'Select batch action': 'Atlasīt partijas darbību',
+  'Delete photo': 'Dzēst fotoattēlu',
+  'Delete photo?': 'Vai dzēst fotoattēlu?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Fotoattēls tiks noņemts no uzdevuma. Šo darbību nevar atsaukt.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/nlNL.ts
@@ -583,4 +583,8 @@ export const nlNL = {
   Tasks: 'Taken',
   'Batch action': 'Batchactie',
   'Select batch action': 'Selecteer batchactie',
+  'Delete photo': 'Foto verwijderen',
+  'Delete photo?': 'Foto verwijderen?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'De foto wordt uit de taak verwijderd. Deze actie kan niet ongedaan worden gemaakt.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/noNO.ts
@@ -583,4 +583,8 @@ export const noNO = {
   Tasks: 'Oppgaver',
   'Batch action': 'Gruppehandling',
   'Select batch action': 'Velg batchhandling',
+  'Delete photo': 'Slett bilde',
+  'Delete photo?': 'Slett bilde?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Bildet fjernes fra oppgaven. Handlingen kan ikke angres.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/plPL.ts
@@ -583,4 +583,8 @@ export const plPL = {
   Tasks: 'Zadania',
   'Batch action': 'Akcja wsadowa',
   'Select batch action': 'Wybierz akcję wsadową',
+  'Delete photo': 'Usuń zdjęcie',
+  'Delete photo?': 'Usunąć zdjęcie?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Zdjęcie zostanie usunięte z zadania. Tej operacji nie można cofnąć.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptBR.ts
@@ -583,4 +583,8 @@ export const ptBR = {
   Tasks: 'Tarefas',
   'Batch action': 'Ação em lote',
   'Select batch action': 'Selecione a ação em lote',
+  'Delete photo': 'Excluir foto',
+  'Delete photo?': 'Excluir foto?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'A foto será removida da tarefa. Esta ação não pode ser desfeita.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ptPT.ts
@@ -583,4 +583,8 @@ export const ptPT = {
   Tasks: 'Tarefas',
   'Batch action': 'Ação em lote',
   'Select batch action': 'Selecione a ação em lote',
+  'Delete photo': 'Eliminar foto',
+  'Delete photo?': 'Eliminar foto?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'A foto será removida da tarefa. Esta ação não pode ser anulada.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/roRO.ts
@@ -583,4 +583,8 @@ export const roRO = {
   Tasks: 'Sarcini',
   'Batch action': 'Acțiune în lot',
   'Select batch action': 'Selectați acțiunea în lot',
+  'Delete photo': 'Ștergeți fotografia',
+  'Delete photo?': 'Ștergeți fotografia?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Fotografia va fi eliminată din sarcină. Această acțiune nu poate fi anulată.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/skSK.ts
@@ -583,4 +583,8 @@ export const skSK = {
   Tasks: 'Úlohy',
   'Batch action': 'Dávková akcia',
   'Select batch action': 'Vybrať dávkovú akciu',
+  'Delete photo': 'Vymazať fotografiu',
+  'Delete photo?': 'Vymazať fotografiu?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Fotografia bude z úlohy odstránená. Túto akciu nie je možné vrátiť späť.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/slSL.ts
@@ -583,4 +583,8 @@ export const slSL = {
   Tasks: 'Naloge',
   'Batch action': 'Paketno dejanje',
   'Select batch action': 'Izberite paketno dejanje',
+  'Delete photo': 'Izbriši fotografijo',
+  'Delete photo?': 'Izbrisati fotografijo?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Fotografija bo odstranjena iz naloge. Dejanja ni mogoče razveljaviti.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/svSE.ts
@@ -583,4 +583,8 @@ export const svSE = {
   Tasks: 'Uppgifter',
   'Batch action': 'Batchåtgärd',
   'Select batch action': 'Välj batchåtgärd',
+  'Delete photo': 'Radera foto',
+  'Delete photo?': 'Radera foto?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Fotot tas bort från uppgiften. Åtgärden kan inte ångras.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/i18n/ukUA.ts
@@ -583,4 +583,8 @@ export const ukUA = {
   Tasks: 'Завдання',
   'Batch action': 'Пакетна дія',
   'Select batch action': 'Виберіть пакетну дію',
+  'Delete photo': 'Видалити фото',
+  'Delete photo?': 'Видалити фото?',
+  'The photo will be removed from the task. This action cannot be undone.':
+    'Фото буде видалено із завдання. Цю дію неможливо скасувати.',
 };

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/adhoc.module.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/adhoc.module.ts
@@ -27,6 +27,7 @@ import {
   AdhocDeleteModalComponent,
   AdhocFiltersComponent,
   AdhocHistoryComponent,
+  AdhocPhotoDeleteModalComponent,
   AdhocTableComponent,
   AdhocTaskDrawerComponent,
 } from './components';
@@ -43,6 +44,7 @@ import {
     AdhocFiltersComponent,
     AdhocTaskDrawerComponent,
     AdhocDeleteModalComponent,
+    AdhocPhotoDeleteModalComponent,
     AdhocCopyModalComponent,
     AdhocCompleteModalComponent,
     AdhocHistoryComponent,

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-photo-delete-modal/adhoc-photo-delete-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-photo-delete-modal/adhoc-photo-delete-modal.component.html
@@ -1,0 +1,14 @@
+<h3 mat-dialog-title>{{ 'Delete photo?' | translate }}</h3>
+<div mat-dialog-content>
+  <p class="photo-delete-modal-body">{{ 'The photo will be removed from the task. This action cannot be undone.' | translate }}</p>
+</div>
+<div mat-dialog-actions class="d-flex flex-row justify-content-end gap-8">
+  <!-- Initial focus lands on the dismissive action, never on the
+       destructive one (design-spec Surface 2). -->
+  <button mat-button id="adhocPhotoDeleteCancelBtn" data-e2e="adhoc-photo-delete-cancel" cdkFocusInitial (click)="hide()">
+    {{ 'Cancel' | translate }}
+  </button>
+  <button mat-flat-button id="adhocPhotoDeleteConfirmBtn" data-e2e="adhoc-photo-delete-confirm" (click)="confirm()">
+    {{ 'Delete' | translate }}
+  </button>
+</div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-photo-delete-modal/adhoc-photo-delete-modal.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-photo-delete-modal/adhoc-photo-delete-modal.component.scss
@@ -1,0 +1,32 @@
+// "Slet billede?" confirm (#1100) - design-spec Surface 2 values: light
+// dismissive text button vs filled brand-red destructive button (white on
+// #961B1E ~= 8.5:1), double-ring focus indicator that survives any backdrop.
+.photo-delete-modal-body {
+  margin: 0;
+  font-size: 14px;
+  line-height: 20px;
+  color: #49454f;
+}
+
+// Id selectors out-rank the MDC theme's class-based button colors, so no
+// !important is needed.
+#adhocPhotoDeleteCancelBtn {
+  color: #961b1e;
+
+  &:hover {
+    background: rgba(150, 27, 30, 0.08);
+  }
+}
+
+#adhocPhotoDeleteConfirmBtn {
+  background-color: #961b1e;
+  color: #fff;
+}
+
+#adhocPhotoDeleteCancelBtn,
+#adhocPhotoDeleteConfirmBtn {
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px #fff, 0 0 0 4px #961b1e;
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-photo-delete-modal/adhoc-photo-delete-modal.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-photo-delete-modal/adhoc-photo-delete-modal.component.spec.ts
@@ -1,0 +1,26 @@
+import {AdhocPhotoDeleteModalComponent} from './adhoc-photo-delete-modal.component';
+
+/**
+ * Class-level unit test (repo convention: authored, not run locally - jest
+ * runs from the host frontend). The modal is a pure confirm dialog (#1100):
+ * it owns no service calls, it only reports the user's choice.
+ */
+describe('AdhocPhotoDeleteModalComponent', () => {
+  let dialogRefSpy: any;
+  let component: AdhocPhotoDeleteModalComponent;
+
+  beforeEach(() => {
+    dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+    component = new AdhocPhotoDeleteModalComponent(dialogRefSpy);
+  });
+
+  it('hide() closes with false', () => {
+    component.hide();
+    expect(dialogRefSpy.close).toHaveBeenCalledWith(false);
+  });
+
+  it('confirm() closes with true', () => {
+    component.confirm();
+    expect(dialogRefSpy.close).toHaveBeenCalledWith(true);
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-photo-delete-modal/adhoc-photo-delete-modal.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-photo-delete-modal/adhoc-photo-delete-modal.component.ts
@@ -1,0 +1,31 @@
+import {Component} from '@angular/core';
+import {MatDialogRef} from '@angular/material/dialog';
+
+/**
+ * "Slet billede?" confirmation (#1100) - gates BOTH photo-delete flavours in
+ * the task drawer (existing/server-side photos and queued create-mode
+ * previews). Unlike `AdhocDeleteModalComponent` (which performs the task
+ * delete itself), this modal is a pure confirm: it only closes with
+ * `true`/`false` and the drawer performs the actual removal - existing-photo
+ * removal is merely staged locally (`removedPhotoIds`, applied on save) and
+ * queued-photo removal is a local array splice, so there is no service call
+ * to share here.
+ */
+@Component({
+  selector: 'app-adhoc-photo-delete-modal',
+  templateUrl: './adhoc-photo-delete-modal.component.html',
+  styleUrls: ['./adhoc-photo-delete-modal.component.scss'],
+  standalone: false,
+})
+export class AdhocPhotoDeleteModalComponent {
+  constructor(public dialogRef: MatDialogRef<AdhocPhotoDeleteModalComponent, boolean>) {
+  }
+
+  hide(): void {
+    this.dialogRef.close(false);
+  }
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+}

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
@@ -123,16 +123,38 @@
           <div class="gcal-row-content adhoc-drawer__photos" id="ny-sektion-komm-billeder">
             <div class="adhoc-drawer__section-title">{{ 'Pictures' | translate }}</div>
             <div class="d-flex flex-wrap gap-8">
-              <div class="photo-thumb" *ngFor="let photo of visiblePhotos" (click)="onViewPhotos(photo)">
+              <!-- #1099 delete-X: design-spec thumbnail Variant C (28px dark
+                   scrim circle, always visible, 44x44 effective target - see
+                   the .photo-delete-btn rules). The X is an inline SVG, not a
+                   font glyph, per the spec. #1100: clicks route through the
+                   "Slet billede?" confirm modal instead of deleting directly. -->
+              <div class="photo-thumb" data-e2e="adhoc-photo-thumb" *ngFor="let photo of visiblePhotos" (click)="onViewPhotos(photo)">
                 <img [src]="photoUrl(photo) | authImage | async" alt="">
-                <button type="button" mat-icon-button *ngIf="!readonly" (click)="removeExistingPhoto(photo); $event.stopPropagation()">
-                  <mat-icon>close</mat-icon>
+                <button
+                  type="button"
+                  class="photo-delete-btn"
+                  data-e2e="adhoc-photo-delete-btn"
+                  *ngIf="!readonly"
+                  [attr.aria-label]="'Delete photo' | translate"
+                  (click)="onDeleteExistingPhoto(photo); $event.stopPropagation()"
+                >
+                  <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true">
+                    <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  </svg>
                 </button>
               </div>
-              <div class="photo-thumb photo-thumb--queued" *ngFor="let preview of queuedPhotoPreviews; let i = index">
+              <div class="photo-thumb photo-thumb--queued" data-e2e="adhoc-photo-thumb-queued" *ngFor="let preview of queuedPhotoPreviews; let i = index">
                 <img [src]="preview" alt="">
-                <button type="button" mat-icon-button (click)="removeQueuedPhoto(i)">
-                  <mat-icon>close</mat-icon>
+                <button
+                  type="button"
+                  class="photo-delete-btn"
+                  data-e2e="adhoc-photo-delete-btn"
+                  [attr.aria-label]="'Delete photo' | translate"
+                  (click)="onDeleteQueuedPhoto(i)"
+                >
+                  <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true">
+                    <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  </svg>
                 </button>
               </div>
               <label class="photo-upload-btn" *ngIf="!readonly">

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.scss
@@ -137,13 +137,60 @@
     border-radius: 4px;
   }
 
-  button {
+  // #1099 delete-X, design-spec thumbnail Variant C: 28px near-opaque dark
+  // scrim circle, always visible on all devices (no hover-reveal - that was
+  // the discoverability complaint), hairline border for edge definition on
+  // dark photos, white 16px SVG glyph.
+  .photo-delete-btn {
     position: absolute;
-    top: -8px;
-    right: -8px;
-    width: 24px;
-    height: 24px;
-    line-height: 24px;
+    top: 4px;
+    right: 4px;
+    box-sizing: border-box;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    border-radius: 50%;
+    background: rgba(32, 33, 36, 0.8);
+    backdrop-filter: blur(4px);
+    color: #fff;
+    cursor: pointer;
+
+    svg {
+      display: block;
+    }
+
+    // 44x44px effective touch target - the pseudo-element extends the
+    // clickable area while the visible circle/glyph stay 28/16px.
+    &::after {
+      content: '';
+      position: absolute;
+      inset: -8px;
+    }
+
+    &:hover {
+      background: rgba(32, 33, 36, 0.95);
+    }
+
+    &:active {
+      transform: scale(0.94);
+    }
+
+    // Double ring survives any photo behind it (white inner, brand-red outer).
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 2px #fff, 0 0 0 4px #961b1e;
+    }
+  }
+}
+
+// No-blur fallback: raise the scrim alpha so contrast holds without the blur.
+@supports not (backdrop-filter: blur(4px)) {
+  .photo-thumb .photo-delete-btn {
+    background: rgba(32, 33, 36, 0.88);
   }
 }
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.spec.ts
@@ -13,6 +13,8 @@ describe('AdhocTaskDrawerComponent', () => {
   let adhocServiceSpy: any;
   let gallerySpy: any;
   let lightboxSpy: any;
+  let matDialogSpy: any;
+  let overlaySpy: any;
 
   const existingTask: AdhocTaskModel = {
     id: 42,
@@ -57,6 +59,9 @@ describe('AdhocTaskDrawerComponent', () => {
     ]);
     gallerySpy = {ref: jasmine.createSpy('ref').and.returnValue({load: jasmine.createSpy('load')})};
     lightboxSpy = {open: jasmine.createSpy('open')};
+    matDialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+    // dialogConfigHelper(overlay) only touches scrollStrategies.reposition().
+    overlaySpy = {scrollStrategies: {reposition: jasmine.createSpy('reposition').and.returnValue({})}};
 
     const component = new AdhocTaskDrawerComponent(
       dialogRefSpy,
@@ -66,6 +71,8 @@ describe('AdhocTaskDrawerComponent', () => {
       adhocServiceSpy,
       gallerySpy,
       lightboxSpy,
+      matDialogSpy,
+      overlaySpy,
     );
     component.ngOnInit();
     return component;
@@ -110,6 +117,30 @@ describe('AdhocTaskDrawerComponent', () => {
     it('showTagsSection is true in create mode despite tagIds being empty', () => {
       expect(component.tagIds).toEqual([]);
       expect(component.showTagsSection).toBeTrue();
+    });
+
+    // #1100: queued (create-mode) previews get the same confirm gate as
+    // existing photos.
+    it('onDeleteQueuedPhoto removes the queued file only after the modal confirms', () => {
+      spyOn(URL, 'revokeObjectURL');
+      component.queuedPhotoFiles = [new File([''], 'a.png', {type: 'image/png'})];
+      component.queuedPhotoPreviews = ['blob:a'];
+      matDialogSpy.open.and.returnValue({afterClosed: () => of(true)});
+      component.onDeleteQueuedPhoto(0);
+      expect(component.queuedPhotoFiles).toEqual([]);
+      expect(component.queuedPhotoPreviews).toEqual([]);
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:a');
+    });
+
+    it('onDeleteQueuedPhoto keeps the queued file when the modal is cancelled', () => {
+      spyOn(URL, 'revokeObjectURL');
+      component.queuedPhotoFiles = [new File([''], 'a.png', {type: 'image/png'})];
+      component.queuedPhotoPreviews = ['blob:a'];
+      matDialogSpy.open.and.returnValue({afterClosed: () => of(false)});
+      component.onDeleteQueuedPhoto(0);
+      expect(component.queuedPhotoFiles.length).toBe(1);
+      expect(component.queuedPhotoPreviews).toEqual(['blob:a']);
+      expect(URL.revokeObjectURL).not.toHaveBeenCalled();
     });
   });
 
@@ -190,6 +221,34 @@ describe('AdhocTaskDrawerComponent', () => {
       const sentModel = adhocServiceSpy.updateTask.calls.mostRecent().args[1];
       expect(sentModel.executionRule).toBe(1);
       expect(sentModel.assignedWorkerIds).toEqual([100]);
+    });
+
+    // #1100: the delete-X never removes a photo directly - the "Slet
+    // billede?" confirm modal gates both the existing- and queued-photo
+    // flavours, and only a confirmed close performs the removal.
+    it('onDeleteExistingPhoto removes the photo only after the modal confirms', () => {
+      matDialogSpy.open.and.returnValue({afterClosed: () => of(true)});
+      component.onDeleteExistingPhoto({id: 5000, contentType: 'image/png'});
+      expect(matDialogSpy.open).toHaveBeenCalled();
+      expect(component.visiblePhotos).toEqual([]);
+    });
+
+    it('onDeleteExistingPhoto keeps the photo when the modal is cancelled', () => {
+      matDialogSpy.open.and.returnValue({afterClosed: () => of(false)});
+      component.onDeleteExistingPhoto({id: 5000, contentType: 'image/png'});
+      expect(matDialogSpy.open).toHaveBeenCalled();
+      expect(component.visiblePhotos).toEqual([{id: 5000, contentType: 'image/png'}]);
+    });
+
+    // Design-spec Surface 2: ESC/scrim-click must cancel (the module-default
+    // dialogConfigHelper sets disableClose: true, which this flow overrides)
+    // and the dialog is announced as an alertdialog.
+    it('opens the photo-delete confirm as a cancellable alertdialog', () => {
+      matDialogSpy.open.and.returnValue({afterClosed: () => of(false)});
+      component.onDeleteExistingPhoto({id: 5000, contentType: 'image/png'});
+      const config = matDialogSpy.open.calls.mostRecent().args[1];
+      expect(config.disableClose).toBeFalse();
+      expect(config.role).toBe('alertdialog');
     });
 
     it('removeExistingPhoto excludes the photo from visiblePhotos and the saved photoIds', () => {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.ts
@@ -1,6 +1,8 @@
 import {Component, Inject, OnDestroy, OnInit, ViewEncapsulation} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
-import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material/dialog';
+import {Overlay} from '@angular/cdk/overlay';
+import {dialogConfigHelper} from 'src/app/common/helpers';
 import {Gallery, GalleryItem, ImageItem} from 'ng-gallery';
 import {Lightbox} from 'ng-gallery/lightbox';
 import {Subscription, forkJoin, from} from 'rxjs';
@@ -18,6 +20,7 @@ import {
 import {BackendConfigurationPnAdhocService} from '../../../../services';
 import {AdhocStateService} from '../store';
 import {resolvePropertyName, resolveWorkerName} from '../../adhoc-display.util';
+import {AdhocPhotoDeleteModalComponent} from '../adhoc-photo-delete-modal/adhoc-photo-delete-modal.component';
 
 export type AdhocTaskDrawerMode = 'create' | 'view' | 'edit';
 
@@ -100,6 +103,7 @@ export class AdhocTaskDrawerComponent implements OnInit, OnDestroy {
   createTagSub$: Subscription;
   uploadPhotoSub$: Subscription;
   viewPhotosSub$: Subscription;
+  photoDeleteSub$: Subscription;
 
   constructor(
     public dialogRef: MatDialogRef<AdhocTaskDrawerComponent, AdhocTaskDrawerCloseResult>,
@@ -109,6 +113,8 @@ export class AdhocTaskDrawerComponent implements OnInit, OnDestroy {
     private adhocService: BackendConfigurationPnAdhocService,
     public gallery: Gallery,
     public lightbox: Lightbox,
+    private dialog: MatDialog,
+    private overlay: Overlay,
   ) {
     this.mode = data.mode;
     this.task = data.task ?? null;
@@ -290,6 +296,36 @@ export class AdhocTaskDrawerComponent implements OnInit, OnDestroy {
 
   removeExistingPhoto(photo: AdhocTaskPhotoModel): void {
     this.removedPhotoIds.add(photo.id);
+  }
+
+  // #1100: both delete-X flavours (existing/server-side photo, queued
+  // create-mode preview) route through the "Slet billede?" confirmation
+  // modal - the removal itself only runs when the user confirms.
+
+  onDeleteExistingPhoto(photo: AdhocTaskPhotoModel): void {
+    this.confirmPhotoDelete(() => this.removeExistingPhoto(photo));
+  }
+
+  onDeleteQueuedPhoto(index: number): void {
+    this.confirmPhotoDelete(() => this.removeQueuedPhoto(index));
+  }
+
+  private confirmPhotoDelete(removePhoto: () => void): void {
+    this.photoDeleteSub$ = this.dialog
+      .open(AdhocPhotoDeleteModalComponent, {
+        ...dialogConfigHelper(this.overlay),
+        // Design-spec Surface 2 deviations from the module's default confirm
+        // config: ESC and scrim-click cancel (dialogConfigHelper sets
+        // disableClose: true), and the dialog is announced as an alertdialog.
+        disableClose: false,
+        role: 'alertdialog',
+      })
+      .afterClosed()
+      .subscribe((confirmed) => {
+        if (confirmed) {
+          removePhoto();
+        }
+      });
   }
 
   photoUrl(photo: AdhocTaskPhotoModel): string {

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/index.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/index.ts
@@ -3,6 +3,7 @@ export * from './adhoc-table/adhoc-table.component';
 export * from './adhoc-filters/adhoc-filters.component';
 export * from './adhoc-task-drawer/adhoc-task-drawer.component';
 export * from './adhoc-delete-modal/adhoc-delete-modal.component';
+export * from './adhoc-photo-delete-modal/adhoc-photo-delete-modal.component';
 export * from './adhoc-copy-modal/adhoc-copy-modal.component';
 export * from './adhoc-complete-modal/adhoc-complete-modal.component';
 export * from './adhoc-history/adhoc-history.component';


### PR DESCRIPTION
Implements #1099 and #1100 (base = stable, so these do not auto-close — close manually after merge).

- **#1099** — always-visible delete-X on photo thumbnails, design **Variant C**: 28×28 circle, `rgba(32,33,36,.8)` scrim + `backdrop-filter: blur(4px)` (with `@supports` alpha fallback), white 16px SVG X, 44×44 touch target via `::after inset:-8px`, double-ring focus, applied to both existing and queued photo rows.
- **#1100** — new `AdhocPhotoDeleteModalComponent` ("Slet billede?") opened through the module's `dialogConfigHelper` idiom with `role: 'alertdialog'` and `disableClose: false` (ESC/scrim cancel); initial focus on Annuller (`cdkFocusInitial`). The modal is a pure confirm (closes true/false) — removal stays the staged-local operation it was (`removedPhotoIds` / queued splice), unchanged byte-for-byte and invoked only on confirm.
- e2e groundwork: `data-e2e` hooks on thumbs, delete buttons, and modal buttons, plus matching accessors and `deletePhoto`/`cancelPhotoDelete` flows in `BackendConfigurationAdhoc.page.ts` (photos previously had zero e2e surface).
- i18n: 3 new keys (`Delete photo`, `Delete photo?`, body copy) in all 26 locale files; buttons reuse the existing `Cancel`/`Delete` keys.
- Unit tests: confirm removes / cancel keeps for both photo flavours + dialog-config assertions, plus a spec for the new modal.

Deliberate deviation from the stakeholder spec: the confirm button is labeled **"Slet"**, not "OK" — an explicit destructive verb lets users confirm without re-reading the title (design-spec Surface 2 recommendation). The "Annuller / OK" layout is otherwise preserved (Annuller left, confirm right). The modal also keeps the module's standard MatDialog chrome rather than the spec's 360px/28px-radius M3 chrome, for consistency with the three existing adhoc modals.

Dual code-review + code-simplifier gate ran clean on the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)