### PR TITLE
fix(task-tracker): filter Etiketter on the tags the column actually shows

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationTaskTrackerServiceHelperTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/BackendConfigurationTaskTrackerServiceHelperTest.cs
@@ -613,4 +613,155 @@ public class BackendConfigurationTaskTrackerServiceHelperTest : TestBaseSetup
 		Assert.That(result.Model[0].TaskName, Is.Null);
 		Assert.That(result.Model[0].WorkerNames, Is.EqualTo(sites.Where(x => x.Id == sites.Last().Id).Select(x => x.Name).ToList()));
 	}
+
+	[Test]
+	public async Task BackendConfigurationTaskTrackerServiceHelper_IndexTasks_WithTagInFilters_MatchesDisplayedTagsOnly()
+	{
+		var core = await GetCore();
+		// Arrange
+		// Create property
+		var propertyCreateModel = new PropertyCreateModel
+		{
+			Address = Guid.NewGuid().ToString(),
+			Chr = Guid.NewGuid().ToString(),
+			IndustryCode = Guid.NewGuid().ToString(),
+			Cvr = Guid.NewGuid().ToString(),
+			IsFarm = true,
+			LanguagesIds = [1],
+			MainMailAddress = Guid.NewGuid().ToString(),
+			Name = Guid.NewGuid().ToString(),
+			WorkorderEnable = true
+		};
+		await BackendConfigurationPropertiesServiceHelper.Create(propertyCreateModel, core, 1,
+			BackendConfigurationPnDbContext!, ItemsPlanningPnDbContext!, 1, 1);
+		var property =
+			await BackendConfigurationPnDbContext!.Properties.FirstAsync(x => x.Name == propertyCreateModel.Name);
+
+		var sites = await MicrotingDbContext!.Sites.AsNoTracking().OrderBy(x => x.Name).ToListAsync();
+
+		// create planning
+		var timeNow = DateTime.Now;
+		var planning = new Planning
+		{
+			WorkflowState = Constants.WorkflowStates.Created,
+			StartDate = timeNow,
+			Enabled = true,
+			RepeatEvery = 1,
+			RepeatType = RepeatType.Month,
+			PlanningSites = sites.Select(x => new PlanningSite { SiteId = x.Id, WorkflowState = Constants.WorkflowStates.Created }).ToList(),
+			NextExecutionTime = timeNow.AddMonths(1),
+			DayOfMonth = timeNow.Day,
+			RepeatUntil = timeNow.AddMonths(6),
+		};
+
+		await ItemsPlanningPnDbContext!.Plannings.AddAsync(planning);
+		await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+		// liveTag is assigned on both sides. staleTag was unassigned (soft-deleted) on the
+		// items-planning side. sourceMismatchTag is live on the items-planning side but was never
+		// mirrored onto the area rule planning - the case that a WorkflowState guard alone misses.
+		var liveTag = new PlanningTag { Name = Guid.NewGuid().ToString(), WorkflowState = Constants.WorkflowStates.Created };
+		var staleTag = new PlanningTag { Name = Guid.NewGuid().ToString(), WorkflowState = Constants.WorkflowStates.Created };
+		var sourceMismatchTag = new PlanningTag { Name = Guid.NewGuid().ToString(), WorkflowState = Constants.WorkflowStates.Created };
+		await ItemsPlanningPnDbContext.PlanningTags.AddRangeAsync(liveTag, staleTag, sourceMismatchTag);
+		await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+		await ItemsPlanningPnDbContext.PlanningsTags.AddRangeAsync(
+			new PlanningsTags
+			{
+				PlanningId = planning.Id, PlanningTagId = liveTag.Id,
+				WorkflowState = Constants.WorkflowStates.Created
+			},
+			new PlanningsTags
+			{
+				PlanningId = planning.Id, PlanningTagId = staleTag.Id,
+				WorkflowState = Constants.WorkflowStates.Removed
+			},
+			new PlanningsTags
+			{
+				PlanningId = planning.Id, PlanningTagId = sourceMismatchTag.Id,
+				WorkflowState = Constants.WorkflowStates.Created
+			});
+		await ItemsPlanningPnDbContext.SaveChangesAsync();
+
+		//create area
+		var area = new Area
+		{
+			WorkflowState = Constants.WorkflowStates.Created
+		};
+
+		await BackendConfigurationPnDbContext.Areas.AddAsync(area);
+		await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+		//create arearule
+		var areaRule = new AreaRule
+		{
+			AreaId = area.Id,
+			WorkflowState = Constants.WorkflowStates.Created,
+			PropertyId = property.Id
+		};
+
+		await BackendConfigurationPnDbContext.AreaRules.AddAsync(areaRule);
+		await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+		//create arearuleplanning
+		var areaRulePlanning = new AreaRulePlanning
+		{
+			AreaRuleId = areaRule.Id,
+			AreaId = area.Id,
+			ItemPlanningId = planning.Id,
+			WorkflowState = Constants.WorkflowStates.Created
+		};
+
+		await BackendConfigurationPnDbContext.AreaRulePlannings.AddAsync(areaRulePlanning);
+		await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+		// only the live tag is on the area rule planning - this is what the Tags column renders
+		await BackendConfigurationPnDbContext.AreaRulePlanningTags.AddAsync(new AreaRulePlanningTag
+		{
+			AreaRulePlanningId = areaRulePlanning.Id,
+			ItemPlanningTagId = liveTag.Id,
+			WorkflowState = Constants.WorkflowStates.Created
+		});
+		await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+		//create compliance
+		var compliance = new Compliance
+		{
+			Deadline = (DateTime)planning.RepeatUntil,
+			PlanningId = planning.Id,
+			PropertyId = property.Id,
+			StartDate = planning.StartDate,
+			WorkflowState = Constants.WorkflowStates.Created,
+		};
+
+		await BackendConfigurationPnDbContext.Compliances.AddAsync(compliance);
+		await BackendConfigurationPnDbContext.SaveChangesAsync();
+
+		// Act + Assert - filtering on the live tag returns the task, and it renders that tag
+		var liveTagResult = await BackendConfigurationTaskTrackerHelper.Index(
+			new TaskTrackerFiltrationModel { PropertyIds = [], TagIds = [liveTag.Id], WorkerIds = [] },
+			BackendConfigurationPnDbContext!, core, 1, ItemsPlanningPnDbContext!);
+
+		Assert.That(liveTagResult, Is.Not.Null);
+		Assert.That(liveTagResult.Success, Is.EqualTo(true));
+		Assert.That(liveTagResult.Model.Count, Is.EqualTo(1));
+		Assert.That(liveTagResult.Model[0].Tags.Select(x => x.Id), Does.Contain(liveTag.Id));
+		Assert.That(liveTagResult.Model[0].Tags.Select(x => x.Id), Does.Not.Contain(staleTag.Id));
+		Assert.That(liveTagResult.Model[0].Tags.Select(x => x.Id), Does.Not.Contain(sourceMismatchTag.Id));
+
+		// Act + Assert - neither of the tags the Tags column does not render may match. Before the
+		// fix the filter read Planning.PlanningsTags, a different table than the column, and one
+		// that is not guarded against soft-deleted rows, so both of these returned this task.
+		foreach (var unmatchableTagId in new[] { staleTag.Id, sourceMismatchTag.Id })
+		{
+			var unmatchedResult = await BackendConfigurationTaskTrackerHelper.Index(
+				new TaskTrackerFiltrationModel { PropertyIds = [], TagIds = [unmatchableTagId], WorkerIds = [] },
+				BackendConfigurationPnDbContext!, core, 1, ItemsPlanningPnDbContext!);
+
+			Assert.That(unmatchedResult, Is.Not.Null);
+			Assert.That(unmatchedResult.Success, Is.EqualTo(true));
+			Assert.That(unmatchedResult.Model, Is.Empty, $"tag {unmatchableTagId} is not rendered in the Tags column, so it must not match");
+		}
+	}
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationTaskTrackerHelper.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Helpers/BackendConfigurationTaskTrackerHelper.cs
@@ -135,8 +135,6 @@ public static class BackendConfigurationTaskTrackerHelper
 				var planning = await itemsPlanningPnDbContext.Plannings
 					.Where(x => x.Id == compliance.PlanningId)
 					.Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-					.Include(x => x.PlanningsTags)
