### PR TITLE
test: regression coverage for task-wizard calendar conversion at all levels

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarConversionRenderTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarConversionRenderTests.cs
@@ -1,0 +1,388 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Infrastructure.Models.Calendar;
+using BackendConfiguration.Pn.Services.BackendConfigurationCalendarService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using BackendConfiguration.Pn.Services.BackendConfigurationTaskWizardService;
+using BackendConfiguration.Pn.Services.CalendarAssignmentReconciliation;
+using BackendConfiguration.Pn.Services.CalendarConfigurationBackfillService;
+using BackendConfiguration.Pn.Services.EventDeployService;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Microting.EformBackendConfigurationBase.Infrastructure.Enum;
+using Microting.eFormApi.BasePn.Abstractions;
+using Microting.ItemsPlanningBase.Infrastructure.Data.Entities;
+using Microting.ItemsPlanningBase.Infrastructure.Enums;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BackendConfiguration.Pn.Integration.Test;
+
+/// <summary>
+/// Conversion-to-render seam for
+/// <c>CalendarConfigurationBackfillService.RunIfNeededAsync</c>: the sibling
+/// <c>CalendarConfigurationBackfillTest</c> proves the WRITTEN fields (ARP +
+/// Planning recurrence normalization, 09:00-10:00 CalendarConfiguration); this
+/// fixture proves that after conversion the real calendar week query
+/// (<c>BackendConfigurationCalendarService.GetTasksForWeek</c>) actually renders
+/// the converted tasks on the correct dates at 09:00-10:00 — and, via the
+/// unconverted control, that the conversion is what makes them render at all.
+/// All seeded dates are fixed in early-mid 2026 (past), never relative to now.
+/// </summary>
+[Parallelizable(ParallelScope.Fixtures)]
+[TestFixture]
+public class CalendarConversionRenderTests : TestBaseSetup
+{
+    private CalendarConfigurationBackfillService _sut = null!;
+
+    private static string IsoUtc(DateTime d) =>
+        DateTime.SpecifyKind(d, DateTimeKind.Utc).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+    [SetUp]
+    public async Task SetUpConversionRender()
+    {
+        // FK-safe clean of the rows this fixture writes, mirroring
+        // CalendarConfigurationBackfillTest's ordering (children before parents).
+        BackendConfigurationPnDbContext!.AreaRuleTranslations.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRuleTranslations);
+        BackendConfigurationPnDbContext.CalendarConfigurations.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarConfigurations);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.CalendarBoards.RemoveRange(
+            BackendConfigurationPnDbContext.CalendarBoards);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRulePlannings.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRulePlannings);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.AreaRules.RemoveRange(
+            BackendConfigurationPnDbContext.AreaRules);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        BackendConfigurationPnDbContext.Areas.RemoveRange(
+            BackendConfigurationPnDbContext.Areas);
+        BackendConfigurationPnDbContext.Properties.RemoveRange(
+            BackendConfigurationPnDbContext.Properties);
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+        ItemsPlanningPnDbContext!.Plannings.RemoveRange(
+            ItemsPlanningPnDbContext.Plannings);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        _sut = new CalendarConfigurationBackfillService(
+            BackendConfigurationPnDbContext!,
+            ItemsPlanningPnDbContext!,
+            NullLogger<CalendarConfigurationBackfillService>.Instance);
+    }
+
+    private async Task<Property> SeedProperty()
+    {
+        var property = new Property
+        {
+            Name = $"CalendarConvRenderProp-{Guid.NewGuid()}",
+            ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await property.Create(BackendConfigurationPnDbContext!);
+        return property;
+    }
+
+    private async Task<Area> SeedArea()
+    {
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1,
+            ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await area.Create(BackendConfigurationPnDbContext!);
+        return area;
+    }
+
+    /// <summary>
+    /// Seeds a full old-style wizard task: AreaRule (CreatedInGuide) +
+    /// items-planning Planning carrying the old frequency encoding + the linked
+    /// AreaRulePlanning — same shape as
+    /// <c>CalendarConfigurationBackfillTest.SeedWizardTask</c> (frequency
+    /// mirrored on both entities, ARP detail columns left at defaults).
+    /// </summary>
+    private async Task<(AreaRulePlanning Arp, Planning Planning)> SeedWizardTask(
+        int propertyId,
+        int areaId,
+        int repeatType,
+        int repeatEvery,
+        DateTime startDate)
+    {
+        var areaRule = new AreaRule
+        {
+            AreaId = areaId,
+            PropertyId = propertyId,
+            CreatedInGuide = true,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await areaRule.Create(BackendConfigurationPnDbContext!);
+
+        var planning = new Planning
+        {
+            Enabled = true,
+            RepeatEvery = repeatEvery,
+            RepeatType = (RepeatType)repeatType,
+            StartDate = startDate,
+            RelatedEFormId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+        await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+        var arp = new AreaRulePlanning
+        {
+            AreaRuleId = areaRule.Id,
+            PropertyId = propertyId,
+            AreaId = areaId,
+            ItemPlanningId = planning.Id,
+            StartDate = startDate,
+            Status = true,
+            RepeatType = repeatType,
+            RepeatEvery = repeatEvery,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await arp.Create(BackendConfigurationPnDbContext!);
+        return (arp, planning);
+    }
+
+    // Same construction as CalendarMultiLanguageTitleDescriptionTests.BuildService,
+    // with the caller language pinned to the first SDK-seeded language (no
+    // per-language assertions here — titles/translations are not under test).
+    private BackendConfigurationCalendarService BuildCalendarService(eFormCore.Core core)
+    {
+        var language = MicrotingDbContext!.Languages.OrderBy(x => x.Id).First();
+        var userService = Substitute.For<IUserService>();
+        userService.UserId.Returns(1);
+        userService.GetCurrentUserLanguage().Returns(Task.FromResult(language));
+        var coreHelper = Substitute.For<IEFormCoreService>();
+        coreHelper.GetCore().Returns(Task.FromResult(core));
+        var taskWizardService = Substitute.For<IBackendConfigurationTaskWizardService>();
+        return new BackendConfigurationCalendarService(
+            new BackendConfigurationLocalizationService(), userService,
+            BackendConfigurationPnDbContext!, coreHelper, Substitute.For<IEventDeployService>(),
+            ItemsPlanningPnDbContext!, taskWizardService,
+            Substitute.For<ICalendarAssignmentReconciliationService>(),
+            NullLogger<BackendConfigurationCalendarService>.Instance);
+    }
+
+    /// <summary>
+    /// Runs the real week query for the Mon-Sun week starting at
+    /// <paramref name="weekStartMonday"/> — identical request shape to
+    /// <c>CalendarMultiLanguageTitleDescriptionTests</c>.
+    /// </summary>
+    private async Task<List<CalendarTaskResponseModel>> QueryWeek(int propertyId, DateTime weekStartMonday)
+    {
+        var core = await GetCore();
+        var svc = BuildCalendarService(core);
+        var res = await svc.GetTasksForWeek(new CalendarTaskRequestModel
+        {
+            PropertyId = propertyId,
+            WeekStart = IsoUtc(weekStartMonday),
+            WeekEnd = IsoUtc(weekStartMonday.AddDays(6).AddHours(23).AddMinutes(59)),
+            ActionableOnly = false, BoardIds = [], TagNames = [], SiteIds = []
+        });
+        Assert.That(res.Success, Is.True, res.Message);
+        return res.Model!;
+    }
+
+    private static void AssertNineToTen(CalendarTaskResponseModel tile)
+    {
+        Assert.That(tile.StartHour, Is.EqualTo(9.0), $"StartHour on {tile.TaskDate}");
+        Assert.That(tile.Duration, Is.EqualTo(1.0), $"Duration on {tile.TaskDate}");
+        Assert.That(tile.IsAllDay, Is.False, $"IsAllDay on {tile.TaskDate}");
+    }
+
+    [Test]
+    public async Task AltidTask_AfterConversion_RendersAllSevenDaysOfLaterWeekNineToTen()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // Wizard "Altid" encoding (0,0); 2026-01-07 is a Wednesday.
+        var (arp, _) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: 0, repeatEvery: 0,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+
+        // A later week entirely past the StartDate: Mon 2026-02-02 .. Sun 2026-02-08.
+        var tiles = await QueryWeek(property.Id, new DateTime(2026, 2, 2, 0, 0, 0, DateTimeKind.Utc));
+
+        var mine = tiles.Where(t => t.Id == arp.Id).ToList();
+        Assert.That(mine, Has.Count.EqualTo(7), "converted Altid task must render every day of the week");
+        Assert.That(mine.Select(t => t.TaskDate),
+            Is.EquivalentTo(Enumerable.Range(2, 7).Select(d => $"2026-02-{d:00}")));
+        foreach (var tile in mine)
+        {
+            AssertNineToTen(tile);
+        }
+    }
+
+    [Test]
+    public async Task DayEveryThreeTask_AfterConversion_RendersOnStrideDatesOnly()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // (Day, 3) from Wed 2026-01-07: occurrences 07, 10, 13, 16, 19, 22, 25 Jan ...
+        var (arp, _) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Day, repeatEvery: 3,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+
+        // Week Mon 2026-01-19 .. Sun 2026-01-25 starts exactly on the +12-day
+        // occurrence, so the in-week pattern is +0/+3/+6: Mon 19, Thu 22, Sun 25.
+        var tiles = await QueryWeek(property.Id, new DateTime(2026, 1, 19, 0, 0, 0, DateTimeKind.Utc));
+
+        var mine = tiles.Where(t => t.Id == arp.Id).ToList();
+        Assert.That(mine.Select(t => t.TaskDate),
+            Is.EquivalentTo(new[] { "2026-01-19", "2026-01-22", "2026-01-25" }),
+            "every-3-days must render only on the stride dates; the days between have none");
+        foreach (var tile in mine)
+        {
+            AssertNineToTen(tile);
+        }
+    }
+
+    [Test]
+    public async Task WeeklyTaskStartingWednesday_AfterConversion_RendersExactlyOnWednesdayOfLaterWeek()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // (Week, 1) anchored on Wed 2026-01-07.
+        var (arp, _) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Week, repeatEvery: 1,
+            startDate: new DateTime(2026, 1, 7));
+
+        await _sut.RunIfNeededAsync();
+
+        // Later week Mon 2026-02-02 .. Sun 2026-02-08; its Wednesday is 2026-02-04.
+        var tiles = await QueryWeek(property.Id, new DateTime(2026, 2, 2, 0, 0, 0, DateTimeKind.Utc));
+
+        var mine = tiles.Where(t => t.Id == arp.Id).ToList();
+        Assert.That(mine, Has.Count.EqualTo(1), "weekly task must render exactly once per week");
+        Assert.That(mine[0].TaskDate, Is.EqualTo("2026-02-04"), "on the anchor weekday (Wednesday)");
+        AssertNineToTen(mine[0]);
+    }
+
+    [Test]
+    public async Task BiweeklyTaskStartingSunday_AfterConversion_RendersOnlyInAnchorParityWeeks()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // (Week, 2) anchored on Sun 2026-01-04. Monday-aligned week buckets put
+        // the anchor Sunday in week Mon 2025-12-29 .. Sun 2026-01-04, so the
+        // even-parity occurrence Sundays are 04 Jan, 18 Jan, 01 Feb ...
+        var (arp, _) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Week, repeatEvery: 2,
+            startDate: new DateTime(2026, 1, 4));
+
+        await _sut.RunIfNeededAsync();
+
+        // Off-parity week Mon 2026-01-05 .. Sun 2026-01-11: no occurrence.
+        var offParity = await QueryWeek(property.Id, new DateTime(2026, 1, 5, 0, 0, 0, DateTimeKind.Utc));
+        Assert.That(offParity.Where(t => t.Id == arp.Id), Is.Empty,
+            "every-2nd-week task must skip the off-parity week");
+
+        // Anchor-parity week Mon 2026-01-12 .. Sun 2026-01-18: Sunday 2026-01-18.
+        var parity = await QueryWeek(property.Id, new DateTime(2026, 1, 12, 0, 0, 0, DateTimeKind.Utc));
+        var mine = parity.Where(t => t.Id == arp.Id).ToList();
+        Assert.That(mine, Has.Count.EqualTo(1), "exactly one occurrence in the anchor-parity week");
+        Assert.That(mine[0].TaskDate, Is.EqualTo("2026-01-18"), "on the anchor weekday (Sunday)");
+        AssertNineToTen(mine[0]);
+    }
+
+    [Test]
+    public async Task MonthlyTaskStartingJan31_AfterConversion_RendersFirstSaturdayNotDayOfMonth()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // (Month, 1) from Sat 2026-01-31 — the conversion rewrites it to
+        // "1st Saturday of every month" (ordinal-weekday), dropping the
+        // day-of-month anchor entirely.
+        var (arp, _) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Month, repeatEvery: 1,
+            startDate: new DateTime(2026, 1, 31));
+
+        await _sut.RunIfNeededAsync();
+
+        // February's 1st Saturday is 2026-02-07 (Feb 1st 2026 is a Sunday);
+        // its week is Mon 2026-02-02 .. Sun 2026-02-08.
+        var febWeek = await QueryWeek(property.Id, new DateTime(2026, 2, 2, 0, 0, 0, DateTimeKind.Utc));
+        var febMine = febWeek.Where(t => t.Id == arp.Id).ToList();
+        Assert.That(febMine, Has.Count.EqualTo(1), "one occurrence in the first-Saturday week of February");
+        Assert.That(febMine[0].TaskDate, Is.EqualTo("2026-02-07"), "on February's 1st Saturday");
+        AssertNineToTen(febMine[0]);
+
+        // Day-of-month semantics are gone: the week containing the next
+        // 31st (Tue 2026-03-31; week Mon 2026-03-30 .. Sun 2026-04-05) has NO
+        // occurrence on the 31st — only April's 1st Saturday (2026-04-04).
+        var day31Week = await QueryWeek(property.Id, new DateTime(2026, 3, 30, 0, 0, 0, DateTimeKind.Utc));
+        var day31Mine = day31Week.Where(t => t.Id == arp.Id).ToList();
+        Assert.That(day31Mine.Select(t => t.TaskDate), Does.Not.Contain("2026-03-31"),
+            "no occurrence on the 31st — day-of-month semantics gone");
+        Assert.That(day31Mine.Select(t => t.TaskDate), Is.EquivalentTo(new[] { "2026-04-04" }),
+            "the only occurrence in that week is April's 1st Saturday");
+    }
+
+    [Test]
+    public async Task AltidTask_WithoutConversion_DoesNotRenderInLaterWeek()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        // Same Altid seed as the converted test — but RunIfNeededAsync is NOT
+        // run. The raw (0,0) Planning only renders on its exact StartDate
+        // (non-recurring branch of the week query), so a later week is empty:
+        // the conversion is what makes the task render.
+        var (arp, _) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: 0, repeatEvery: 0,
+            startDate: new DateTime(2026, 1, 7));
+
+        var tiles = await QueryWeek(property.Id, new DateTime(2026, 2, 2, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.That(tiles.Where(t => t.Id == arp.Id), Is.Empty,
+            "unconverted Altid task must not render in a later week");
+    }
+}

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/a/420_eform-backend-configuration-plugin.sql
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/a/420_eform-backend-configuration-plugin.sql
@@ -2482,3 +2482,54 @@ UNLOCK TABLES;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
 -- Dump completed on 2023-09-22 17:07:29
