### PR TITLE
Fix: re-normalize legacy calendar tasks with stale CalendarConfiguration markers

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarConfigurationBackfillTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarConfigurationBackfillTest.cs
@@ -361,6 +361,52 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
     }
 
     [Test]
+    public async Task RunIfNeededAsync_MonthlyDayOfMonthWithLiveMarker_IsLeftUntouched()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        var board = new CalendarBoard { Name = "Board A", Color = "#111111", PropertyId = property.Id };
+        await board.Create(BackendConfigurationPnDbContext!);
+
+        // A legitimately-configured "day 15 of month" wizard task: converted, then
+        // edited via UpdateTask to monthly-on-day-15. RepeatOrdinalWeek stays null
+        // (that's the "Nth weekday" encoding, not used here) but DayOfMonth is a real
+        // value >= 1 — the marker of a live, correctly-normalized recurrence. The
+        // Month sentinel must NOT re-select this row (it would overwrite DayOfMonth
+        // back to 0), which it only avoids because it also requires DayOfMonth == 0.
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Month, repeatEvery: 1,
+            startDate: new DateTime(2026, 1, 15));
+        arp.DayOfMonth = 15;
+        await BackendConfigurationPnDbContext!.SaveChangesAsync();
+
+        var liveMarker = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id,
+            StartHour = 9.0,
+            Duration = 1.0,
+            BoardId = board.Id
+        };
+        await liveMarker.Create(BackendConfigurationPnDbContext!);
+
+        await _sut.RunIfNeededAsync();
+
+        // Completely untouched: DayOfMonth still 15, no ordinal-weekday re-derivation.
+        var updatedArp = BackendConfigurationPnDbContext.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(3));
+        Assert.That(updatedArp.DayOfMonth, Is.EqualTo(15));
+        Assert.That(updatedArp.RepeatOrdinalWeek, Is.Null);
+
+        // No re-normalization of the linked Planning either.
+        var untouchedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(untouchedPlanning.RepeatType, Is.EqualTo(RepeatType.Month));
+
+        // The live marker is left alone, not duplicated.
+        Assert.That(BackendConfigurationPnDbContext.CalendarConfigurations
+            .Count(c => c.AreaRulePlanningId == arp.Id), Is.EqualTo(1));
+    }
+
+    [Test]
     public async Task RunIfNeededAsync_WeeklyWithStaleMarkerButUnnormalizedArp_NormalizesInPlaceWithoutDuplicatingMarker()
     {
         var property = await SeedProperty();

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarConfigurationBackfillTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarConfigurationBackfillTest.cs
@@ -317,6 +317,86 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
     }
 
     [Test]
