### PR TITLE
fix(calendar): restore admin-only gating for the Compliance view

### DIFF
--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-admin-gating.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-admin-gating.spec.ts
@@ -3,17 +3,15 @@ import { CalendarUiEnhancementsPage } from '../calendar-ui-enhancements.page';
 import { generateRandmString } from '../../../helper-functions';
 
 /**
- * Calendar view-mode dropdown — "Måned"/Month and "Compliance" are available
- * to every user (regression guard).
+ * Calendar COMPLIANCE admin-gating suite.
  *
- * These two options used to be built conditionally on `isAdmin` in
- * calendar-header.component.ts's `buildViewModeOptions()`. That gating was
- * removed: all five options are now unconditional, so a NON-ADMIN user must
- * see the full list ['Dag', 'Uge', 'Måned', 'Tidsplan', 'Compliance'] — the
- * same order the ADMIN suite asserts (see `q/calendar-month-view.spec.ts`,
- * MV1). The endpoints these views call (calendar/tasks/week,
- * calendar/compliance-report) are `[Authorize]`-only, so non-admins are
- * served.
+ * The view-mode dropdown's admin-only option ("Compliance") is built
+ * conditionally on `isAdmin` in calendar-header.component.ts's
+ * `buildViewModeOptions()`. "Måned"/Month is NOT gated — it is available to
+ * every user, exactly like Dag/Uge/Tidsplan (see
+ * `q/calendar-month-view.spec.ts`, MV1, for the ADMIN dropdown order:
+ * Dag, Uge, Måned, Tidsplan, Compliance). A NON-ADMIN user must see exactly
+ * ['Dag', 'Uge', 'Måned', 'Tidsplan'] — never 'Compliance'.
  *
  * `loginViaApi`/`loginAs`/`setupNonAdminUser` are copied VERBATIM from
  * `r/property-workers-nonadmin-no-logout.spec.ts` (lines 23-166) — the same
@@ -173,7 +171,7 @@ async function setupNonAdminUser(page: Page, rand: string): Promise<string> {
   return userEmail;
 }
 
-test.describe.serial('Calendar view-mode dropdown — non-admin sees all options', () => {
+test.describe.serial('Calendar compliance view — non-admin dropdown gating', () => {
   const rand = generateRandmString(8).toLowerCase();
   let userEmail = '';
 
@@ -192,10 +190,9 @@ test.describe.serial('Calendar view-mode dropdown — non-admin sees all options
   });
 
   // =======================================================================
-  // Non-admin dropdown — all five options are present, including Måned and
-  // Compliance (same list and order the admin suite asserts).
+  // Non-admin dropdown gating — Måned stays present, Compliance does not.
   // =======================================================================
-  test('non-admin sees all five options including Måned and Compliance', async ({ page }) => {
+  test('non-admin sees Måned but not Compliance', async ({ page }) => {
     test.setTimeout(300000);
     expect(userEmail).not.toBe('');
 
@@ -208,6 +205,6 @@ test.describe.serial('Calendar view-mode dropdown — non-admin sees all options
     await page.waitForTimeout(2000);
     await page.locator('#calendarViewModeSelect').click();
     const options = page.locator('.ng-dropdown-panel .ng-option');
-    await expect(options).toHaveText(['Dag', 'Uge', 'Måned', 'Tidsplan', 'Compliance']);
+    await expect(options).toHaveText(['Dag', 'Uge', 'Måned', 'Tidsplan']);
   });
 });

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-month-view.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/q/calendar-month-view.spec.ts
@@ -15,10 +15,10 @@ import {
  * Calendar MONTH VIEW suite (calendar month-view feature).
  *
  * The view-mode dropdown (`#calendarViewModeSelect`) gains a third
- * option — "Måned" — between "Uge" and "Tidsplan". The full order is: Dag,
- * Uge, Måned, Tidsplan, Compliance — available to every user, not just
- * admins (see `q/calendar-admin-gating.spec.ts`, a regression guard
- * asserting a NON-ADMIN user sees the same full five-option list).
+ * option — "Måned" — between "Uge" and "Tidsplan", available to every user.
+ * For an ADMIN the full order is: Dag, Uge, Måned, Tidsplan, Compliance
+ * (see `q/calendar-admin-gating.spec.ts` for the non-admin variant, which
+ * keeps Måned but lacks the admin-only Compliance).
  *
  * Month view renders 6 `.month-week-row` rows, 6 `.wk-cell` week-number
  * buttons, and `.month-day-cell` cells (each carrying a `.day-number`

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.html
@@ -33,6 +33,7 @@
       [viewMode]="viewMode"
       [sidebarOpen]="sidebarOpen"
       [propertyName]="selectedPropertyName"
+      [isAdmin]="isAdmin"
       [scheduleScope]="scheduleScope"
       (navigate)="onNavigate($event)"
       (goToToday)="onGoToToday()"
@@ -100,6 +101,7 @@
 
       <ng-container *ngSwitchCase="'compliance'">
         <app-calendar-compliance-view
+          *ngIf="isAdmin"
           #complianceView
           [properties]="properties"
           [boards]="boards"

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-container/calendar-container.component.ts
@@ -125,12 +125,17 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
     private store: Store,
     private router: Router,
   ) {
-    // isAdmin still gates the admin-only controls in the week/day grid
-    // (see the [isAdmin] bindings in the template); the month and compliance
-    // views are available to every user, so no view-mode guard is applied.
     this.store.select(selectCurrentUserIsAdmin).pipe(takeUntil(this.destroy$))
       .subscribe(isAdmin => {
         this.isAdmin = isAdmin;
+        // isAdmin resolves async from the store after init — if it turns out
+        // the user is not an admin while compliance view is still active
+        // (e.g. deep link, or a stale admin session), force back to week
+        // view so a non-admin can never remain in the admin-only mode.
+        if (!isAdmin && this.viewMode === 'compliance') {
+          this.stateService.updateViewMode('week');
+          this.loadTasks();
+        }
       });
   }
 
@@ -144,6 +149,19 @@ export class CalendarContainerComponent implements OnInit, OnDestroy {
       this.activeTeamIds = filters.activeTeamIds;
       this.activeTagNames = filters.activeTagNames;
       this.sidebarOpen = filters.sidebarOpen;
+
+      // Defense in depth (mirrors the constructor's isAdmin-subscription
+      // guard): NgRx calendar state persists across in-app navigations, so
+      // a non-admin can land on this component with a stale 'compliance'
+      // viewMode inherited from a previous admin session, with no admin
+      // check ever having run. Force back to week — the updateViewMode
+      // dispatch re-emits filters$ with 'week', which this same
+      // subscription then processes normally, so no extra loadTasks() call
+      // is needed here.
+      if (this.viewMode === 'compliance' && !this.isAdmin) {
+        this.stateService.updateViewMode('week');
+        return;
+      }
     });
 
     this.loadProperties();

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.spec.ts
@@ -1,3 +1,4 @@
+import {SimpleChange} from '@angular/core';
 import {TranslateService} from '@ngx-translate/core';
 import {CalendarHeaderComponent} from './calendar-header.component';
 
@@ -17,13 +18,25 @@ describe('CalendarHeaderComponent', () => {
     component = new CalendarHeaderComponent(makeTranslate());
   });
 
-  it('offers all five view-mode options to every user', () => {
-    // ngOnInit builds the option list.
+  it('hides the Compliance option from non-admin users', () => {
+    // ngOnInit builds the option list; isAdmin defaults to false.
     component.ngOnInit();
 
     const values = component.viewModeOptions.map(o => o.value);
-    // Month and Compliance are available to everyone, exactly like
-    // day/week/schedule — no admin gating.
+    // Month is available to everyone, exactly like day/week/schedule —
+    // only Compliance is admin-gated.
+    expect(values).toEqual(['day', 'week', 'month', 'schedule']);
+  });
+
+  it('offers the Compliance option once isAdmin arrives from the store', () => {
+    component.ngOnInit();
+
+    // isAdmin is delivered asynchronously by the store after init, arriving
+    // as an @Input change — ngOnChanges must rebuild the option list.
+    component.isAdmin = true;
+    component.ngOnChanges({isAdmin: new SimpleChange(false, true, false)});
+
+    const values = component.viewModeOptions.map(o => o.value);
     expect(values).toEqual(['day', 'week', 'month', 'schedule', 'compliance']);
   });
 });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/components/calendar-header/calendar-header.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
 import {TranslateService} from '@ngx-translate/core';
 import {getCurrentLocale} from '../../services/calendar-locale.helper';
 
@@ -8,11 +8,12 @@ import {getCurrentLocale} from '../../services/calendar-locale.helper';
   templateUrl: './calendar-header.component.html',
   styleUrls: ['./calendar-header.component.scss'],
 })
-export class CalendarHeaderComponent implements OnInit {
+export class CalendarHeaderComponent implements OnInit, OnChanges {
   @Input() currentDate: string = '';
   @Input() viewMode: 'week' | 'day' | 'schedule' | 'month' | 'compliance' = 'week';
   @Input() sidebarOpen = true;
   @Input() propertyName: string = '';
+  @Input() isAdmin = false;
   @Input() scheduleScope: 'week' | 'month' = 'week';
 
   viewModeOptions: {value: string; label: string}[] = [];
@@ -29,13 +30,22 @@ export class CalendarHeaderComponent implements OnInit {
     this.buildViewModeOptions();
   }
 
+  ngOnChanges(changes: SimpleChanges) {
+    // isAdmin arrives asynchronously from the store after this component has
+    // already initialised, so the option list must be rebuilt whenever it
+    // changes (not just once in ngOnInit).
+    if (changes['isAdmin']) {
+      this.buildViewModeOptions();
+    }
+  }
+
   private buildViewModeOptions() {
     this.viewModeOptions = [
       {value: 'day', label: this.translate.instant('Day')},
       {value: 'week', label: this.translate.instant('Week')},
       {value: 'month', label: this.translate.instant('Month')},
       {value: 'schedule', label: this.translate.instant('List')},
-      {value: 'compliance', label: this.translate.instant('Compliance')},
+      ...(this.isAdmin ? [{value: 'compliance', label: this.translate.instant('Compliance')}] : []),
     ];
   }
 


### PR DESCRIPTION
Partial revert of #1098, per request: the **Compliance** calendar view mode is admin-gated again, while **Month (Måned) stays available to all users** (the other half of #1098 is preserved).

Restored from the pre-removal guard (`be78b62f^`), minus the month arm:
- `calendar-header`: `@Input() isAdmin` + `ngOnChanges` rebuild (isAdmin arrives async from the store), Compliance option emitted only for admins.
- `calendar-container`: `[isAdmin]` binding, `*ngIf="isAdmin"` on `<app-calendar-compliance-view>`, and both defense-in-depth resets — a non-admin whose persisted NgRx `viewMode` is `'compliance'` (deep link, role change, stale session) is sent back to `'week'`.
- Tests (both surfaces now execute in CI): the jest header spec asserts non-admins get `['day','week','month','schedule']` and admins additionally get `'compliance'` after `ngOnChanges`; `q/calendar-admin-gating.spec.ts` asserts a non-admin's dropdown reads `['Dag','Uge','Måned','Tidsplan']`; `q/calendar-month-view.spec.ts` comment-only update (its admin assertions are unchanged).

Note, as in the original guard: this is client-side gating. The `calendar/compliance-report` endpoint remains `[Authorize]`-only without a role check (that was #1098's rationale) — flagging in case a server-side role check should be a follow-up issue.

Dual code-review + code-simplifier gate ran clean on the final diff; the reviewer verified the restore byte-for-byte against `be78b62f^` apart from the deliberate month exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)