+
+--
+-- E2E seed (appended for shard-a taskwizard-calendar-conversion.spec.ts):
+-- an old-style task-wizard AreaRule (CreatedInGuide=1) + AreaRulePlanning
+-- with NO CalendarConfiguration row. "Altid" wizard shape: RepeatType=0,
+-- RepeatEvery=0, ARP DayOfWeek/DayOfMonth left at 0 exactly as the wizard
+-- writes them. On the post-seed container restart the startup
+-- CalendarConfigurationBackfillService must convert it: rewrite ARP and the
+-- linked items-planning Planning (Id 9001) to daily (Day, RepeatEvery=1) and
+-- create a CalendarConfiguration (StartHour 9, Duration 1) on Property 1's
+-- ("Farm 1") default board. Unconverted, this row renders only in its
+-- StartDate week (2026-01-07) — so the spec's future-week assertions fail
+-- hard if the conversion ever stops running.
+-- Ids 9001 avoid collisions (AUTO_INCREMENT was 205/520/118 at dump time).
+-- Column lists deliberately match the 2023 dump schema only — migrations add
+-- RepeatWeekdaysCsv/RepeatOrdinalWeek/RepeatEndMode on restart, before the
+-- backfill runs. FK order: AreaRules before its translations and planning;
+-- AreaId 1 and PropertyId 1 exist in the seeded data above.
+--
+INSERT INTO `AreaRules`
+  (`Id`,`AreaId`,`PropertyId`,`EformId`,`EformName`,`FolderId`,`FolderName`,
+   `Alarm`,`Type`,`ChecklistStable`,`TailBite`,`DayOfWeek`,`GroupItemId`,`IsDefault`,
+   `RepeatEvery`,`CreatedAt`,`UpdatedAt`,`WorkflowState`,`CreatedByUserId`,`UpdatedByUserId`,
+   `Version`,`RepeatType`,`ComplianceEnabled`,`ComplianceModifiable`,`Notifications`,
+   `NotificationsModifiable`,`SecondaryeFormId`,`SecondaryeFormName`,`CreatedInGuide`)
+VALUES
+  (9001,1,1,77,'Mock eForm',11,'Torsdag',
+   0,0,0,0,0,0,0,
+   0,'2023-09-01 00:00:00.000000',NULL,'created',0,0,
+   1,0,0,0,0,
+   0,0,NULL,1);
+
+INSERT INTO `AreaRuleTranslations`
+  (`Id`,`Name`,`LanguageId`,`AreaRuleId`,`CreatedAt`,`UpdatedAt`,`WorkflowState`,
+   `CreatedByUserId`,`UpdatedByUserId`,`Version`)
+VALUES
+  (9001,'GamleOpgaveKonvertering',1,9001,'2023-09-01 00:00:00.000000',NULL,'created',0,0,1),
+  (9002,'GamleOpgaveKonvertering',2,9001,'2023-09-01 00:00:00.000000',NULL,'created',0,0,1);
+
+INSERT INTO `AreaRulePlannings`
+  (`Id`,`StartDate`,`EndDate`,`DayOfWeek`,`DayOfMonth`,`RepeatEvery`,`RepeatType`,
+   `Status`,`SendNotifications`,`Alarm`,`Type`,`AreaRuleId`,`ItemPlanningId`,`FolderId`,
+   `HoursAndEnergyEnabled`,`CreatedAt`,`UpdatedAt`,`WorkflowState`,`CreatedByUserId`,
+   `UpdatedByUserId`,`Version`,`PropertyId`,`AreaId`,`ComplianceEnabled`,
+   `UseStartDateAsStartOfPeriod`,`ItemPlanningTagId`)
+VALUES
+  (9001,'2026-01-07 00:00:00.000000',NULL,0,0,0,0,
+   1,0,0,0,9001,9001,11,
+   0,'2023-09-01 00:00:00.000000',NULL,'created',0,
+   0,1,1,1,0,
+   0,NULL);

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/a/taskwizard-calendar-conversion.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/a/taskwizard-calendar-conversion.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../../../Page objects/Login.page';
+import { CalendarUiEnhancementsPage } from '../calendar-ui-enhancements.page';
+
+/**
+ * Regression test for the CalendarConfigurationBackfillService startup
+ * conversion of old task-wizard plannings.
+ *
+ * SEED (appended at the end of the two shard-a SQL dumps):
+ *   - items-planning `Plannings` Id 9001: the "Altid" wizard encoding
+ *     (RepeatType=0, RepeatEvery=0), StartDate 2026-01-07, plus
+ *     PlanningNameTranslation rows.
+ *   - backend-configuration `AreaRules` Id 9001 (CreatedInGuide=1, Property 1
+ *     "Farm 1", Area 1) + `AreaRuleTranslations` ("GamleOpgaveKonvertering",
+ *     da+en) + `AreaRulePlannings` Id 9001 (ItemPlanningId 9001, RepeatType=0,
+ *     RepeatEvery=0) with NO CalendarConfiguration row.
+ *
+ * The shard-a CI job loads the dumps AFTER first boot and then RESTARTS the
+ * container, so migrations and the startup backfill both run against the
+ * seeded data. The backfill must convert the Altid planning to daily
+ * (Day, RepeatEvery=1 on both entities) and create a CalendarConfiguration
+ * (StartHour 9, Duration 1) on Farm 1's auto-created "Default" board.
+ *
+ * ASSERTION MODEL — why "Altid"
+ * -----------------------------
+ * Altid is the only wizard frequency whose rendering CHANGES on conversion:
+ * unconverted, a (0,0) planning renders exactly once, in the week containing
+ * its StartDate (2026-01-07), and never in any later week; converted, it
+ * renders daily 09:00–10:00 forever. We therefore navigate one week FORWARD
+ * (strictly future relative to any CI run date) and assert the event on ALL
+ * SEVEN days, then one more week forward to prove the recurrence continues.
+ * If the backfill ever stops running, every assertion here fails hard.
+ * (A weekly seed would be useless: the legacy null-CSV weekly render path plus
+ * the 09:00 no-config fallback make an unconverted weekly row indistinguishable
+ * from a converted one.)
+ *
+ * The seeded rows are converted exactly once at the post-seed restart and are
+ * never mutated by this read-only spec, so ordering against other shard-a
+ * specs does not matter. All assertions are scoped to the unique title.
+ */
+
+const TITLE = 'GamleOpgaveKonvertering';
+const PROPERTY_NAME = 'Farm 1';
+const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6]; // data-day index: Mon=0 .. Sun=6
+
+test.describe('Task-wizard planning → calendar startup conversion', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4200');
+    await new LoginPage(page).login();
+    await page.waitForTimeout(2000);
+
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+    await calendarPage.goToCalendar();
+    await calendarPage.ensureSidebarOpen();
+
+    // The container auto-selects the first property, which is normally
+    // Farm 1 (Id 1) already — click it anyway so the selection is
+    // deterministic. Because a re-select of the already-active property may
+    // not trigger a fresh /tasks/week round-trip, the response waiter is
+    // best-effort (same .catch pattern as o/calendar-repeat-presets.spec.ts).
+    const weekResp = page.waitForResponse(
+      r => r.url().includes('/api/backend-configuration-pn/calendar/tasks/week')
+        && r.request().method() === 'POST',
+      { timeout: 15000 }
+    );
+    await calendarPage.selectProperty(PROPERTY_NAME);
+    await weekResp.catch(() => undefined);
+    await page.waitForTimeout(1000);
+  });
+
+  test('converted Altid wizard planning renders daily at 09:00–10:00', async ({ page }) => {
+    test.setTimeout(180000);
+    const calendarPage = new CalendarUiEnhancementsPage(page);
+
+    // --- Week +1 (strictly future): the converted Altid planning must render
+    // on every day of the week at the backfill's fixed 09:00–10:00 slot.
+    // Unconverted, a (0,0) planning renders ONLY in its 2026-01-07 StartDate
+    // week, so any block here proves the startup conversion ran. ---
+    await calendarPage.navigateToNextWeek();
+
+    for (const day of ALL_DAYS) {
+      const count = await calendarPage.getDayColumnTaskBlocks(day, TITLE).count();
+      expect(
+        count,
+        `Expected the converted Altid task-wizard planning "${TITLE}" on ` +
+        `data-day ${day} (Mon=0..Sun=6) of the next week — the startup ` +
+        `CalendarConfigurationBackfillService must rewrite it to daily — ` +
+        `but found ${count} blocks.`
+      ).toBeGreaterThanOrEqual(1);
+    }
+
+    // Backfill creates the CalendarConfiguration with StartHour=9,
+    // Duration=1 → the card's time text must render 09:00–10:00.
+    const timeText = await calendarPage.getEventTimeText(TITLE);
+    expect(
+      timeText,
+      `Expected the converted event's time text to start at 09:00 ` +
+      `(CalendarConfiguration.StartHour=9 from the backfill), got "${timeText}".`
+    ).toContain('09:00');
+    expect(
+      timeText,
+      `Expected the converted event's time text to end at 10:00 ` +
+      `(CalendarConfiguration.Duration=1 from the backfill), got "${timeText}".`
+    ).toContain('10:00');
+
+    // --- Week +2: the daily recurrence continues — all seven days again. ---
+    await calendarPage.navigateToNextWeek();
+
+    for (const day of ALL_DAYS) {
+      const count = await calendarPage.getDayColumnTaskBlocks(day, TITLE).count();
+      expect(
+        count,
+        `Expected "${TITLE}" to keep recurring daily in the following week ` +
+        `(data-day ${day}), but found ${count} blocks.`
+      ).toBeGreaterThanOrEqual(1);
+    }
+
+    const timeTextNext = await calendarPage.getEventTimeText(TITLE);
+    expect(
+      timeTextNext,
+      `Expected the recurring occurrence to keep the 09:00 start, got "${timeTextNext}".`
+    ).toContain('09:00');
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-repeat.service.spec.ts
@@ -1,4 +1,5 @@
 import {CalendarRepeatService} from './calendar-repeat.service';
+import {mapResponseToCalendarTask} from './calendar-task.mapper';
 import {CalendarRepeatMeta, CalendarTaskModel} from '../../../models/calendar';
 import {TranslateService} from '@ngx-translate/core';
 
@@ -1339,5 +1340,110 @@ describe('CalendarRepeatService — monthly kinds', () => {
     );
     expect(meta.kind).toBe('monthlyFirstWeekday');
     expect(meta.weekday).toBe(0);
+  });
+});
+
+// ── Conversion wire encodings → reconstructMetaFromTask ──────────────────────
+//
+// The backend conversion writes raw repeat integers/CSV onto calendar tasks;
+// these tests feed exactly those wire shapes through the REAL load path —
+// mapResponseToCalendarTask (which derives repeatRule via mapRepeatType) and
+// then reconstructMetaFromTask — instead of hand-picking a repeatRule. This
+// pins the previously untested raw-task branches: the repeatOrdinalWeek
+// monthly-ordinal paths (both the 'monthlyDom' built-in branch at n=1 and the
+// 'custom'/repeatType=3 branch at n>1) and everyNWeekOne via a single-day CSV.
+
+describe('CalendarRepeatService — conversion wire encodings (reconstructMetaFromTask)', () => {
+  let service: CalendarRepeatService;
+
+  beforeEach(() => {
+    service = new CalendarRepeatService(translateStub);
+  });
+
+  // Builds the task exactly as the calendar load path does: a raw DTO with
+  // the persisted repeat columns, run through mapResponseToCalendarTask so
+  // repeatRule is derived by the real mapRepeatType — not hand-assigned.
+  function taskFromWire(wire: Partial<CalendarTaskModel>): CalendarTaskModel {
+    return mapResponseToCalendarTask({
+      id: 1, title: 't', startHour: 9, duration: 1, startText: '09:00',
+      endText: '10:00', tags: [], assigneeIds: [], boardId: 1, color: '',
+      descriptionHtml: '', taskDate: '2026-03-16', completed: false,
+      propertyId: 1, repeatEndMode: 0,
+      ...wire,
+    });
+  }
+
+  // ----- Monthly ordinal (repeatOrdinalWeek=1) from raw task ---------------
+
+  it('repeatType=3, repeatEvery=1, repeatOrdinalWeek=1, dayOfWeek=2, dayOfMonth=0 → monthlyFirstWeekday', () => {
+    const task = taskFromWire({
+      repeatType: 3, repeatEvery: 1, repeatOrdinalWeek: 1,
+      dayOfWeek: 2, dayOfMonth: 0,
+    });
+    // mapRepeatType(3, 1) routes through the 'monthlyDom' built-in branch.
+    expect(task.repeatRule).toBe('monthlyDom');
+    const r = service.reconstructMetaFromTask(task);
+    expect(r?.kind).toBe('monthlyFirstWeekday');
+    expect(r?.ordinalWeek).toBe(1);
+    // Weekday must come from dayOfWeek, not from any DOM field.
+    expect(r?.weekday).toBe(2);
+    expect(r?.n).toBe(1);
+  });
+
+  it('repeatType=3, repeatEvery=3, repeatOrdinalWeek=1, dayOfWeek=5, dayOfMonth=0 → everyNMonthFirstWeekday', () => {
+    const task = taskFromWire({
+      repeatType: 3, repeatEvery: 3, repeatOrdinalWeek: 1,
+      dayOfWeek: 5, dayOfMonth: 0,
+    });
+    // mapRepeatType(3, 3) routes through the 'custom' branch → repeatType=3.
+    expect(task.repeatRule).toBe('custom');
+    const r = service.reconstructMetaFromTask(task);
+    expect(r?.kind).toBe('everyNMonthFirstWeekday');
+    expect(r?.n).toBe(3);
+    expect(r?.ordinalWeek).toBe(1);
+    expect(r?.weekday).toBe(5);
+  });
+
+  // ----- Conversion-shape guard --------------------------------------------
+
+  it('dayOfMonth=0 with repeatOrdinalWeek=1 does NOT classify as monthlyDom (ordinal wins over the DOM sentinel)', () => {
+    // The conversion writes dayOfMonth=0 as the "no DOM" sentinel alongside
+    // repeatOrdinalWeek=1. If the ordinal branch regressed, dayOfMonth=0 is
+    // non-null and would fall through to a bogus monthlyDom with dom=0.
+    const task = taskFromWire({
+      repeatType: 3, repeatEvery: 1, repeatOrdinalWeek: 1,
+      dayOfWeek: 1, dayOfMonth: 0,
+    });
+    const r = service.reconstructMetaFromTask(task);
+    expect(r?.kind).not.toBe('monthlyDom');
+    expect(r?.kind).toBe('monthlyFirstWeekday');
+    expect(r?.dom).toBeUndefined();
+  });
+
+  // ----- everyNWeekOne from raw task (repeatType=2, N>1, single-day CSV) ---
+
+  it('repeatType=2, repeatEvery=2, repeatWeekdaysCsv="0" → everyNWeekOne on Sunday (weekday from CSV)', () => {
+    const task = taskFromWire({
+      repeatType: 2, repeatEvery: 2, repeatWeekdaysCsv: '0',
+      dayOfWeek: 4,  // intentionally different — the CSV must win
+    });
+    // mapRepeatType(2, 2) routes through the 'custom' branch → repeatType=2.
+    expect(task.repeatRule).toBe('custom');
+    const r = service.reconstructMetaFromTask(task);
+    expect(r?.kind).toBe('everyNWeekOne');
+    expect(r?.n).toBe(2);
+    expect(r?.weekday).toBe(0);
+  });
+
+  it('repeatType=2, repeatEvery=2, repeatWeekdaysCsv="3" → everyNWeekOne on Wednesday (weekday from CSV)', () => {
+    const task = taskFromWire({
+      repeatType: 2, repeatEvery: 2, repeatWeekdaysCsv: '3',
+      dayOfWeek: null,
+    });
+    expect(task.repeatRule).toBe('custom');
+    const r = service.reconstructMetaFromTask(task);
+    expect(r?.kind).toBe('everyNWeekOne');
+    expect(r?.n).toBe(2);
+    expect(r?.weekday).toBe(3);
   });
 });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-task.mapper.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/calendar/services/calendar-task.mapper.spec.ts
