### PR TITLE
CI: cache Playwright browsers + yarn deps (prewarm job, version-keyed, self-healing)

### DIFF
--- a/.github/workflows/dotnet-core-master.yml
+++ b/.github/workflows/dotnet-core-master.yml
@@ -91,6 +91,10 @@ jobs:
       run: |
         cd eform-angular-frontend/eform-client
         VER=$(awk -F'"' '/^"@playwright\/test@/{b=1} b&&/^  version/{print $2; exit}' yarn.lock)
+        if [ -z "$VER" ]; then
+          echo "::error::Could not resolve @playwright/test version from yarn.lock"
+          exit 1
+        fi
         echo "version=$VER" >> "$GITHUB_OUTPUT"
     - name: Cache Playwright browsers
       id: pwcache
@@ -100,7 +104,9 @@ jobs:
         key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
     - name: Download browsers (cache miss only)
       if: steps.pwcache.outputs.cache-hit != 'true'
-      run: npx playwright@${{ steps.pw.outputs.version }} install chromium
+      env:
+        PW_VERSION: ${{ steps.pw.outputs.version }}
+      run: npx playwright@"$PW_VERSION" install chromium
   pn-playwright-test:
     needs: [backend-pn-build, prewarm-playwright]
     runs-on: ubuntu-latest
@@ -183,15 +189,12 @@ jobs:
       with:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ needs.prewarm-playwright.outputs.version }}
-    # Cache miss: install browser binaries + system apt deps.
-    # Cache hit: browsers were restored from the cache above, but system apt
-    # deps live outside ~/.cache/ms-playwright and must be installed each run.
-    - name: Install Playwright (+browsers) — cache miss
-      if: steps.pwcache.outputs.cache-hit != 'true'
+    # The restored browser cache makes `install` a no-op download on a hit while
+    # still (re)installing apt system-deps; running it unconditionally keeps the
+    # shard self-healing if the cache is ever incomplete or the resolved version
+    # differs from prewarm's.
+    - name: Install Playwright browsers + system deps
       run: cd eform-angular-frontend/eform-client && npx playwright install --with-deps chromium
-    - name: Install Playwright system deps only — cache hit
-      if: steps.pwcache.outputs.cache-hit == 'true'
-      run: cd eform-angular-frontend/eform-client && npx playwright install-deps chromium
     - name: Create errorShots directory
       run: mkdir eform-angular-frontend/eform-client/errorShots
     - name: Pretest changes to work with Docker container

--- a/.github/workflows/dotnet-core-master.yml
+++ b/.github/workflows/dotnet-core-master.yml
@@ -62,6 +62,40 @@ jobs:
       with:
         name: work-items-planning-container
         path: work-items-planning-container.tar
+  prewarm-playwright:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pw.outputs.version }}
+    steps:
+    - name: Extract branch name
+      id: extract_branch
+      run: echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+    - name: 'Preparing Frontend checkout'
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+        repository: microting/eform-angular-frontend
+        ref: ${{ steps.extract_branch.outputs.BRANCH }}
+        path: eform-angular-frontend
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 22
+    - name: Resolve Playwright version
+      id: pw
+      run: |
+        cd eform-angular-frontend/eform-client
+        VER=$(awk -F'"' '/^"@playwright\/test@/{b=1} b&&/^  version/{print $2; exit}' yarn.lock)
+        echo "version=$VER" >> "$GITHUB_OUTPUT"
+    - name: Cache Playwright browsers
+      id: pwcache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+    - name: Download browsers (cache miss only)
+      if: steps.pwcache.outputs.cache-hit != 'true'
+      run: npx playwright@${{ steps.pw.outputs.version }} install chromium
   pn-playwright-test:
     needs: backend-pn-build
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-core-master.yml
+++ b/.github/workflows/dotnet-core-master.yml
@@ -97,7 +97,7 @@ jobs:
       if: steps.pwcache.outputs.cache-hit != 'true'
       run: npx playwright@${{ steps.pw.outputs.version }} install chromium
   pn-playwright-test:
-    needs: backend-pn-build
+    needs: [backend-pn-build, prewarm-playwright]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -164,10 +164,26 @@ jobs:
         cd eform-angular-frontend/eform-client && ../../eform-angular-items-planning-plugin/testinginstallpn.sh
         ../../eform-angular-timeplanning-plugin/testinginstallpn.sh
         ../../eform-backendconfiguration-plugin/testinginstallpn.sh
+    - name: Cache yarn
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('eform-angular-frontend/eform-client/yarn.lock') }}
+        restore-keys: ${{ runner.os }}-yarn-
     - name: yarn install
       run: cd eform-angular-frontend/eform-client && yarn install
-    - name: Install Playwright browsers
+    - name: Cache Playwright browsers
+      id: pwcache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ needs.prewarm-playwright.outputs.version }}
+    - name: Install Playwright (+browsers) — cache miss
+      if: steps.pwcache.outputs.cache-hit != 'true'
       run: cd eform-angular-frontend/eform-client && npx playwright install --with-deps chromium
+    - name: Install Playwright system deps only — cache hit
+      if: steps.pwcache.outputs.cache-hit == 'true'
+      run: cd eform-angular-frontend/eform-client && npx playwright install-deps chromium
     - name: Create errorShots directory
       run: mkdir eform-angular-frontend/eform-client/errorShots
     - name: Pretest changes to work with Docker container

--- a/.github/workflows/dotnet-core-master.yml
+++ b/.github/workflows/dotnet-core-master.yml
@@ -62,6 +62,11 @@ jobs:
       with:
         name: work-items-planning-container
         path: work-items-planning-container.tar
+  # Warms the shared ~/.cache/ms-playwright browser cache once, before the
+  # pn-playwright-test matrix fans out, so each shard restores the browsers
+  # instead of re-downloading them. Installs browser binaries only (no
+  # --with-deps): system apt deps live outside the cache and are (re)installed
+  # per shard in pn-playwright-test below.
   prewarm-playwright:
     runs-on: ubuntu-latest
     outputs:
@@ -178,6 +183,9 @@ jobs:
       with:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ needs.prewarm-playwright.outputs.version }}
+    # Cache miss: install browser binaries + system apt deps.
+    # Cache hit: browsers were restored from the cache above, but system apt
+    # deps live outside ~/.cache/ms-playwright and must be installed each run.
     - name: Install Playwright (+browsers) — cache miss
       if: steps.pwcache.outputs.cache-hit != 'true'
       run: cd eform-angular-frontend/eform-client && npx playwright install --with-deps chromium

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -90,6 +90,10 @@ jobs:
       run: |
         cd eform-angular-frontend/eform-client
         VER=$(awk -F'"' '/^"@playwright\/test@/{b=1} b&&/^  version/{print $2; exit}' yarn.lock)