+    public async Task RunIfNeededAsync_MonthlyWithStaleMarkerButUnnormalizedArp_NormalizesInPlaceWithoutDuplicatingMarker()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        var board = new CalendarBoard { Name = "Board A", Color = "#111111", PropertyId = property.Id };
+        await board.Create(BackendConfigurationPnDbContext!);
+
+        // 2026-01-31 is a Saturday (DayOfWeek 6).
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Month, repeatEvery: 1,
+            startDate: new DateTime(2026, 1, 31));
+
+        // Reproduce the old, since-replaced backfill's output: a live marker exists
+        // but the ARP recurrence detail columns were never populated
+        // (RepeatOrdinalWeek still null), so the task keeps rendering "på dag 0".
+        var staleMarker = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id,
+            StartHour = 9.0,
+            Duration = 1.0,
+            BoardId = board.Id
+        };
+        await staleMarker.Create(BackendConfigurationPnDbContext!);
+
+        await _sut.RunIfNeededAsync();
+
+        // The stale marker must NOT gate normalization: the ordinal-weekday encoding
+        // has to be derived exactly as the no-prior-marker Month test asserts.
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(3));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedArp.DayOfWeek, Is.EqualTo(6));
+        Assert.That(updatedArp.RepeatOrdinalWeek, Is.EqualTo(1));
+        Assert.That(updatedArp.DayOfMonth, Is.EqualTo(0));
+
+        var updatedPlanning = ItemsPlanningPnDbContext!.Plannings.Single(x => x.Id == planning.Id);
+        Assert.That(updatedPlanning.RepeatOrdinalWeek, Is.EqualTo(1));
+
+        // The existing marker is reused, not duplicated.
+        Assert.That(BackendConfigurationPnDbContext.CalendarConfigurations
+            .Count(c => c.AreaRulePlanningId == arp.Id), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task RunIfNeededAsync_WeeklyWithStaleMarkerButUnnormalizedArp_NormalizesInPlaceWithoutDuplicatingMarker()
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        var board = new CalendarBoard { Name = "Board A", Color = "#111111", PropertyId = property.Id };
+        await board.Create(BackendConfigurationPnDbContext!);
+
+        // 2026-01-07 is a Wednesday (DayOfWeek 3).
+        var (arp, planning) = await SeedWizardTask(
+            property.Id, area.Id, repeatType: (int)RepeatType.Week, repeatEvery: 1,
+            startDate: new DateTime(2026, 1, 7));
+
+        // Old backfill's output: marker exists, RepeatWeekdaysCsv never written.
+        var staleMarker = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id,
+            StartHour = 9.0,
+            Duration = 1.0,
+            BoardId = board.Id
+        };
+        await staleMarker.Create(BackendConfigurationPnDbContext!);
+
+        await _sut.RunIfNeededAsync();
+
+        var updatedArp = BackendConfigurationPnDbContext!.AreaRulePlannings.Single(x => x.Id == arp.Id);
+        Assert.That(updatedArp.RepeatType, Is.EqualTo(2));
+        Assert.That(updatedArp.RepeatEvery, Is.EqualTo(1));
+        Assert.That(updatedArp.DayOfWeek, Is.EqualTo(3));
+        Assert.That(updatedArp.RepeatWeekdaysCsv, Is.EqualTo("3"));
+
+        // The existing marker is reused, not duplicated.
+        Assert.That(BackendConfigurationPnDbContext.CalendarConfigurations
+            .Count(c => c.AreaRulePlanningId == arp.Id), Is.EqualTo(1));
+    }
+
+    [Test]
     public async Task RunIfNeededAsync_PlanningWhoseAreaRuleWasNotCreatedInGuide_GetsNoConfiguration()
     {
         var property = await SeedProperty();

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarConfigurationBackfillService/CalendarConfigurationBackfillService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarConfigurationBackfillService/CalendarConfigurationBackfillService.cs
@@ -39,7 +39,7 @@ public class CalendarConfigurationBackfillService(
         // Month via a null RepeatOrdinalWeek, both columns NormalizeRecurrence always
         // sets and the old buggy service never touched (RepeatOrdinalWeek is nullable
         // so its absence is unambiguous, unlike DayOfMonth which defaults to 0).
-        var missing = await dbContext.AreaRulePlannings
+        var arpsToNormalize = await dbContext.AreaRulePlannings
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
             .Include(x => x.AreaRule)
             .Where(x => x.AreaRule.CreatedInGuide)
@@ -48,19 +48,19 @@ public class CalendarConfigurationBackfillService(
                         || (x.RepeatType == 3 && x.RepeatOrdinalWeek == null))
             .ToListAsync();
 
-        if (missing.Count == 0)
+        if (arpsToNormalize.Count == 0)
         {
             return;
         }
 
         logger.LogInformation(
             "CalendarConfigurationBackfill: converting {Count} plannings to calendar tasks",
-            missing.Count);
+            arpsToNormalize.Count);
 
         // Old-frequency source of truth is the linked items-planning Planning row.
         // No WorkflowState filter on purpose: soft-deleted Plannings (inactive
         // tasks) render dimmed in the calendar and need normalization too.
-        var planningIds = missing.Select(x => x.ItemPlanningId).Distinct().ToList();
+        var planningIds = arpsToNormalize.Select(x => x.ItemPlanningId).Distinct().ToList();
         var plannings = await itemsPlanningPnDbContext.Plannings
             .Where(x => planningIds.Contains(x.Id))
             .ToDictionaryAsync(x => x.Id);
@@ -68,7 +68,7 @@ public class CalendarConfigurationBackfillService(
         // Default board per property = lowest-Id non-removed board; create if none.
         // "Default"/"#c30000" mirrors BackendConfigurationCalendarService.GetBoards'
         // auto-create-default-board values verbatim.
-        foreach (var propertyId in missing.Select(x => x.PropertyId).Distinct())
+        foreach (var propertyId in arpsToNormalize.Select(x => x.PropertyId).Distinct())
         {
             var board = await dbContext.CalendarBoards
                 .Where(b => b.WorkflowState != Constants.WorkflowStates.Removed)
@@ -87,7 +87,7 @@ public class CalendarConfigurationBackfillService(
                 await board.Create(dbContext);
             }
 
-            foreach (var arp in missing.Where(x => x.PropertyId == propertyId))
+            foreach (var arp in arpsToNormalize.Where(x => x.PropertyId == propertyId))
             {
                 try
                 {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarConfigurationBackfillService/CalendarConfigurationBackfillService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarConfigurationBackfillService/CalendarConfigurationBackfillService.cs
@@ -28,11 +28,24 @@ public class CalendarConfigurationBackfillService(
         // Mirrors BackendConfigurationCalendarService.CreateTask's ARP-to-AreaRule
         // correlation: navigate via the AreaRule FK/nav property and filter on
         // CreatedInGuide (task-wizard-created rules only).
+        //
+        // Selection is by correctness, not marker existence alone: an older,
+        // since-replaced version of this service created the CalendarConfiguration
+        // marker WITHOUT ever populating the ARP recurrence detail columns, so those
+        // rows (and any reintroduced via a restore of old production data) still
+        // render as "dag 0" and need normalizing even though a marker exists. A row
+        // qualifies when it has no live marker OR it is a still-un-normalized
+        // Week/Month wizard row — Week detected via an empty RepeatWeekdaysCsv and
+        // Month via a null RepeatOrdinalWeek, both columns NormalizeRecurrence always
+        // sets and the old buggy service never touched (RepeatOrdinalWeek is nullable
+        // so its absence is unambiguous, unlike DayOfMonth which defaults to 0).
         var missing = await dbContext.AreaRulePlannings
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
             .Include(x => x.AreaRule)
             .Where(x => x.AreaRule.CreatedInGuide)
-            .Where(x => !configuredArpIds.Contains(x.Id))
+            .Where(x => !configuredArpIds.Contains(x.Id)
+                        || (x.RepeatType == 2 && string.IsNullOrEmpty(x.RepeatWeekdaysCsv))
+                        || (x.RepeatType == 3 && x.RepeatOrdinalWeek == null))
             .ToListAsync();
 
         if (missing.Count == 0)
@@ -90,15 +103,22 @@ public class CalendarConfigurationBackfillService(
                     // startup backfill (WorkorderCaseGroupIdBackfillService) relies on.
                     // Created last: its existence is the idempotency marker for the
                     // whole conversion of this ARP, so a crash mid-run resumes here.
-                    var configuration = new CalendarConfiguration
+                    //
+                    // A stale-marker row (re-selected for normalization above) already
+                    // has a live marker; re-inserting would duplicate it, so only
+                    // create when none exists and leave the existing one untouched.
+                    if (!configuredArpIds.Contains(arp.Id))
                     {
-                        AreaRulePlanningId = arp.Id,
-                        StartHour = 9.0,
-                        Duration = 1.0,
-                        BoardId = board.Id,
-                        Color = null
-                    };
-                    await configuration.Create(dbContext);
+                        var configuration = new CalendarConfiguration
+                        {
+                            AreaRulePlanningId = arp.Id,
+                            StartHour = 9.0,
+                            Duration = 1.0,
+                            BoardId = board.Id,
+                            Color = null
+                        };
+                        await configuration.Create(dbContext);
+                    }
                 }
                 catch (Exception e)
                 {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarConfigurationBackfillService/CalendarConfigurationBackfillService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarConfigurationBackfillService/CalendarConfigurationBackfillService.cs
@@ -36,16 +36,19 @@ public class CalendarConfigurationBackfillService(
         // render as "dag 0" and need normalizing even though a marker exists. A row
         // qualifies when it has no live marker OR it is a still-un-normalized
         // Week/Month wizard row — Week detected via an empty RepeatWeekdaysCsv and
-        // Month via a null RepeatOrdinalWeek, both columns NormalizeRecurrence always
-        // sets and the old buggy service never touched (RepeatOrdinalWeek is nullable
-        // so its absence is unambiguous, unlike DayOfMonth which defaults to 0).
+        // Month via a null RepeatOrdinalWeek AND a zero DayOfMonth — a legitimate
+        // "day N of month" row (edited via UpdateTask) has RepeatOrdinalWeek null but
+        // DayOfMonth >= 1, so requiring DayOfMonth == 0 avoids re-normalizing and
+        // corrupting it; only truly-stale rows leave both at their defaults.
         var arpsToNormalize = await dbContext.AreaRulePlannings
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
             .Include(x => x.AreaRule)
             .Where(x => x.AreaRule.CreatedInGuide)
             .Where(x => !configuredArpIds.Contains(x.Id)
                         || (x.RepeatType == 2 && string.IsNullOrEmpty(x.RepeatWeekdaysCsv))
-                        || (x.RepeatType == 3 && x.RepeatOrdinalWeek == null))
+                        // DayOfMonth == 0 required: a legit "day N of month" row has
+                        // RepeatOrdinalWeek null but DayOfMonth >= 1; don't re-normalize it.
+                        || (x.RepeatType == 3 && x.RepeatOrdinalWeek == null && x.DayOfMonth == 0))
             .ToListAsync();
 
         if (arpsToNormalize.Count == 0)


### PR DESCRIPTION
## The bug

`CalendarConfigurationBackfillService.RunIfNeededAsync` decides which task-wizard `AreaRulePlanning` rows still need converting to the new calendar model purely by whether a `CalendarConfiguration` marker row already exists for them. That's wrong: an older, since-replaced version of this backfill service created the marker row **without ever populating** the ARP's recurrence-detail columns (`DayOfWeek` / `DayOfMonth` / `RepeatOrdinalWeek` / `RepeatWeekdaysCsv`). Any ARP touched by that old service — or reintroduced via a restore of old production data — ended up with a marker that made it look "already handled," so it was permanently skipped on every subsequent boot and kept rendering as "dag 0" in the calendar.

## The fix

- Broadened the backfill's selection predicate so a row also qualifies for (re-)normalization when it has a marker but is still un-normalized:
  - **Week**: `RepeatType == 2` with an empty `RepeatWeekdaysCsv`.
  - **Month**: `RepeatType == 3` with `RepeatOrdinalWeek == null` **and** `DayOfMonth == 0`.
- The `DayOfMonth == 0` half of the Month check matters: a legitimately-configured "day N of month" row (set via `UpdateTask`) also has `RepeatOrdinalWeek == null`, but `DayOfMonth >= 1`. Requiring both defaults isolates truly-stale rows and avoids clobbering a real day-of-month configuration back to "dag 0". A negative-case test (`RunIfNeededAsync_MonthlyDayOfMonthWithLiveMarker_IsLeftUntouched`) proves this row is left completely alone.
- Guarded `CalendarConfiguration` creation so a re-selected stale-marker row reuses its existing marker instead of inserting a duplicate.
- Added regression coverage for the Week and Month stale-marker cases, asserting normalization happens in place and the marker count stays at 1.

## Deploy-safety note

**This changes behavior for existing production data**, not just code. The first boot after this deploys will scan for and mass re-normalize any previously-stuck legacy rows across all properties — this is the intended fix, but it is a one-shot startup data mutation (not merely a bugfix sitting inert until someone edits a task), so please review with that in mind.

## Context

Found while investigating recurrence-display bugs reported as "still broken" for old weekly/monthly recurring tasks after related fixes had already shipped. I searched the repo's issues for "Gamle opgaver med frekvens" / similar recurrence-display reports but didn't find an exact match to cross-reference; the closest thematically-related prior issue is #938 (task-wizard update/reactivation hard-setting `DayOfMonth`), which is a different bug in the same problem area (wizard-created recurring tasks rendering the wrong day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