@@ -1,0 +1,93 @@
+import {mapRepeatType, mapResponseToCalendarTask} from './calendar-task.mapper';
+
+// Regression-pinning for the repeat-type wire encoding → CalendarRepeatRule
+// classification. The backend conversion persists (repeatType, repeatEvery)
+// integer pairs; mapRepeatType is the single derivation point both the
+// week-grid and the task-list page share. Each test asserts the REAL
+// function's current behaviour for one cell of the input table — including
+// the deliberate collapse of every repeatEvery > 1 rule to 'custom', which
+// reconstructMetaFromTask later refines (daily→everyNd, weekly→everyNWeekOne,
+// monthly-ordinal→everyNMonthFirstWeekday, …).
+describe('mapRepeatType', () => {
+  it('(0, 1) → "none" (repeatType 0 means no repetition)', () => {
+    expect(mapRepeatType(0, 1)).toBe('none');
+  });
+
+  it('(0, 5) → "none" (repeatEvery is ignored when repeatType is 0)', () => {
+    expect(mapRepeatType(0, 5)).toBe('none');
+  });
+
+  it('(1, 0) → "custom" (pins current behaviour: repeatEvery=0 is not treated as 1)', () => {
+    expect(mapRepeatType(1, 0)).toBe('custom');
+  });
+
+  it('(1, 1) → "daily"', () => {
+    expect(mapRepeatType(1, 1)).toBe('daily');
+  });
+
+  it('(1, 4) → "custom" (every-N-days routes through the custom branch)', () => {
+    expect(mapRepeatType(1, 4)).toBe('custom');
+  });
+
+  it('(2, 1) → "weeklyOne"', () => {
+    expect(mapRepeatType(2, 1)).toBe('weeklyOne');
+  });
+
+  it('(2, 2) → "custom" (every-N-weeks routes through the custom branch)', () => {
+    expect(mapRepeatType(2, 2)).toBe('custom');
+  });
+
+  it('(3, 1) → "monthlyDom"', () => {
+    expect(mapRepeatType(3, 1)).toBe('monthlyDom');
+  });
+
+  it('(3, 6) → "custom" (every-N-months routes through the custom branch)', () => {
+    expect(mapRepeatType(3, 6)).toBe('custom');
+  });
+
+  it('(4, 1) → "yearlyOne"', () => {
+    expect(mapRepeatType(4, 1)).toBe('yearlyOne');
+  });
+
+  it('(4, 2) → "custom" (every-N-years routes through the custom branch)', () => {
+    expect(mapRepeatType(4, 2)).toBe('custom');
+  });
+
+  it('unknown repeatType (5, 1) → "custom" (default branch)', () => {
+    expect(mapRepeatType(5, 1)).toBe('custom');
+  });
+
+  it('nullish repeatType → "none" (falsy guard, pinned via runtime cast)', () => {
+    // The signature declares number, but wire data could be absent; the
+    // `!repeatType` guard handles it. Cast so the runtime path is exercised.
+    expect(mapRepeatType(null as unknown as number, 1)).toBe('none');
+    expect(mapRepeatType(undefined as unknown as number, 1)).toBe('none');
+  });
+});
+
+describe('mapResponseToCalendarTask', () => {
+  it('derives repeatRule from the DTO repeat integers', () => {
+    const task = mapResponseToCalendarTask({id: 1, repeatType: 2, repeatEvery: 1});
+    expect(task.repeatRule).toBe('weeklyOne');
+  });
+
+  it('missing repeatType defaults to 0 → "none"', () => {
+    const task = mapResponseToCalendarTask({id: 1});
+    expect(task.repeatRule).toBe('none');
+  });
+
+  it('missing repeatEvery defaults to 1 → built-in rule, not "custom"', () => {
+    const task = mapResponseToCalendarTask({id: 1, repeatType: 3});
+    expect(task.repeatRule).toBe('monthlyDom');
+  });
+
+  it('preserves all other DTO fields verbatim (spread)', () => {
+    const task = mapResponseToCalendarTask({
+      id: 7, title: 'x', repeatType: 1, repeatEvery: 4, repeatOrdinalWeek: 1,
+    });
+    expect(task.id).toBe(7);
+    expect(task.title).toBe('x');
+    expect(task.repeatOrdinalWeek).toBe(1);
+    expect(task.repeatRule).toBe('custom');
+  });
+});