+        if [ -z "$VER" ]; then
+          echo "::error::Could not resolve @playwright/test version from yarn.lock"
+          exit 1
+        fi
         echo "version=$VER" >> "$GITHUB_OUTPUT"
     - name: Cache Playwright browsers
       id: pwcache
@@ -99,7 +103,9 @@ jobs:
         key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
     - name: Download browsers (cache miss only)
       if: steps.pwcache.outputs.cache-hit != 'true'
-      run: npx playwright@${{ steps.pw.outputs.version }} install chromium
+      env:
+        PW_VERSION: ${{ steps.pw.outputs.version }}
+      run: npx playwright@"$PW_VERSION" install chromium
   pn-playwright-test:
     needs: [backend-pn-build, prewarm-playwright]
     runs-on: ubuntu-latest
@@ -187,15 +193,12 @@ jobs:
       with:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ needs.prewarm-playwright.outputs.version }}
-    # Cache miss: install browser binaries + system apt deps.
-    # Cache hit: browsers were restored from the cache above, but system apt
-    # deps live outside ~/.cache/ms-playwright and must be installed each run.
-    - name: Install Playwright (+browsers) — cache miss
-      if: steps.pwcache.outputs.cache-hit != 'true'
+    # The restored browser cache makes `install` a no-op download on a hit while
+    # still (re)installing apt system-deps; running it unconditionally keeps the
+    # shard self-healing if the cache is ever incomplete or the resolved version
+    # differs from prewarm's.
+    - name: Install Playwright browsers + system deps
       run: cd eform-angular-frontend/eform-client && npx playwright install --with-deps chromium
-    - name: Install Playwright system deps only — cache hit
-      if: steps.pwcache.outputs.cache-hit == 'true'
-      run: cd eform-angular-frontend/eform-client && npx playwright install-deps chromium
     - name: Create errorShots directory
       run: mkdir eform-angular-frontend/eform-client/errorShots
     - name: Pretest changes to work with Docker container

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -56,6 +56,45 @@ jobs:
       with:
         name: work-items-planning-container
         path: work-items-planning-container.tar
+  prewarm-playwright:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pw.outputs.version }}
+    steps:
+    - name: Extract branch name
+      id: extract_branch
+      run: |
+        BRANCH=$(echo ${GITHUB_REF#refs/heads/})
+        if [[ "$BRANCH" != "stable" && "$BRANCH" != "master" && "$BRANCH" != "angular19" ]]; then
+          BRANCH="stable"
+        fi
+        echo "BRANCH=$BRANCH" >> $GITHUB_OUTPUT
+    - name: 'Preparing Frontend checkout'
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+        repository: microting/eform-angular-frontend
+        ref: ${{ steps.extract_branch.outputs.BRANCH }}
+        path: eform-angular-frontend
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 22
+    - name: Resolve Playwright version
+      id: pw
+      run: |
+        cd eform-angular-frontend/eform-client
+        VER=$(awk -F'"' '/^"@playwright\/test@/{b=1} b&&/^  version/{print $2; exit}' yarn.lock)
+        echo "version=$VER" >> "$GITHUB_OUTPUT"
+    - name: Cache Playwright browsers
+      id: pwcache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+    - name: Download browsers (cache miss only)
+      if: steps.pwcache.outputs.cache-hit != 'true'
+      run: npx playwright@${{ steps.pw.outputs.version }} install chromium
   pn-playwright-test:
     needs: backend-pn-build
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -56,6 +56,11 @@ jobs:
       with:
         name: work-items-planning-container
         path: work-items-planning-container.tar
+  # Warms the shared ~/.cache/ms-playwright browser cache once, before the
+  # pn-playwright-test matrix fans out, so each shard restores the browsers
+  # instead of re-downloading them. Installs browser binaries only (no
+  # --with-deps): system apt deps live outside the cache and are (re)installed
+  # per shard in pn-playwright-test below.
   prewarm-playwright:
     runs-on: ubuntu-latest
     outputs:
@@ -182,6 +187,9 @@ jobs:
       with:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ needs.prewarm-playwright.outputs.version }}
+    # Cache miss: install browser binaries + system apt deps.
+    # Cache hit: browsers were restored from the cache above, but system apt
+    # deps live outside ~/.cache/ms-playwright and must be installed each run.
     - name: Install Playwright (+browsers) — cache miss
       if: steps.pwcache.outputs.cache-hit != 'true'
       run: cd eform-angular-frontend/eform-client && npx playwright install --with-deps chromium

--- a/.github/workflows/dotnet-core-pr.yml
+++ b/.github/workflows/dotnet-core-pr.yml
@@ -96,7 +96,7 @@ jobs:
       if: steps.pwcache.outputs.cache-hit != 'true'
       run: npx playwright@${{ steps.pw.outputs.version }} install chromium
   pn-playwright-test:
-    needs: backend-pn-build
+    needs: [backend-pn-build, prewarm-playwright]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -168,10 +168,26 @@ jobs:
         cd eform-angular-frontend/eform-client && ../../eform-angular-items-planning-plugin/testinginstallpn.sh
         ../../eform-angular-timeplanning-plugin/testinginstallpn.sh
         ../../eform-backendconfiguration-plugin/testinginstallpn.sh
+    - name: Cache yarn
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('eform-angular-frontend/eform-client/yarn.lock') }}
+        restore-keys: ${{ runner.os }}-yarn-
     - name: yarn install
       run: cd eform-angular-frontend/eform-client && yarn install
-    - name: Install Playwright browsers
+    - name: Cache Playwright browsers
+      id: pwcache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ needs.prewarm-playwright.outputs.version }}
+    - name: Install Playwright (+browsers) — cache miss
+      if: steps.pwcache.outputs.cache-hit != 'true'
       run: cd eform-angular-frontend/eform-client && npx playwright install --with-deps chromium
+    - name: Install Playwright system deps only — cache hit
+      if: steps.pwcache.outputs.cache-hit == 'true'
+      run: cd eform-angular-frontend/eform-client && npx playwright install-deps chromium
     - name: Create errorShots directory
       run: mkdir eform-angular-frontend/eform-client/errorShots
     - name: Pretest changes to work with Docker container

