### PR TITLE
feat: convert task-wizard plannings to calendar tasks at 09:00-10:00

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarConfigurationBackfillTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarConfigurationBackfillTest.cs
@@ -29,19 +29,22 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microting.eForm.Infrastructure.Constants;
 using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
 using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
 using NUnit.Framework;
 
 namespace BackendConfiguration.Pn.Integration.Test;
 
 /// <summary>
-/// Focused coverage for <c>CalendarConfigurationBackfillService.RunIfNeededAsync</c>,
-/// the idempotent startup backfill that attaches a <c>CalendarConfiguration</c>
-/// (board link) to every non-removed <c>AreaRulePlanning</c> whose <c>AreaRule</c>
-/// has <c>CreatedInGuide == true</c> and does not already have one. Exercises: the
-/// happy path onto an existing board, auto-creation of a "Default" board when the
-/// property has none, idempotency against already-configured plannings, a second
-/// no-op run, and the <c>CreatedInGuide</c> filter that excludes non-wizard
-/// (area-rule-authored) plannings from the backfill.
+/// Coverage for <c>CalendarConfigurationBackfillService.RunIfNeededAsync</c>, the
+/// idempotent startup pass that converts task-wizard plannings (AreaRule
+/// <c>CreatedInGuide == true</c>, no live <c>CalendarConfiguration</c>) into
+/// calendar tasks: recurrence normalization on ARP + linked items-planning
+/// Planning row, then a <c>CalendarConfiguration</c> at 09:00-10:00 on the
+/// property's default board. Exercises the full frequency conversion table
+/// (Altid, legacy (Day,0), Day N, Week N, Month N, Year pass-through), inactive
+/// and orphaned rows, idempotency, crash-resume, board resolution, and the
+/// <c>CreatedInGuide</c> filter.
 /// </summary>
 [Parallelizable(ParallelScope.Fixtures)]
 [TestFixture]
@@ -76,8 +79,13 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
             BackendConfigurationPnDbContext.Properties);
         await BackendConfigurationPnDbContext.SaveChangesAsync();
 
+        ItemsPlanningPnDbContext!.Plannings.RemoveRange(
+            ItemsPlanningPnDbContext.Plannings);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
         _sut = new CalendarConfigurationBackfillService(
             BackendConfigurationPnDbContext!,
+            ItemsPlanningPnDbContext!,
             NullLogger<CalendarConfigurationBackfillService>.Instance);
     }
 
@@ -117,10 +125,10 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
     }
 
     /// <summary>