-					.ThenInclude(x => x.PlanningTag)
 					.FirstOrDefaultAsync();
 
 				if (planning == null)
@@ -146,7 +144,6 @@ public static class BackendConfigurationTaskTrackerHelper
 				var deadlineDate = compliance.Deadline.AddDays(-1);
 
 				var areaRulePlanningQuery = backendConfigurationPnDbContext.AreaRulePlannings
-					.Include(x => x.AreaRulePlanningTags)
 					.Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
 					.Where(x => x.ItemPlanningId == compliance.PlanningId);
 
@@ -183,12 +180,25 @@ public static class BackendConfigurationTaskTrackerHelper
 					}
 				}
 
-				if (filtersModel.TagIds.Any()) // filtration by planning(?) tags
+				// The tag ids the Tags column renders for this task.
+				var itemPlanningTagIds = (await areaRulePlanningQuery
+					.SelectMany(x => x.AreaRulePlanningTags
+						.Where(y => y.WorkflowState != Constants.WorkflowStates.Removed)
+						.Select(y => (int?)y.ItemPlanningTagId))
+					.Union(areaRulePlanningQuery
+						.Where(x => x.ItemPlanningTagId.HasValue)
+						.Select(x => x.ItemPlanningTagId))
+					.ToListAsync())
+					.Select(x => x!.Value)
+					.ToList();
+
+				// Filter on that same set. Filtering on Planning.PlanningsTags instead - a different
+				// table, and one that also carries soft-deleted rows - returns tasks that never show
+				// the selected tag.
+				if (filtersModel.TagIds.Any()
+				    && !itemPlanningTagIds.Any(filtersModel.TagIds.Contains))
 				{
-					if (!planning.PlanningsTags.Any(x => filtersModel.TagIds.Contains(x.PlanningTagId)))
-					{
-						continue;
-					}
+					continue;
 				}
 
 				var taskName = await itemsPlanningPnDbContext.PlanningNameTranslation