--- a/docs/superpowers/plans/2026-08-19-ci-playwright-cache.md
+++ b/docs/superpowers/plans/2026-08-19-ci-playwright-cache.md
@@ -1,0 +1,483 @@
+# CI Playwright browser + yarn caching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cache the Playwright Chromium browser and the yarn package cache in the 26-shard `pn-playwright-test` job of both CI workflow files, keyed on the resolved `@playwright/test` version so it auto-invalidates on version bumps.
+
+**Architecture:** Add a new single-run `prewarm-playwright` job (per file) that resolves the Playwright version from the host frontend `yarn.lock` and downloads the browser once into `actions/cache`. The shard job gains a `needs` dependency on it, restores the browser cache keyed on the prewarm job's output version, restores a standalone yarn cache, and splits the browser-install step into a cache-miss (full `--with-deps`) path and a cache-hit (`install-deps` only) path. The change is duplicated verbatim across `dotnet-core-pr.yml` and `dotnet-core-master.yml`, with each file reusing its **own** `extract_branch` block.
+
+**Tech Stack:** GitHub Actions, `actions/cache@v4`, `actions/checkout@v3`, `actions/setup-node@v3` (node 22), yarn v1 classic, Playwright CLI.
+
+## Global Constraints
+
+- **Source of truth:** `docs/superpowers/specs/2026-08-19-ci-playwright-cache-design.md`. Follow it exactly.
+- **No local test harness for GitHub Actions YAML.** The only local verification per task is that the modified file still parses/lints cleanly (`actionlint` if available, else `python3 -c "import yaml; yaml.safe_load(open(...))"`). The **authoritative** validation is the PR's own CI run showing `prewarm-playwright` populating the browser cache and the shards restoring it (cache-hit path runs `npx playwright install-deps chromium` with no browser download). State this in every task's verification.
+- **Two files in sync:** every change lands in BOTH `.github/workflows/dotnet-core-pr.yml` and `.github/workflows/dotnet-core-master.yml`. Any adjustment must be mirrored.
+- **Per-file `extract_branch`:** the two files' `extract_branch` step bodies differ (pr.yml has a `stable` fallback; master.yml is a plain one-liner). In each file the `prewarm-playwright` job MUST copy **that file's own** `extract_branch` block verbatim.
+- **Identical key strings (do NOT rename):**
+  - browser cache path: `~/.cache/ms-playwright`
+  - prewarm browser cache key: `${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}`
+  - shard browser cache key: `${{ runner.os }}-playwright-${{ needs.prewarm-playwright.outputs.version }}`
+  - yarn cache path: `~/.cache/yarn`; key: `${{ runner.os }}-yarn-${{ hashFiles('eform-angular-frontend/eform-client/yarn.lock') }}`; restore-keys: `${{ runner.os }}-yarn-`
+  - step ids: `pw` (version resolution), `pwcache` (browser cache); job output name: `version`.
+  The version component of the prewarm key and the shard key MUST resolve to the same string — that is the whole point of exposing `version` as a job output.
+- **Indentation (both files):** job names at 2 spaces; job-level keys (`runs-on`, `outputs`, `needs`, `strategy`, `steps`) at 4 spaces; step dashes (`- name:`) at 4 spaces; step keys at 6 spaces; `with:` children at 8 spaces.
+- **Standard commits only** — no `--amend`, no force, no push, no PR from these tasks.
+- **Scope:** CI infrastructure only. No test, product, or docker-orchestration behavior changes.
+
+---
+
+## File Structure
+
+- `.github/workflows/dotnet-core-pr.yml` — add `prewarm-playwright` job before `pn-playwright-test`; wire the shard job. (Tasks 1–2)
+- `.github/workflows/dotnet-core-master.yml` — same two changes, mirrored, using master.yml's own `extract_branch`. (Tasks 3–4)
+- Task 5 validates both files parse/lint and finalizes.
+
+Line numbers below are from the current HEAD of this worktree (re-confirmed 2026-08-19). Re-check them before editing; anchor edits on the surrounding text shown, not the numbers.
+
+---
+
+### Task 1: Add `prewarm-playwright` job to `dotnet-core-pr.yml`
+
+**Files:**
+- Modify: `.github/workflows/dotnet-core-pr.yml` (insert a new job immediately before `  pn-playwright-test:` at line 59)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: job `prewarm-playwright` with output `version` (the resolved `@playwright/test` version string, e.g. `1.58.2`), consumed by Task 2 via `${{ needs.prewarm-playwright.outputs.version }}`.
+
+- [ ] **Step 1: Insert the new job before `pn-playwright-test`**
+
+The current text at lines 55–60 is:
+
+```yaml
+    - uses: actions/upload-artifact@v4
+      with:
+        name: work-items-planning-container
+        path: work-items-planning-container.tar
+  pn-playwright-test:
+    needs: backend-pn-build
+```
+
+Insert the entire `prewarm-playwright` job between the `path: work-items-planning-container.tar` line and the `  pn-playwright-test:` line, so it reads:
+
+```yaml
+    - uses: actions/upload-artifact@v4
+      with:
+        name: work-items-planning-container
+        path: work-items-planning-container.tar
+  prewarm-playwright:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pw.outputs.version }}
+    steps:
+    - name: Extract branch name
+      id: extract_branch
+      run: |
+        BRANCH=$(echo ${GITHUB_REF#refs/heads/})
+        if [[ "$BRANCH" != "stable" && "$BRANCH" != "master" && "$BRANCH" != "angular19" ]]; then
+          BRANCH="stable"
+        fi
+        echo "BRANCH=$BRANCH" >> $GITHUB_OUTPUT
+    - name: 'Preparing Frontend checkout'
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+        repository: microting/eform-angular-frontend
+        ref: ${{ steps.extract_branch.outputs.BRANCH }}
+        path: eform-angular-frontend
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 22
+    - name: Resolve Playwright version
+      id: pw
+      run: |
+        cd eform-angular-frontend/eform-client
+        VER=$(awk -F'"' '/^"@playwright\/test@/{b=1} b&&/^  version/{print $2; exit}' yarn.lock)
+        echo "version=$VER" >> "$GITHUB_OUTPUT"
+    - name: Cache Playwright browsers
+      id: pwcache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+    - name: Download browsers (cache miss only)
+      if: steps.pwcache.outputs.cache-hit != 'true'
+      run: npx playwright@${{ steps.pw.outputs.version }} install chromium
+  pn-playwright-test:
+    needs: backend-pn-build
+```
+
+Notes:
+- The `extract_branch` block above is copied **verbatim from pr.yml's own** shard step (lines 70–77), including the `stable` fallback.
+- Prewarm uses `fetch-depth: 1` (shallow) per spec §A.2 — only `yarn.lock` is needed. The `ref:` expression is identical to the shard's, so the resolved version cannot diverge.
+- No `--with-deps` in the download step — prewarm only needs the browser binary in `~/.cache/ms-playwright`; apt system-deps are handled per-shard.
+
+- [ ] **Step 2: Verify the file still parses**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/dotnet-core-pr.yml')); print('OK')"`
+Expected: `OK` (no traceback).
+
+If `actionlint` is installed, also run: `actionlint .github/workflows/dotnet-core-pr.yml`
+Expected: no output (exit 0). (If `actionlint` is not installed, skip — the yaml parse is sufficient locally; CI is the authoritative check.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/dotnet-core-pr.yml
+git commit -m "ci(pr): add prewarm-playwright job to prewarm the browser cache"
+```
+
+---
+
+### Task 2: Wire the `pn-playwright-test` shard job in `dotnet-core-pr.yml` to the caches
+
+**Files:**
+- Modify: `.github/workflows/dotnet-core-pr.yml` — shard `needs` (line 60 pre-Task-1; shifts down after Task 1's insertion), yarn cache before `yarn install`, browser cache + split install steps replacing `Install Playwright browsers` (lines 132–135 pre-Task-1).
+
+**Interfaces:**
+- Consumes: `prewarm-playwright` job's `version` output (Task 1) via `${{ needs.prewarm-playwright.outputs.version }}`.
+- Produces: nothing consumed by later pr.yml tasks.
+
+> After Task 1, the shard job's line numbers shifted down by the inserted job. Anchor every edit below on the surrounding text, not the numbers.
+
+- [ ] **Step 1: Add `prewarm-playwright` to the shard's `needs`**
+
+Current (shard job header):
+
+```yaml
+  pn-playwright-test:
+    needs: backend-pn-build
+    runs-on: ubuntu-latest
+```
+
+Change to:
+
+```yaml
+  pn-playwright-test:
+    needs: [backend-pn-build, prewarm-playwright]
+    runs-on: ubuntu-latest
+```
+
+- [ ] **Step 2: Insert the yarn cache before `yarn install`**
+
+Current text (shard job, "yarn install" step, was lines 132–133):
+
+```yaml
+    - name: yarn install
+      run: cd eform-angular-frontend/eform-client && yarn install
+```
+
+Change to (insert the `Cache yarn` step directly above it):
+
+```yaml
+    - name: Cache yarn
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('eform-angular-frontend/eform-client/yarn.lock') }}
+        restore-keys: ${{ runner.os }}-yarn-
+    - name: yarn install
+      run: cd eform-angular-frontend/eform-client && yarn install
+```
+
+- [ ] **Step 3: Add the browser cache and split the install step**
+
+Current text (shard job, "Install Playwright browsers" step, was lines 134–135):
+
+```yaml
+    - name: Install Playwright browsers
+      run: cd eform-angular-frontend/eform-client && npx playwright install --with-deps chromium
+```
+
+Replace those two lines entirely with:
+
+```yaml
+    - name: Cache Playwright browsers
+      id: pwcache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ needs.prewarm-playwright.outputs.version }}
+    - name: Install Playwright (+browsers) — cache miss
+      if: steps.pwcache.outputs.cache-hit != 'true'
+      run: cd eform-angular-frontend/eform-client && npx playwright install --with-deps chromium
+    - name: Install Playwright system deps only — cache hit
+      if: steps.pwcache.outputs.cache-hit == 'true'
+      run: cd eform-angular-frontend/eform-client && npx playwright install-deps chromium
+```
+
+After this step the shard region reads, in order: `Cache yarn` → `yarn install` → `Cache Playwright browsers` → `Install Playwright (+browsers) — cache miss` → `Install Playwright system deps only — cache hit` → `Create errorShots directory` (unchanged, next existing step).
+
+- [ ] **Step 4: Verify the file still parses**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/dotnet-core-pr.yml')); print('OK')"`
+Expected: `OK`.
+
+If available: `actionlint .github/workflows/dotnet-core-pr.yml` → no output (exit 0).
+
+Also grep to confirm the two keys share an identical version component and the ids are consistent:
+
+Run: `grep -nE 'playwright-\$\{\{ (runner\.os|steps\.pw|needs\.prewarm)|id: pw' .github/workflows/dotnet-core-pr.yml`
+Expected: shows the prewarm key `...-playwright-${{ steps.pw.outputs.version }}`, the shard key `...-playwright-${{ needs.prewarm-playwright.outputs.version }}`, and `id: pw` / `id: pwcache` — the trailing `...playwright-<X>` component identical modulo the source of `version`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/dotnet-core-pr.yml
+git commit -m "ci(pr): restore Playwright browser + yarn caches in shard job"
+```
+
+---
+
+### Task 3: Add `prewarm-playwright` job to `dotnet-core-master.yml`
+
+**Files:**
+- Modify: `.github/workflows/dotnet-core-master.yml` (insert a new job immediately before `  pn-playwright-test:` at line 65)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: job `prewarm-playwright` with output `version`, consumed by Task 4.
+
+> master.yml's `extract_branch` is the plain one-liner (no fallback). Everything else in the job is identical to Task 1.
+
+- [ ] **Step 1: Insert the new job before `pn-playwright-test`**
+
+The current text at lines 61–66 is:
+
+```yaml
+    - uses: actions/upload-artifact@v4
+      with:
+        name: work-items-planning-container
+        path: work-items-planning-container.tar
+  pn-playwright-test:
+    needs: backend-pn-build
+```
+
+Insert the entire `prewarm-playwright` job between the `path: work-items-planning-container.tar` line and the `  pn-playwright-test:` line, so it reads:
+
+```yaml
+    - uses: actions/upload-artifact@v4
+      with:
+        name: work-items-planning-container
+        path: work-items-planning-container.tar
+  prewarm-playwright:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pw.outputs.version }}
+    steps:
+    - name: Extract branch name
+      id: extract_branch
+      run: echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+    - name: 'Preparing Frontend checkout'
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+        repository: microting/eform-angular-frontend
+        ref: ${{ steps.extract_branch.outputs.BRANCH }}
+        path: eform-angular-frontend
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 22
+    - name: Resolve Playwright version
+      id: pw
+      run: |
+        cd eform-angular-frontend/eform-client
+        VER=$(awk -F'"' '/^"@playwright\/test@/{b=1} b&&/^  version/{print $2; exit}' yarn.lock)
+        echo "version=$VER" >> "$GITHUB_OUTPUT"
+    - name: Cache Playwright browsers
+      id: pwcache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+    - name: Download browsers (cache miss only)
+      if: steps.pwcache.outputs.cache-hit != 'true'
+      run: npx playwright@${{ steps.pw.outputs.version }} install chromium
+  pn-playwright-test:
+    needs: backend-pn-build
+```
+
+Notes:
+- The `extract_branch` block above is copied **verbatim from master.yml's own** shard step (lines 76–78) — the plain one-liner, **no** `stable` fallback. This is the only line that differs from Task 1's job.
+- Everything else (outputs, checkout with `fetch-depth: 1`, node 22, `id: pw` resolve, `id: pwcache` cache, miss-only download) is byte-identical to the pr.yml job.
+
+- [ ] **Step 2: Verify the file still parses**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/dotnet-core-master.yml')); print('OK')"`
+Expected: `OK`.
+
+If available: `actionlint .github/workflows/dotnet-core-master.yml` → no output (exit 0).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/dotnet-core-master.yml
+git commit -m "ci(master): add prewarm-playwright job to prewarm the browser cache"
+```
+
+---
+
+### Task 4: Wire the `pn-playwright-test` shard job in `dotnet-core-master.yml` to the caches
+
+**Files:**
+- Modify: `.github/workflows/dotnet-core-master.yml` — shard `needs` (line 66 pre-Task-3; shifts down after Task 3), yarn cache before `yarn install`, browser cache + split install steps replacing `Install Playwright browsers` (lines 133–136 pre-Task-3).
+
+**Interfaces:**
+- Consumes: `prewarm-playwright` job's `version` output (Task 3) via `${{ needs.prewarm-playwright.outputs.version }}`.
+- Produces: nothing consumed later.
+
+> After Task 3, the shard job's line numbers shifted down by the inserted job. Anchor every edit on the surrounding text.
+
+- [ ] **Step 1: Add `prewarm-playwright` to the shard's `needs`**
+
+Current (shard job header):
+
+```yaml
+  pn-playwright-test:
+    needs: backend-pn-build
+    runs-on: ubuntu-latest
+```
+
+Change to:
+
+```yaml
+  pn-playwright-test:
+    needs: [backend-pn-build, prewarm-playwright]
+    runs-on: ubuntu-latest
+```
+
+- [ ] **Step 2: Insert the yarn cache before `yarn install`**
+
+Current text (shard job, "yarn install" step, was lines 133–134):
+
+```yaml
+    - name: yarn install
+      run: cd eform-angular-frontend/eform-client && yarn install
+```
+
+Change to (insert the `Cache yarn` step directly above it):
+
+```yaml
+    - name: Cache yarn
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('eform-angular-frontend/eform-client/yarn.lock') }}
+        restore-keys: ${{ runner.os }}-yarn-
+    - name: yarn install
+      run: cd eform-angular-frontend/eform-client && yarn install
+```
+
+- [ ] **Step 3: Add the browser cache and split the install step**
+
+Current text (shard job, "Install Playwright browsers" step, was lines 135–136):
+
+```yaml
+    - name: Install Playwright browsers
+      run: cd eform-angular-frontend/eform-client && npx playwright install --with-deps chromium
+```
+
+Replace those two lines entirely with:
+
+```yaml
+    - name: Cache Playwright browsers
+      id: pwcache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ needs.prewarm-playwright.outputs.version }}
+    - name: Install Playwright (+browsers) — cache miss
+      if: steps.pwcache.outputs.cache-hit != 'true'
+      run: cd eform-angular-frontend/eform-client && npx playwright install --with-deps chromium
+    - name: Install Playwright system deps only — cache hit
+      if: steps.pwcache.outputs.cache-hit == 'true'
+      run: cd eform-angular-frontend/eform-client && npx playwright install-deps chromium
+```
+
+After this step the shard region reads, in order: `Cache yarn` → `yarn install` → `Cache Playwright browsers` → `Install Playwright (+browsers) — cache miss` → `Install Playwright system deps only — cache hit` → `Create errorShots directory` (unchanged).
+
+- [ ] **Step 4: Verify the file still parses**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/dotnet-core-master.yml')); print('OK')"`
+Expected: `OK`.
+
+If available: `actionlint .github/workflows/dotnet-core-master.yml` → no output (exit 0).
+
+Run: `grep -nE 'playwright-\$\{\{ (runner\.os|steps\.pw|needs\.prewarm)|id: pw' .github/workflows/dotnet-core-master.yml`
+Expected: prewarm key `...-playwright-${{ steps.pw.outputs.version }}`, shard key `...-playwright-${{ needs.prewarm-playwright.outputs.version }}`, and `id: pw` / `id: pwcache` present.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/dotnet-core-master.yml
+git commit -m "ci(master): restore Playwright browser + yarn caches in shard job"
+```
+
+---
+
+### Task 5: Validate both files and finalize
+
+**Files:**
+- Read-only verification of both workflow files. No edits unless validation fails.
+
+- [ ] **Step 1: Parse both files**
+
+Run:
+
+```bash
+python3 -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/dotnet-core-pr.yml','.github/workflows/dotnet-core-master.yml']]; print('both OK')"
+```
+
+Expected: `both OK` (no traceback).
+
+- [ ] **Step 2: Lint if actionlint is available**
+
+Run: `command -v actionlint >/dev/null && actionlint .github/workflows/dotnet-core-pr.yml .github/workflows/dotnet-core-master.yml && echo "actionlint clean" || echo "actionlint not installed — CI is authoritative"`
+Expected: `actionlint clean` if installed, else the fallback message. Neither is a failure; the yaml parse in Step 1 is the local gate.
+
+- [ ] **Step 3: Confirm the two files' new blocks match (except extract_branch)**
+
+Run:
+
+```bash
+grep -nE 'prewarm-playwright:|id: pw$|id: pwcache|-playwright-\$\{\{|-yarn-\$\{\{|install-deps chromium|needs: \[backend-pn-build, prewarm-playwright\]' .github/workflows/dotnet-core-pr.yml .github/workflows/dotnet-core-master.yml
+```
+
+Expected: each file shows the `prewarm-playwright:` job, `id: pw`, `id: pwcache`, both `-playwright-${{ ... }}` keys, the `-yarn-${{ ... }}` key, the `install-deps chromium` hit-path, and the widened `needs:` list. The only intended difference between the files is the `extract_branch` body (pr.yml multi-line with `stable` fallback; master.yml one-liner).
+
+- [ ] **Step 4: No commit**
+
+This task makes no source changes. If Steps 1–3 pass, there is nothing to commit. If any check fails, return to the offending task, fix, and re-run its own verification and commit — do not amend prior commits.
+
+**Authoritative validation (post-merge / on the PR):** open the PR's Actions run and confirm (a) `prewarm-playwright` runs once and, on a cold cache, executes `Download browsers (cache miss only)`; (b) the shards' `Cache Playwright browsers` step reports a cache hit and the `Install Playwright system deps only — cache hit` step runs (no browser download); (c) `Cache yarn` restores; (d) all 26 shards still pass. On the first run after a Playwright version bump, prewarm downloads once and all shards hit.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (spec `2026-08-19-ci-playwright-cache-design.md` → task):
+- §A `prewarm-playwright` job (pr.yml) → Task 1. (master.yml) → Task 3.
+- §A.1 extract-branch verbatim per file → Task 1 (pr fallback variant), Task 3 (master one-liner). Global Constraints restates the divergence.
+- §A.2 frontend checkout, `ref: ${{ steps.extract_branch.outputs.BRANCH }}`, `fetch-depth: 1` shallow → Tasks 1 & 3, Step 1.
+- §A.3 setup-node@v3 node 22 → Tasks 1 & 3.
+- §A.4 resolve version via awk into `id: pw` output `version` → Tasks 1 & 3 (`echo "version=$VER" >> "$GITHUB_OUTPUT"`).
+- §A.5 `actions/cache@v4` restore (`id: pwcache`) + miss-only `npx playwright@<ver> install chromium` (no `--with-deps`) → Tasks 1 & 3.
+- §A job-level `outputs: version:` → Tasks 1 & 3, `outputs` block.
+- §B.1 shard `needs: [backend-pn-build, prewarm-playwright]` → Tasks 2 & 4, Step 1.
+- §B.2 shard browser cache keyed on `needs.prewarm-playwright.outputs.version` → Tasks 2 & 4, Step 3.
+- §B.3 split install: miss `install --with-deps chromium`, hit `install-deps chromium`, each `cd eform-angular-frontend/eform-client && ...` → Tasks 2 & 4, Step 3.
+- §B.4 standalone yarn cache after frontend checkout / before `yarn install` → Tasks 2 & 4, Step 2.
+- "No local test harness; CI is authoritative" → Global Constraints + every task's verification + Task 5.
+- Two-files-in-sync → Tasks 3–4 mirror 1–2; Task 5 Step 3 asserts parity.
+
+**2. Placeholder scan:** No TBD/TODO/"similar to Task N"/"add error handling". Every YAML block is complete with the target file's exact indentation; master.yml's YAML is repeated in full (not referenced) even though it mirrors pr.yml.
+
+**3. Type/name consistency:**
+- Step ids `pw` and `pwcache` — identical in both jobs, both files.
+- Job output name `version` — identical everywhere; prewarm sets `steps.pw.outputs.version`, shards read `needs.prewarm-playwright.outputs.version`.
+- Browser cache path `~/.cache/ms-playwright` and yarn cache path `~/.cache/yarn` — identical in all four locations.
+- Prewarm browser key `${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}` and shard browser key `${{ runner.os }}-playwright-${{ needs.prewarm-playwright.outputs.version }}` — the `${{ runner.os }}-playwright-` prefix is byte-identical and the version component resolves to the same string (the shard reads the prewarm job's own output), so prewarm's saved key matches the shard's restore key exactly.
+- Yarn key `${{ runner.os }}-yarn-${{ hashFiles('eform-angular-frontend/eform-client/yarn.lock') }}` with restore-keys `${{ runner.os }}-yarn-` — identical in Tasks 2 & 4.

--- a/docs/superpowers/specs/2026-08-19-ci-playwright-cache-design.md
+++ b/docs/superpowers/specs/2026-08-19-ci-playwright-cache-design.md
@@ -1,0 +1,318 @@
+# CI Playwright browser + yarn caching — design spec
+
+**Date:** 2026-08-19
+**Branch:** `feat/ci-playwright-cache`
+**Status:** Approved for implementation
+**Scope:** CI infrastructure only. No test, product, or docker-orchestration behavior changes.
+
+## Problem
+
+The `pn-playwright-test` job fans out into 26 shards (matrix `test: [a..z]`) in
+both `.github/workflows/dotnet-core-pr.yml` and `.github/workflows/dotnet-core-master.yml`.
+Every shard runs, from a cold runner:
+
+- `yarn install` in the checked-out host frontend (`eform-angular-frontend/eform-client`), and
+- `npx playwright install --with-deps chromium` — which downloads the Chromium
+  build from the Playwright CDN and installs apt system deps.
+
+The Playwright browser download is the dominant slow/flaky cost: 26 concurrent
+CDN fetches per workflow run, with no caching. This spec removes that cost by
+caching the browser binary and the yarn package cache, keyed so the cache
+auto-invalidates when the Playwright version changes.
+
+## Constraints (why the obvious shortcut is rejected)
+
+- The job runs on a **bare `ubuntu-latest` runner** because it orchestrates
+  host docker directly: `docker network create`, `docker run` for MariaDB
+  (`mariadb:10.8`) and RabbitMQ (`rabbitmq:latest`), `docker run --name my-container
+  -p 4200:5000 ...` for the app-under-test, plus `docker exec`/`docker restart`
+  against those containers. The app is reached at `localhost:4200` (host port
+  4200 → container port 5000). Moving the job into a Playwright container would
+  require docker-in-docker and rewriting the container/app network wiring —
+  **considered and rejected.**
+- Playwright is **not pinned in this repo.** The version is resolved at job time
+  from the host frontend lockfile that the job checks out:
+  `eform-angular-frontend/eform-client/yarn.lock`. The cached browser build must
+  match the `@playwright/test` version exactly, so the cache key must derive from
+  that resolved version rather than from anything in this repo.
+- The change is **duplicated across both workflow files** (`dotnet-core-pr.yml`
+  and `dotnet-core-master.yml`). Both must be kept in sync.
+
+## Verified facts from the current workflows (read 2026-08-19)
+
+Line numbers are from the current HEAD (`c6635997`) of this worktree.
+
+### `.github/workflows/dotnet-core-pr.yml`
+
+| Item | Location |
+| --- | --- |
+| `pn-playwright-test:` job header | line 59 |
+| `needs: backend-pn-build` | line 60 |
+| matrix `test: [a..z]` (26 shards) | line 65 |
+| **Extract branch name** step (`id: extract_branch`) | lines 70–77 |
+| **Use Node.js** — `actions/setup-node@v3`, `node-version: 22` | lines 97–100 |
+| **Preparing Frontend checkout** — `microting/eform-angular-frontend` → `path: eform-angular-frontend` | lines 101–107 |
+| frontend checkout `ref:` expression | line 106: `ref: ${{ steps.extract_branch.outputs.BRANCH }}` |
+| **yarn install** (`cd eform-angular-frontend/eform-client && yarn install`) | lines 132–133 |
+| **Install Playwright browsers** (`... && npx playwright install --with-deps chromium`) | lines 134–135 |
+
+The `pr.yml` **Extract branch name** step body (lines 72–77) has a fallback:
+
+```yaml
+- name: Extract branch name
+  id: extract_branch
+  run: |
+    BRANCH=$(echo ${GITHUB_REF#refs/heads/})
+    if [[ "$BRANCH" != "stable" && "$BRANCH" != "master" && "$BRANCH" != "angular19" ]]; then
+      BRANCH="stable"
+    fi
+    echo "BRANCH=$BRANCH" >> $GITHUB_OUTPUT
+```
+
+On a `pull_request` event `GITHUB_REF` is `refs/pull/N/merge`, so
+`${GITHUB_REF#refs/heads/}` does not strip and the branch falls through the
+guard to `BRANCH="stable"` in practice — but the prewarm job must replicate this
+**exact** block so it resolves the same ref the shards do.
+
+### `.github/workflows/dotnet-core-master.yml`
+
+| Item | Location |
+| --- | --- |
+| `pn-playwright-test:` job header | line 65 |
+| `needs: backend-pn-build` | line 66 |
+| matrix `test: [a..z]` (26 shards) | line 71 |
+| **Extract branch name** step (`id: extract_branch`) | lines 76–78 |
+| **Use Node.js** — `actions/setup-node@v3`, `node-version: 22` | lines 98–101 |
+| **Preparing Frontend checkout** → `path: eform-angular-frontend` | lines 102–108 |
+| frontend checkout `ref:` expression | line 107: `ref: ${{ steps.extract_branch.outputs.BRANCH }}` |
+| **yarn install** | lines 133–134 |
+| **Install Playwright browsers** | lines 135–136 |
+
+The `master.yml` **Extract branch name** step (lines 76–78) is **different** — no
+fallback, because it runs on `push` (real branch ref):
+
+```yaml
+- name: Extract branch name
+  id: extract_branch
+  run: echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+```
+
+> **Critical:** the two files' `extract_branch` bodies differ. In each file the
+> prewarm job MUST copy that file's own `extract_branch` block verbatim. The
+> `ref:` expression consuming it (`ref: ${{ steps.extract_branch.outputs.BRANCH }}`)
+> is identical in both.
+
+### Other verified facts
+
+- **Step ordering matters:** in the shard job `actions/setup-node@v3` (node 22)
+  runs **before** the Frontend checkout. Therefore setup-node's built-in
+  `cache: yarn` cannot see the lockfile at setup-node time; the yarn cache must be
+  a **standalone `actions/cache` step placed after the frontend checkout.**
+- The frontend checkout targets the **public** repo `microting/eform-angular-frontend`
+  with `fetch-depth: 0` and **no token/secret** — the default `actions/checkout`
+  token suffices. Prewarm can safely use a shallow checkout (`fetch-depth: 1`)
+  since only `yarn.lock` is needed.
+- `testinginstallpn.sh` (run in the "Copy dependencies" step between frontend
+  checkout and `yarn install`) only edits `src/app/plugins/plugins.routing.ts`
+  via `perl -pi`. It does **not** modify `package.json` or `yarn.lock`. So the
+  resolved Playwright version and the yarn.lock hash are stable across the whole
+  job, and prewarm's fresh checkout resolves the identical version.
+- **Lockfile format confirmed** against the current host checkout
+  (`microting/eform-angular-frontend`, branch `stable`,
+  `eform-client/yarn.lock`): yarn v1 classic. The relevant block is:
+
+  ```
+  "@playwright/test@^1.50.0":
+    version "1.58.2"
+    resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.58.2.tgz#..."
+  ```
+
+  The awk in Component A below extracts `1.58.2` correctly from this format
+  (verified by running it against the real file).
+
+## Design
+
+Two components, applied identically to **both** workflow files.
+
+### A. New `prewarm-playwright` job
+
+Runs before the shards and guarantees exactly **one** browser download per
+version bump, so all 26 shards cache-hit — even on the first run after a
+Playwright upgrade. The shards gain a dependency on it (Component B.1).
+
+Steps:
+
+1. **Extract branch name** — copy the surrounding file's own `extract_branch`
+   step verbatim (the `pr.yml` fallback variant in `pr.yml`; the plain
+   `master.yml` variant in `master.yml`).
+2. **Frontend checkout** — `actions/checkout@v3`, `repository: microting/eform-angular-frontend`,
+   `ref: ${{ steps.extract_branch.outputs.BRANCH }}`, `path: eform-angular-frontend`.
+   Use `fetch-depth: 1` (shallow) — only `eform-client/yarn.lock` is required.
+   This MUST use the same `ref:` expression the shards use, or the resolved
+   version could diverge.
+3. **Use Node.js** — `actions/setup-node@v3` with `node-version: 22` (the `npx
+   playwright ... install` in step 5 needs node).
+4. **Resolve Playwright version** into a job output:
+
+   ```yaml
+   - name: Resolve Playwright version
+     id: pw
+     run: |
+       cd eform-angular-frontend/eform-client
+       VER=$(awk -F'"' '/^"@playwright\/test@/{b=1} b&&/^  version/{print $2; exit}' yarn.lock)
+       echo "version=$VER" >> "$GITHUB_OUTPUT"
+   ```
+
+   Verified: this yields `1.58.2` against the current host `yarn.lock` (yarn v1
+   classic; block header `"@playwright/test@^1.50.0":`). See Risks for the
+   must-re-verify note if the host ever migrates lockfile format / package
+   manager.
+
+5. **Cache + download browsers:**
+
+   ```yaml
+   - name: Cache Playwright browsers
+     id: pwcache
+     uses: actions/cache@v4
+     with:
+       path: ~/.cache/ms-playwright
+       key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+   - name: Download browsers (cache miss only)
+     if: steps.pwcache.outputs.cache-hit != 'true'
+     run: npx playwright@${{ steps.pw.outputs.version }} install chromium
+   ```
+
+   No `--with-deps` here — prewarm only needs the browser **binary** in
+   `~/.cache/ms-playwright`; apt system-deps are runner-local and handled
+   per-shard. `actions/cache`'s automatic post-step saves the cache on a miss.
+
+Expose the resolved version as a **job output** so the shards key on the exact
+same value:
+
+```yaml
+jobs:
+  prewarm-playwright:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pw.outputs.version }}
+    steps:
+      # ... steps 1–5 above
+```
+
+### B. `pn-playwright-test` (shard) changes
+
+1. **Add the prewarm dependency:**
+
+   ```yaml
+   needs: [backend-pn-build, prewarm-playwright]
+   ```
+
+   (pr.yml line 60 / master.yml line 66 currently `needs: backend-pn-build`.)
+
+2. **Browser cache restore** — placed **after** the Frontend checkout (so
+   `yarn.lock` exists) and **before** the existing "Install Playwright browsers"
+   step. Keyed on the prewarm job's output version, guaranteeing an identical key
+   to prewarm:
+
+   ```yaml
+   - name: Cache Playwright browsers
+     id: pwcache
+     uses: actions/cache@v4
+     with:
+       path: ~/.cache/ms-playwright
+       key: ${{ runner.os }}-playwright-${{ needs.prewarm-playwright.outputs.version }}
+   ```
+
+3. **Split the browser install step.** Replace the single
+   `npx playwright install --with-deps chromium` (pr.yml lines 134–135 /
+   master.yml lines 135–136) with:
+
+   ```yaml
+   - name: Install Playwright (+browsers) — cache miss
+     if: steps.pwcache.outputs.cache-hit != 'true'
+     run: cd eform-angular-frontend/eform-client && npx playwright install --with-deps chromium
+   - name: Install Playwright system deps only — cache hit
+     if: steps.pwcache.outputs.cache-hit == 'true'
+     run: cd eform-angular-frontend/eform-client && npx playwright install-deps chromium
+   ```
+
+   On a hit: browsers come from the restored cache; only apt system-deps run — no
+   CDN download. On a miss: the shard self-heals with the full `--with-deps`
+   install (and re-populates the cache via the restore step's post action).
+
+4. **Yarn cache** — standalone `actions/cache` (setup-node's built-in yarn cache
+   cannot be used; it runs before the frontend checkout). Placed after the
+   frontend checkout, before "yarn install" (pr.yml lines 132–133 / master.yml
+   lines 133–134):
+
+   ```yaml
+   - name: Cache yarn
+     uses: actions/cache@v4
+     with:
+       path: ~/.cache/yarn
+       key: ${{ runner.os }}-yarn-${{ hashFiles('eform-angular-frontend/eform-client/yarn.lock') }}
+       restore-keys: ${{ runner.os }}-yarn-
+   ```
+
+   Placement relative to the "Copy dependencies" step is not sensitive:
+   `testinginstallpn.sh` does not modify `yarn.lock`, so `hashFiles` is stable.
+
+## Behavior / invariants
+
+- **Steady state (Playwright version unchanged):** every shard skips the
+  Playwright CDN browser download; yarn packages are served from
+  `~/.cache/yarn`; only apt system-deps run. The dominant slow/flaky cost is
+  removed.
+- **Auto-update:** the browser cache key is the resolved `@playwright/test`
+  version. A version bump in the host lockfile changes the key → prewarm
+  downloads once → all shards repopulate on their next run. No manual
+  cache-busting.
+- **First run after a bump:** prewarm downloads the new browser exactly once
+  (one download total), so all 26 shards still cache-hit.
+- **No behavioral change** to the tests, the docker orchestration, the two
+  `wait-on http://localhost:4200` gates, or the app-under-test. Pure CI
+  infrastructure.
+
+## Out of scope (explicit)
+
+- The `wait-on http://localhost:4200 --timeout 120000` dev-server gate flakiness
+  — the actual cause of the shard (t)/(l) failures — is **deliberately
+  deferred** per decision; not addressed here.
+- Moving the job into a Playwright container — **rejected** (needs DinD + app
+  network rewrite).
+- Caching the MariaDB / RabbitMQ `docker pull`s — separate concern, not in this
+  change.
+
+## Risks / implementation checks
+
+- **Lockfile parse:** the awk is verified against the current host `yarn.lock`
+  (yarn v1 classic → `1.58.2`). If the host `eform-angular-frontend` ever
+  migrates to a different lockfile format or package manager (yarn Berry,
+  `package-lock.json`, `pnpm-lock.yaml`), the extraction must be adapted.
+  Re-verify the resolved `version=` value in the prewarm job logs on first run.
+- **Concurrent cache saves:** on a cold `~/.cache/ms-playwright` miss, up to 26
+  shards may attempt `actions/cache` saves for the same key. `actions/cache@v4`
+  handles this gracefully — losers log a harmless "cache already exists" and
+  continue. The prewarm job makes shard-time misses rare (prewarm saves the key
+  before shards start), so this is a first-run edge only.
+- **setup-node ordering:** do NOT switch to setup-node's built-in `cache: yarn`
+  — the lockfile is absent when setup-node runs (it precedes the frontend
+  checkout). The standalone yarn cache step (B.4) is required.
+- **Two files in sync:** the change is duplicated across `dotnet-core-pr.yml` and
+  `dotnet-core-master.yml`. Any adjustment must be mirrored.
+- **Prewarm ↔ shard ref agreement:** the prewarm frontend checkout MUST use the
+  same branch-ref logic as the shards' frontend checkout (copy each file's own
+  `extract_branch` block verbatim), or the version prewarm resolves could differ
+  from what the shards install, defeating the cache-hit guarantee.
+
+## Testing / verification
+
+Workflow YAML has no unit-test harness. Verification is by running the PR's own
+CI:
+
+- On the first run, the `prewarm-playwright` job populates the browser cache on a
+  miss and the shards restore it.
+- Confirm via the Actions logs that on shards the **cache-hit** path runs
+  `npx playwright install-deps chromium` only (no browser download), that
+  yarn was restored from cache, and that all 26 shards still pass.
+- The change is inherently CI-validated on the PR itself.


### PR DESCRIPTION
## Problem

The `pn-playwright-test` matrix fans out into 26 shards, and every single shard
did a cold `yarn install` followed by `npx playwright install --with-deps
chromium` on every run, with **no caching whatsoever**. Each shard therefore
re-downloaded the ~150MB Playwright browser bundle from the Playwright CDN and
re-ran the apt system-deps install from scratch, 26× per CI run. This
redundant browser download was the dominant slow (and flaky) cost of the
Playwright leg of CI.

## Fix

A new **`prewarm-playwright`** job runs once, before the shards fan out:

- It checks out the host `eform-angular-frontend` and resolves the exact
  `@playwright/test` version straight from that repo's `yarn.lock` (the single
  source of truth for the version the shards will actually use).
- It populates an `actions/cache` of `~/.cache/ms-playwright` keyed on
  `${{ runner.os }}-playwright-<resolved-version>`, downloading the browser
  binaries only on a cache miss (`npx playwright@<ver> install chromium`, no
  `--with-deps` — apt deps live outside the cache).

The `pn-playwright-test` shards now `needs: [backend-pn-build,
prewarm-playwright]` and restore the **same** version-keyed browser cache before
running `npx playwright install --with-deps chromium`. On a cache hit that
command becomes a no-op browser download and only (re)installs the apt
system-deps. A standalone **yarn cache** (`~/.cache/yarn`, keyed on the
`yarn.lock` hash with a `restore-keys` fallback) is added to the shards as well.

### Key properties

- **Self-updating cache key.** The browser cache key is derived from the
  resolved Playwright version, so it auto-invalidates the moment the version
  changes in the frontend lockfile — no manual cache-busting ever needed.
- **Guaranteed hits after a bump.** Because prewarm runs first and the shards
  `needs:` it, all 26 shards hit the cache even on the first run following a
  version bump.
- **Self-healing.** The shard's `install` is run unconditionally, so if the
  cache is ever incomplete or the shard's resolved version differs from
  prewarm's, the shard simply re-downloads what's missing rather than failing.
- **Loud failure, not cache poisoning.** An empty-version guard fails prewarm
  explicitly (`::error::` + `exit 1`) if the version can't be resolved from
  `yarn.lock`, rather than silently populating the cache under an empty key.

### Scope / non-goals

- The runner stays bare `ubuntu-latest`. This job orchestrates the host docker
  stack; a Playwright container image was considered and rejected because it
  would require docker-in-docker plus an app-network rewrite.
- **CI-infrastructure only** — no test, behavior, or orchestration change. The
  two `wait-on` dev-server gate flakes are explicitly out of scope.
- The change is applied **identically** to both `dotnet-core-pr.yml` and
  `dotnet-core-master.yml`.

See the design spec (`docs/superpowers/specs/2026-08-19-ci-playwright-cache-design.md`)
and the implementation plan (`docs/superpowers/plans/2026-08-19-ci-playwright-cache.md`)
on this branch for full rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