-    /// Seeds one AreaRule + AreaRulePlanning series for <paramref name="propertyId"/>.
-    /// <paramref name="createdInGuide"/> becomes AreaRule.CreatedInGuide, the flag the
-    /// backfill filters on: only rules created via the task wizard/calendar (true) are
-    /// eligible; rules authored directly on an area rule (false) are left alone.
+    /// Seeds one AreaRule + AreaRulePlanning series for <paramref name="propertyId"/>
+    /// WITHOUT a linked items-planning Planning row (ItemPlanningId points nowhere) —
+    /// the orphan case. <paramref name="createdInGuide"/> becomes
+    /// AreaRule.CreatedInGuide, the flag the backfill filters on.
     /// </summary>
     private async Task<AreaRulePlanning> SeedPlanning(int propertyId, int areaId, bool createdInGuide)
     {
@@ -155,6 +163,83 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
     private async Task<AreaRulePlanning> SeedWizardPlanning(int propertyId, int areaId)
         => await SeedPlanning(propertyId, areaId, createdInGuide: true);
 
+    /// <summary>
+    /// Seeds a full wizard task: AreaRule (CreatedInGuide) + items-planning Planning
+    /// carrying the old frequency encoding + the linked AreaRulePlanning, mirroring
+    /// what BackendConfigurationTaskWizardService.CreateTask writes (frequency
+    /// mirrored on both entities, ARP detail columns left at defaults).
+    /// </summary>
+    private async Task<(AreaRulePlanning Arp, Planning Planning)> SeedWizardTask(
+        int propertyId,
+        int areaId,
+        int repeatType,
+        int repeatEvery,
+        DateTime startDate,
+        bool status = true,
+        string planningWorkflowState = Constants.WorkflowStates.Created)
+    {
+        var areaRule = new AreaRule
+        {
+            AreaId = areaId,
+            PropertyId = propertyId,
+            CreatedInGuide = true,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await areaRule.Create(BackendConfigurationPnDbContext!);
+
+        // AddAsync, not .Create(): .Create() would overwrite the caller-chosen
+        // WorkflowState (needed Removed for the inactive-task case).
+        var planning = new Planning
+        {
+            Enabled = status,
+            RepeatEvery = repeatEvery,
+            RepeatType = (RepeatType)repeatType,
+            StartDate = startDate,
+            RelatedEFormId = 0,
+            WorkflowState = planningWorkflowState,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id,
+            PropertyId = propertyId,
+            AreaId = areaId,
+            ItemPlanningId = planning.Id,
+            StartDate = startDate,
+            Status = status,
+            RepeatType = repeatType,
+            RepeatEvery = repeatEvery,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await arp.Create(BackendConfigurationPnDbContext!);
+        return (arp, planning);
+    }
+
+    private CalendarConfiguration GetSingleConfiguration(int arpId)
+        => BackendConfigurationPnDbContext!.CalendarConfigurations
+            .Single(c => c.AreaRulePlanningId == arpId);
+
+    private void AssertNineToTenOnDefaultBoard(CalendarConfiguration configuration, int propertyId)
+    {
+        Assert.That(configuration.StartHour, Is.EqualTo(9.0));
+        Assert.That(configuration.Duration, Is.EqualTo(1.0));
+        Assert.That(configuration.Color, Is.Null);
+        var defaultBoard = BackendConfigurationPnDbContext!.CalendarBoards
+            .Where(b => b.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(b => b.PropertyId == propertyId)
+            .OrderBy(b => b.Id)
+            .First();
+        Assert.That(configuration.BoardId, Is.EqualTo(defaultBoard.Id));
+    }
+
     [Test]
     public async Task RunIfNeededAsync_WizardPlanningWithoutConfiguration_UsesPropertysLowestIdBoard()
     {
@@ -172,11 +257,10 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
 
         await _sut.RunIfNeededAsync();
 
-        var configuration = BackendConfigurationPnDbContext!.CalendarConfigurations
-            .Single(c => c.AreaRulePlanningId == planning.Id);
+        var configuration = GetSingleConfiguration(planning.Id);
         Assert.That(configuration.BoardId, Is.EqualTo(lowerBoard.Id));
-        Assert.That(configuration.StartHour, Is.EqualTo(0));
-        Assert.That(configuration.Duration, Is.EqualTo(1));
+        Assert.That(configuration.StartHour, Is.EqualTo(9.0));
+        Assert.That(configuration.Duration, Is.EqualTo(1.0));
         Assert.That(configuration.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Created));
     }
 
@@ -194,8 +278,7 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
         Assert.That(createdBoard.Name, Is.EqualTo("Default"));
         Assert.That(createdBoard.Color, Is.EqualTo("#c30000"));
 
-        var configuration = BackendConfigurationPnDbContext.CalendarConfigurations
-            .Single(c => c.AreaRulePlanningId == planning.Id);
+        var configuration = GetSingleConfiguration(planning.Id);
         Assert.That(configuration.BoardId, Is.EqualTo(createdBoard.Id));
     }
 
@@ -215,7 +298,7 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
         var existing = new CalendarConfiguration
         {
             AreaRulePlanningId = planning.Id,
-            StartHour = 9,
+            StartHour = 8,
             Duration = 2,
             BoardId = otherBoard.Id
         };
@@ -229,25 +312,8 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
         Assert.That(configurations, Has.Count.EqualTo(1),
             "Backfill must not create a second configuration for an already-configured planning.");
         Assert.That(configurations[0].BoardId, Is.EqualTo(otherBoard.Id));
-        Assert.That(configurations[0].StartHour, Is.EqualTo(9));
+        Assert.That(configurations[0].StartHour, Is.EqualTo(8));
         Assert.That(configurations[0].Duration, Is.EqualTo(2));
-    }
-
-    [Test]
-    public async Task RunIfNeededAsync_CalledTwice_SecondRunIsNoOp()
-    {
-        var property = await SeedProperty();
-        var area = await SeedArea();
-        await SeedWizardPlanning(property.Id, area.Id);
-
-        await _sut.RunIfNeededAsync();
-        var countAfterFirst = BackendConfigurationPnDbContext!.CalendarConfigurations.Count();
-        Assert.That(countAfterFirst, Is.EqualTo(1));
-
-        await _sut.RunIfNeededAsync();
-
-        Assert.That(BackendConfigurationPnDbContext.CalendarConfigurations.Count(),
-            Is.EqualTo(countAfterFirst));
     }
 
     [Test]
@@ -272,5 +338,391 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
         var boardExists = BackendConfigurationPnDbContext.CalendarBoards
             .Any(b => b.PropertyId == property.Id);
         Assert.That(boardExists, Is.False);
+    }
+
+    // --- Frequency conversion table ---
+
+    [Test]
+    public async Task RunIfNeededAsync_AltidPlanning_ConvertsToDailyOnBothEntities()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // Wizard "Altid" encoding: RepeatType 0, RepeatEvery 0.
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: 0, repeatEvery: 0,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(1));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedArp.DayOfWeek, Is.EqualTo(0));
+        Assert.That(updatedArp.RepeatWeekdaysCsv, Is.Null);
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(updatedPlanning.RepeatType, Is.EqualTo(RepeatType.Day));
+        Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(1));
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_LegacyDayZeroPlanning_ConvertsToDailyOnBothEntities()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // Legacy items-planning "always" encoding: (Day, 0).
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Day, repeatEvery: 0,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(1));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedArp.DayOfWeek, Is.EqualTo(0));
+        Assert.That(updatedArp.RepeatWeekdaysCsv, Is.Null);
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(updatedPlanning.RepeatType, Is.EqualTo(RepeatType.Day));
+        Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(1));
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_DailyEveryOne_ReDerivesArpAndLeavesPlanningUntouched()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Day, repeatEvery: 1,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(1));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(updatedPlanning.RepeatType, Is.EqualTo(RepeatType.Day));
+        Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedPlanning.RepeatOrdinalWeek, Is.Null);
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_DailyEveryThree_ReDerivesArpAndLeavesPlanningUntouched()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Day, repeatEvery: 3,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(1));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(3));
+        Assert.That(updatedArp.RepeatWeekdaysCsv, Is.Null);
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(updatedPlanning.RepeatType, Is.EqualTo(RepeatType.Day));
+        Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(3));
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_WeeklyEveryOneStartingWednesday_WritesWeekdayDetailColumns()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // 2026-01-07 is a Wednesday (DayOfWeek 3).
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Week, repeatEvery: 1,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(2));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedArp.DayOfWeek, Is.EqualTo(3));
+        Assert.That(updatedArp.RepeatWeekdaysCsv, Is.EqualTo("3"));
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(updatedPlanning.RepeatType, Is.EqualTo(RepeatType.Week));
+        Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedPlanning.RepeatOrdinalWeek, Is.Null);
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_WeeklyEveryTwoStartingSunday_WritesWeekdayZero()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // 2026-01-04 is a Sunday (DayOfWeek 0) — the CSV must still be written
+        // ("0"), not left null, so the edit modal classifies it as weekly-one.
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Week, repeatEvery: 2,
+            startDate: new DateTime(2026, 1, 4));
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(2));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(2));
+        Assert.That(updatedArp.DayOfWeek, Is.EqualTo(0));
+        Assert.That(updatedArp.RepeatWeekdaysCsv, Is.EqualTo("0"));
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(updatedPlanning.RepeatType, Is.EqualTo(RepeatType.Week));
+        Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(2));
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_MonthlyEveryOneStartingDay31_WritesFirstOrdinalWeekday()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // 2026-01-31 is a Saturday (DayOfWeek 6) on a month-boundary day the
+        // ordinal-weekday encoding must not choke on.
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Month, repeatEvery: 1,
+            startDate: new DateTime(2026, 1, 31));
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(3));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedArp.DayOfWeek, Is.EqualTo(6));
+        Assert.That(updatedArp.RepeatOrdinalWeek, Is.EqualTo(1));
+        Assert.That(updatedArp.DayOfMonth, Is.EqualTo(0));
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(updatedPlanning.RepeatType, Is.EqualTo(RepeatType.Month));
+        Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedPlanning.RepeatOrdinalWeek, Is.EqualTo(1));
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_MonthlyEveryThreeStartingDay29_WritesFirstOrdinalWeekday()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // 2026-03-29 is a Sunday (DayOfWeek 0) on day 29.
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Month, repeatEvery: 3,
+            startDate: new DateTime(2026, 3, 29));
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(3));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(3));
+        Assert.That(updatedArp.DayOfWeek, Is.EqualTo(0));
+        Assert.That(updatedArp.RepeatOrdinalWeek, Is.EqualTo(1));
+        Assert.That(updatedArp.DayOfMonth, Is.EqualTo(0));
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(updatedPlanning.RepeatType, Is.EqualTo(RepeatType.Month));
+        Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(3));
+        Assert.That(updatedPlanning.RepeatOrdinalWeek, Is.EqualTo(1));
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_YearlyPlanning_PassesThroughUntouchedButGetsConfiguration()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // RepeatType 4 (Year) is not wizard-producible; the conversion must not
+        // rewrite its recurrence, only attach the 09:00-10:00 configuration.
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: 4, repeatEvery: 1,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(4));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedArp.DayOfWeek, Is.EqualTo(0));
+        Assert.That(updatedArp.RepeatWeekdaysCsv, Is.Null);
+        Assert.That(updatedArp.RepeatOrdinalWeek, Is.Null);
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That((int)updatedPlanning.RepeatType, Is.EqualTo(4));
+        Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedPlanning.RepeatOrdinalWeek, Is.Null);
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_YearlyWithRepeatEveryZero_RepeatEveryZeroTakesPrecedence()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // Pins the (RepeatType 4, RepeatEvery 0) precedence: RepeatEvery 0 means
+        // "Altid" regardless of type, so it converts to daily rather than passing
+        // through as yearly.
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: 4, repeatEvery: 0,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(1));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(updatedPlanning.RepeatType, Is.EqualTo(RepeatType.Day));
+        Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(1));
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    // --- Inactive / orphaned rows ---
+
+    [Test]
+    public async Task RunIfNeededAsync_RemovedArp_IsSkippedEntirely()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: 0, repeatEvery: 0,
+            startDate: new DateTime(2026, 1, 7));
+        arp.WorkflowState = Constants.WorkflowStates.Removed;
+        await BackendConfigurationPnDbContext!.SaveChangesAsync();
+
+        await _sut.RunIfNeededAsync();
+
+        Assert.That(BackendConfigurationPnDbContext.CalendarConfigurations
+            .Any(c => c.AreaRulePlanningId == arp.Id), Is.False);
+        var untouchedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That((int)untouchedPlanning.RepeatType, Is.EqualTo(0));
+        Assert.That(untouchedPlanning.RepeatEvery, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_InactiveTaskWithSoftDeletedPlanning_IsStillNormalized()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // Inactive wizard task: ARP.Status=false, Planning soft-deleted. The
+        // Planning lookup deliberately includes removed rows so a reactivated
+        // task carries the correct recurrence.
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Week, repeatEvery: 1,
+            startDate: new DateTime(2026, 1, 7),
+            status: false,
+            planningWorkflowState: Constants.WorkflowStates.Removed);
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(2));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedArp.DayOfWeek, Is.EqualTo(3));
+        Assert.That(updatedArp.RepeatWeekdaysCsv, Is.EqualTo("3"));
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_ArpWithMissingPlanningRow_GetsConfigurationWithoutCrash()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // SeedPlanning creates no items-planning Planning row (ItemPlanningId 0):
+        // normalization must be skipped but the marker row still created so the
+        // ARP is never re-scanned on later boots.
+        var arp = await SeedWizardPlanning(property.Id, area.Id);
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(2));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedArp.RepeatWeekdaysCsv, Is.Null);
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+
+        await _sut.RunIfNeededAsync();
+        Assert.That(BackendConfigurationPnDbContext.CalendarConfigurations
+            .Count(c => c.AreaRulePlanningId == arp.Id), Is.EqualTo(1));
+    }
+
+    // --- Idempotency / crash-resume ---
+
+    [Test]
+    public async Task RunIfNeededAsync_CalledTwice_SecondRunIsNoOp()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: 0, repeatEvery: 0,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+        var countAfterFirst = BackendConfigurationPnDbContext!.CalendarConfigurations.Count();
+        Assert.That(countAfterFirst, Is.EqualTo(1));
+        var arpVersionAfterFirst = BackendConfigurationPnDbContext.AreaRulePlannings
+            .Single(x => x.Id == arp.Id).Version;
+
+        await _sut.RunIfNeededAsync();
+
+        Assert.That(BackendConfigurationPnDbContext.CalendarConfigurations.Count(),
+            Is.EqualTo(countAfterFirst));
+        Assert.That(BackendConfigurationPnDbContext.AreaRulePlannings
+            .Single(x => x.Id == arp.Id).Version, Is.EqualTo(arpVersionAfterFirst));
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_CrashResumeAfterPlanningMutation_ConvergesToSameFinalState()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // Altid row: the first pass rewrites Planning to (Day, 1). Deleting only
+        // the CalendarConfiguration simulates a crash between the recurrence
+        // writes and the marker insert; the re-run re-dispatches the row as
+        // (Day, 1) and must converge to the identical final state.
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: 0, repeatEvery: 0,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+
+        var configuration = GetSingleConfiguration(arp.Id);
+        BackendConfigurationPnDbContext!.CalendarConfigurations.Remove(configuration);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(1));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(updatedPlanning.RepeatType, Is.EqualTo(RepeatType.Day));
+        Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(1));
+
+        AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarConfigurationBackfillService/CalendarConfigurationBackfillService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarConfigurationBackfillService/CalendarConfigurationBackfillService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -5,11 +6,15 @@ using Microsoft.Extensions.Logging;
 using Microting.eForm.Infrastructure.Constants;
 using Microting.EformBackendConfigurationBase.Infrastructure.Data;
 using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Data;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
 
 namespace BackendConfiguration.Pn.Services.CalendarConfigurationBackfillService;
 
 public class CalendarConfigurationBackfillService(
     BackendConfigurationPnDbContext dbContext,
+    ItemsPlanningPnDbContext itemsPlanningPnDbContext,
     ILogger<CalendarConfigurationBackfillService> logger)
 {
     public async Task RunIfNeededAsync()
@@ -28,7 +33,6 @@ public class CalendarConfigurationBackfillService(
             .Include(x => x.AreaRule)
             .Where(x => x.AreaRule.CreatedInGuide)
             .Where(x => !configuredArpIds.Contains(x.Id))
-            .Select(x => new { x.Id, x.PropertyId })
             .ToListAsync();
 
         if (missing.Count == 0)
@@ -37,8 +41,16 @@ public class CalendarConfigurationBackfillService(
         }
 
         logger.LogInformation(
-            "CalendarConfigurationBackfill: attaching {Count} plannings to default boards",
+            "CalendarConfigurationBackfill: converting {Count} plannings to calendar tasks",
             missing.Count);
+
+        // Old-frequency source of truth is the linked items-planning Planning row.
+        // No WorkflowState filter on purpose: soft-deleted Plannings (inactive
+        // tasks) render dimmed in the calendar and need normalization too.
+        var planningIds = missing.Select(x => x.ItemPlanningId).Distinct().ToList();
+        var plannings = await itemsPlanningPnDbContext.Plannings
+            .Where(x => planningIds.Contains(x.Id))
+            .ToDictionaryAsync(x => x.Id);
 
         // Default board per property = lowest-Id non-removed board; create if none.
         // "Default"/"#c30000" mirrors BackendConfigurationCalendarService.GetBoards'
@@ -64,19 +76,86 @@ public class CalendarConfigurationBackfillService(
 
             foreach (var arp in missing.Where(x => x.PropertyId == propertyId))
             {
-                // No user context at startup — CreatedByUserId/UpdatedByUserId are
-                // left at their int default (0), same fallback the plugin's other
-                // startup backfill (WorkorderCaseGroupIdBackfillService) relies on.
-                var configuration = new CalendarConfiguration
+                try
                 {
-                    AreaRulePlanningId = arp.Id,
-                    StartHour = 0,
-                    Duration = 1,
-                    BoardId = board.Id,
-                    Color = null
-                };
-                await configuration.Create(dbContext);
+                    // ARP with a missing Planning row: skip normalization but still
+                    // create the config row so the ARP is never re-scanned.
+                    if (plannings.TryGetValue(arp.ItemPlanningId, out var planning))
+                    {
+                        await NormalizeRecurrence(arp, planning);
+                    }
+
+                    // No user context at startup — CreatedByUserId/UpdatedByUserId are
+                    // left at their int default (0), same fallback the plugin's other
+                    // startup backfill (WorkorderCaseGroupIdBackfillService) relies on.
+                    // Created last: its existence is the idempotency marker for the
+                    // whole conversion of this ARP, so a crash mid-run resumes here.
+                    var configuration = new CalendarConfiguration
+                    {
+                        AreaRulePlanningId = arp.Id,
+                        StartHour = 9.0,
+                        Duration = 1.0,
+                        BoardId = board.Id,
+                        Color = null
+                    };
+                    await configuration.Create(dbContext);
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e,
+                        "CalendarConfigurationBackfill: conversion failed for AreaRulePlanning {AreaRulePlanningId}",
+                        arp.Id);
+                }
             }
+        }
+    }
+
+    // Normalizes recurrence to the calendar encoding. All ARP writes are
+    // unconditional re-derivations from Planning.StartDate/RepeatType/RepeatEvery,
+    // so any interrupted pass converges to the same final state on the next run.
+    private async Task NormalizeRecurrence(AreaRulePlanning arp, Planning planning)
+    {
+        // "Altid" (RepeatType 0) and legacy (Day, 0) both become daily.
+        if (planning.RepeatType == 0 || planning.RepeatEvery == 0)
+        {
+            arp.RepeatType = 1;
+            arp.RepeatEvery = 1;
+            await arp.Update(dbContext);
+
+            planning.RepeatType = RepeatType.Day;
+            planning.RepeatEvery = 1;
+            await planning.Update(itemsPlanningPnDbContext);
+            return;
+        }
+
+        var dow = (int)planning.StartDate.DayOfWeek;
+
+        switch (planning.RepeatType)
+        {
+            case RepeatType.Day:
+                arp.RepeatType = 1;
+                arp.RepeatEvery = planning.RepeatEvery;
+                await arp.Update(dbContext);
+                break;
+            case RepeatType.Week:
+                arp.RepeatType = 2;
+                arp.RepeatEvery = planning.RepeatEvery;
+                arp.DayOfWeek = dow;
+                arp.RepeatWeekdaysCsv = dow.ToString();
+                await arp.Update(dbContext);
+                break;
+            case RepeatType.Month:
+                arp.RepeatType = 3;
+                arp.RepeatEvery = planning.RepeatEvery;
+                arp.DayOfWeek = dow;
+                arp.RepeatOrdinalWeek = 1;
+                arp.DayOfMonth = 0;
+                await arp.Update(dbContext);
+
+                planning.RepeatOrdinalWeek = 1;
+                await planning.Update(itemsPlanningPnDbContext);
+                break;
+            // Year/unknown: not wizard-producible — pass through untouched.
         }
     }
 }