### PR DESCRIPTION
## What

Regression tests for the task-wizard→calendar conversion (#1110) at every CI-run level. All three levels are auto-discovered (full-project `dotnet test`, path-based jest, shard-dir playwright) — no workflow changes needed.

### 1. Backend integration — conversion→render seam (`CalendarConversionRenderTests`)
Runs `RunIfNeededAsync` then asserts the public `GetTasksForWeek` output on fixed, weekday-verified 2026 dates: Altid renders all 7 days at 09:00–10:00; Day-3 stride via set-equality; weekly Wednesday; biweekly Monday-aligned parity (anchor Sun 2026-01-04 → Jan 18, not Jan 11); monthly first-Saturday incl. proof day-of-month semantics are gone; and an **unconverted control** proving the conversion is what makes an Altid task render in later weeks.

### 2. Angular unit (jest)
- `calendar-repeat.service.spec.ts`: the conversion wire encodings through the **real** load path (`mapResponseToCalendarTask` → `reconstructMetaFromTask`): `monthlyFirstWeekday`/`everyNMonthFirstWeekday` from `repeatOrdinalWeek` (previously untested branches), `everyNWeekOne` with CSV-wins-over-stale-`dayOfWeek` proof, and a `dayOfMonth=0` sentinel guard.
- New `calendar-task.mapper.spec.ts`: pins `mapRepeatType` for the full input table (incl. `(1,0)`→custom, null→none) and `mapResponseToCalendarTask` defaults.

### 3. Playwright e2e (shard a) — true end-to-end conversion
The shard-a dumps now seed an old-style **Altid** wizard planning (`GamleOpgaveKonvertering`, `(0,0)`, no `CalendarConfiguration`, 2023-schema columns only, append-only INSERTs with collision-free Ids). Shard a loads the dumps and **restarts the container**, so the real startup backfill converts the row; the spec asserts daily 09:00–10:00 blocks on all seven days across two strictly-future weeks. Altid is deliberately the seeded shape: it is the only frequency whose rendering changes on conversion (unconverted it renders only in its StartDate week), so the spec fails hard if the backfill ever stops running — a weekly seed would stay green via the legacy render fallbacks.

## Verification
- Solution + test project builds: 0 errors; `tsc --noEmit -p src/tsconfig.spec.json` clean for the new specs; `playwright test --list` parses shard a; SQL appends validated column-by-column against the dumps' own CREATE TABLEs (counts, NOT-NULLs, FK order, Id high-water marks).
- Adversarially code-reviewed; the review's one Important finding (weekly seed can't detect a missing conversion) is fixed by the Altid seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)