@@ -234,18 +244,6 @@ public static class BackendConfigurationTaskTrackerHelper
 				// 					.Exists(dateTask => dateTask.ToString("d") == date.Date.ToString("d"))
 				// 			}).ToList()
 				// 	}).ToList();
-
-				var itemPlanningTagIds = await areaRulePlanningQuery
-					.SelectMany(x => x.AreaRulePlanningTags
-						.Where(y => y.WorkflowState != Constants.WorkflowStates.Removed)
-						.Select(y => y.ItemPlanningTagId))
-					.Distinct()
-					.ToListAsync();
-				itemPlanningTagIds.AddRange(await areaRulePlanningQuery
-					.Where(x => x.ItemPlanningTagId.HasValue)
-					.Select(x => x.ItemPlanningTagId.Value)
-					.Distinct()
-					.ToListAsync());
 
 				var itemPlanningTags = await itemsPlanningPnDbContext.PlanningTags
 					.Where(x => itemPlanningTagIds.Contains(x.Id))


### PR DESCRIPTION
## The bug

Selecting a tag in **Etiketter** on the task tracker lists tasks that do not carry that tag.

The filter and the column read **different tables**, and the filter side had no soft-delete guard:

| | Source | Guards `WorkflowState = 'removed'`? |
|---|---|---|
| Filter | `Planning.PlanningsTags.PlanningTagId` | **No** |
| Etiketter column | `AreaRulePlanningTags.ItemPlanningTagId` ∪ `AreaRulePlannings.ItemPlanningTagId` | Yes |

## Measured on restored tenant 916

Filtering **Kontrolplan** returned **82 rows, 38 of which never showed the tag**. All 38 matched only through a `PlanningsTags` row soft-deleted in 2024 — three of them (`2676`, `2704`, `2724`) through the *same* dead row, since one stale link inflates the result by every recurrence of that planning.

Tenant-wide: **317** (task, tag) pairs matched the filter without being displayed. **264** of those survive even a soft-delete guard — they are auto-generated property tags (`0. Prøvegård - … CHR: 92555`) that exist only on the items-planning side and that the column deliberately never renders. **Zero** pairs went the other way: no displayed tag was ever missed by the filter.

## The fix

Compute the displayed tag ids once, above the filter, and filter on that same set — the two halves are now one expression and cannot drift apart again. The two queries that built the set are merged via `Union`, keeping it at one round trip even though it now also runs for rows the filter rejects. Two dead `Include`s are removed.

## Verified

| | Before | After |
|---|---|---|
| No filter | 264 rows | **264** — nothing lost |
| Kontrolplan | 82 rows, **38 without the tag** | **44 rows, 0 without the tag** |
| `0. Prøvegård - … CHR: 92555` | 51 rows, **none** showing the tag | **0 rows** |

Checked in the browser against the restored tenant, and all 5 tests in `BackendConfigurationTaskTrackerServiceHelperTest` pass.

## Intentional behaviour change

The 13 property-name tags become dead filter options. They map 1:1 onto the 13 properties, the **Ejendom** filter already does that job, and they previously returned rows that never showed the tag. (Note the dropdown is unscoped and already offered 144 of 190 tags that returned nothing — that is pre-existing and untouched here.)

## The test

The four pre-existing tests in this file are vacuous for tags — they create no tag rows and pass `TagIds = []`. The new test pins the **source alignment**, not merely the soft-delete guard: it includes a tag that is live on `PlanningsTags` but was never mirrored onto the area rule planning, and asserts it does not match. Verified to fail against the original code **and** against a `WorkflowState`-guard-only fix.

## Not addressed here

The underlying data drift: `UpdateTags` diffs desired state only against `AreaRulePlanningTags`, so a tag present on one side and missing on the other is never repaired by re-saving, and `DeleteTask` cleans neither table. This PR makes the task tracker honest without touching that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016saJQTv49GY9WQGkx3xfA6