### PR DESCRIPTION
## What

Extends `CalendarConfigurationBackfillService` (idempotent startup pass, unreleased — not in any tag) from a board-link backfill into a full conversion of old task-wizard plannings into calendar tasks:

| Old frequency | Calendar result |
|---|---|
| Altid (RepeatType 0) & legacy (Day, 0) | Dagligt, 09:00–10:00 |
| 1/N Dag | Dagligt / Hver N. dag, 09:00–10:00 |
| 1/N Uge | Ugentligt hver [ugedag på startdato] / Hver N. uge, 09:00–10:00 |
| 1/N Måned | Månedligt på den 1. [ugedag på startdato] / Hver N. måned, 09:00–10:00 |
| Year/unknown | pass-through, config row only |

## How

- Recurrence normalized on ARP (+ Planning for Altid/(Day,0) and Month's `RepeatOrdinalWeek=1`), keyed on `Planning.RepeatType/RepeatEvery` as source of truth; all writes are unconditional re-derivations (crash-resume converges).
- `CalendarConfiguration` now seeded `StartHour=9.0, Duration=1.0` (was 0) on the property's default board, created **last** per ARP as the idempotency marker.
- Soft-deleted Plannings included (inactive tasks normalize too); missing-Planning ARPs get the marker row so they are never re-scanned.
- No DI/registration change needed; no -base migration; no frontend change (verified the edit modal reconstructs the correct Gentagelse labels from these encodings).

## Decisions (user-approved)

- Altid and legacy (Day,0) both fully convert to daily (app-cadence change accepted).
- Backfill-only: the wizard create path is unchanged; new wizard tasks convert at next backend restart.
- Converted tasks land on the property's default board.

## Tests

Integration tests cover the full conversion table (incl. Sunday starts, day-29/31 month boundaries, (4,0) precedence), inactive + soft-deleted, missing-Planning, removed-ARP skip, CreatedInGuide filter, board resolution, idempotency (Version-stable no-op) and crash-resume convergence.

Spec: `docs/superpowers/specs/2026-08-13-taskwizard-planning-calendar-conversion-design.md` (in workspace root repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)