### PR TITLE
fix(adhoc): align "Oprettet af" with the drawer title, not the field column

### DIFF
--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.html
@@ -10,9 +10,10 @@
   </div>
 
   <!--
-    Intro text is indented to the content column (icon gutter of the gcal
-    rows below), and the complete button sits on its own row, right-aligned
-    to the content gutter the fields end at (#1101 / #1102).
+    Intro text is flush with the title above (both at the drawer's 16px
+    left edge - the title is the task text, #1107), and the complete button
+    sits on its own row, right-aligned to the content gutter the fields
+    end at (#1101 / #1102).
   -->
   <div class="adhoc-drawer__intro" *ngIf="!isCreate">
     <span>{{ 'Created by' | translate }}: {{ workerName(task?.createdByWorkerId) }}</span>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.scss
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/adhoc/components/adhoc-task-drawer/adhoc-task-drawer.component.scss
@@ -28,26 +28,41 @@
   width: min(560px, 100vw);
 }
 
+// 4px bottom padding keeps a small title→intro gap now that the title's
+// own theme bottom padding is zeroed (see the h3 rule below).
 .adhoc-drawer__header {
-  padding: 8px 8px 0 16px;
+  padding: 8px 8px 4px 16px;
 }
 
-// Left padding = the content column's left edge: 16px `.gcal-modal`
-// padding + 20px `.gcal-icon` + 16px icon margin, so the intro text lines
-// up with the task text / form fields below (#1101).
+// The themes give `mat-dialog-title` differing side padding (Material 20
+// default `6px 24px 13px`; theme-workspace `16px 16px 0`), pushing the
+// title off the drawer's 16px base edge - and each theme differently.
+// Zero it so the title sits flush at the header's 16px left padding,
+// where the intro below must align (#1107). ViewEncapsulation.None;
+// `!important` follows this file's theme-fight precedent (mtx-select
+// max-width lift below).
+.adhoc-drawer__header h3.mat-mdc-dialog-title {
+  padding: 0 !important;
+}
+
+// Left padding 16px = the header's left padding, so the "Created by"
+// intro's first glyph is flush with the title's first glyph - the title
+// IS the task text the stakeholder asked to align with (#1107, replacing
+// the #1101/#1103 form-field-column reading).
 .adhoc-drawer__intro {
-  padding: 0 16px 8px 52px;
+  padding: 0 16px 8px 16px;
   font-size: 12px;
   color: rgba(0, 0, 0, 0.6);
 }
 
 // Complete-task button on its own row, right-aligned to the content
 // gutter (`.gcal-modal` padding-right: 24px) so it shares the Property
-// dropdown's right edge (#1102).
+// dropdown's right edge (#1102). Left padding matches the drawer's 16px
+// base edge (inert while the button is right-aligned).
 .adhoc-drawer__complete-row {
   display: flex;
   justify-content: flex-end;
-  padding: 0 24px 8px 52px;
+  padding: 0 24px 8px 16px;
 }
 
 .adhoc-drawer__content {


### PR DESCRIPTION
Implements #1107 (does not auto-close — base is stable; close manually after merge).

Corrects the #1101→#1103 misinterpretation, verified against the stakeholder mockup of 13.08.2026: "Opgaveteksten" is the drawer **title** (it renders `task.title`), so "Oprettet af" must sit flush with it at the 16px base edge — not at the 52px form-field column.

- `.adhoc-drawer__intro` left padding `52px` → `16px`.
- New rule zeroing the title's theme-injected side padding (`.adhoc-drawer__header h3.mat-mdc-dialog-title { padding: 0 !important; }`) — makes the title's left edge 16px under **both** themes (Material default was 24px side padding → title at 40px; `theme-workspace` 16px → title at 32px). Reviewer verified the selector cannot leak beyond this drawer (class unique to the component) and that `!important` beats both theme sources; the close-X positioning is independent of title padding.
- Header bottom padding `0` → `4px`, preserving a theme-uniform title→intro gap.
- `.adhoc-drawer__complete-row` inert left padding normalized `52px` → `16px`; its behavior (own row, `flex-end`, 24px right inset matching the Ejendom dropdown) is **unchanged** — that half of #1103 matches the mockup (button right edge x=577 vs dropdown x=579) and stays.
- Stale derivation comments rewritten (a stale comment is what caused this round-trip).

Layout-only: `#adhoc-drawer-complete`, `onCompleteTask()`, and all `*ngIf` gating untouched. Dual code-review + code-simplifier gate ran clean on the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)