### PR TITLE
fix(calendar): repair legacy midnight StartHour on converted wizard tasks

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarConfigurationBackfillTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarConfigurationBackfillTest.cs
@@ -83,6 +83,13 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
             ItemsPlanningPnDbContext.Plannings);
         await ItemsPlanningPnDbContext.SaveChangesAsync();
 
+        // The one-time StartHour repair records a marker here; drop it so each test
+        // starts from an unrepaired database.
+        BackendConfigurationPnDbContext.PluginConfigurationValues.RemoveRange(
+            BackendConfigurationPnDbContext.PluginConfigurationValues
+                .Where(x => x.Name == CalendarConfigurationBackfillService.LegacyStartHourRepairMarkerName));
+        await BackendConfigurationPnDbContext.SaveChangesAsync();
+
         _sut = new CalendarConfigurationBackfillService(
             BackendConfigurationPnDbContext!,
             ItemsPlanningPnDbContext!,
@@ -221,6 +228,41 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
         };
         await arp.Create(BackendConfigurationPnDbContext!);
         return (arp, planning);
+    }
+
+    /// <summary>
+    /// Seeds the exact shape the one-time repair targets: a wizard task whose
+    /// recurrence is ALREADY normalized (so the conversion pass skips it, proving the
+    /// repair runs independently) plus a 00:00-01:00 CalendarConfiguration on its own
+    /// board. <paramref name="createdByUserId"/> is the whole gate: 0 means the row
+    /// was written by the superseded backfill and is repairable, non-zero means a
+    /// person chose midnight and it must be left alone.
+    /// </summary>
+    private async Task<(AreaRulePlanning Arp, CalendarBoard Board)> SeedTaskWithMidnightConfiguration(
+        int createdByUserId)
+    {
+        var property = await SeedProperty();
+        var area = await SeedArea();
+        var board = new CalendarBoard { Name = "Board A", Color = "#111111", PropertyId = property.Id };
+        await board.Create(BackendConfigurationPnDbContext!);
+
+        var (arp, _) = await SeedWizardTask(property.Id, area.Id, repeatType: 2, repeatEvery: 4,
+            startDate: new DateTime(2025, 11, 4, 0, 0, 0, DateTimeKind.Utc));
+        arp.RepeatWeekdaysCsv = "2";
+        await arp.Update(BackendConfigurationPnDbContext!);
+
+        var configuration = new CalendarConfiguration
+        {
+            AreaRulePlanningId = arp.Id,
+            StartHour = 0,
+            Duration = 1,
+            BoardId = board.Id,
+            CreatedByUserId = createdByUserId,
+            UpdatedByUserId = createdByUserId
+        };
+        await configuration.Create(BackendConfigurationPnDbContext!);
+
+        return (arp, board);
     }
 
     private CalendarConfiguration GetSingleConfiguration(int arpId)
@@ -850,5 +892,72 @@ public class CalendarConfigurationBackfillTest : TestBaseSetup
         Assert.That(updatedPlanning.RepeatEvery, Is.EqualTo(1));
 
         AssertNineToTenOnDefaultBoard(GetSingleConfiguration(arp.Id), property.Id);
+    }
+
+    /// <summary>
+    /// Repairs the legacy 00:00-01:00 markers written by the first version of this
+    /// service (commit fac1e0aa, 2026-07-19), which seeded StartHour = 0 before
+    /// fa8740bf changed the literal to 9.0. That change shipped without a data
+    /// repair, and the create below is gated on marker absence, so those rows would
+    /// otherwise render at midnight forever. Backfill origin is identified by
+    /// CreatedByUserId == 0 (the startup pass has no user context, while both
+    /// CreateTask and UpdateTask stamp a real user id).
+    /// </summary>
+    [Test]
+    public async Task RunIfNeededAsync_LegacyMidnightMarkerFromOldBackfill_IsRepairedToNine()
+    {
+        var (arp, board) = await SeedTaskWithMidnightConfiguration(createdByUserId: 0);
+
+        await _sut.RunIfNeededAsync();
+
+        var configuration = GetSingleConfiguration(arp.Id);
+        Assert.That(configuration.StartHour, Is.EqualTo(9.0));
+        Assert.That(configuration.Duration, Is.EqualTo(1.0));
+        Assert.That(configuration.BoardId, Is.EqualTo(board.Id),
+            "Repair must correct only the time, never the user's board choice.");
+    }
+
+    /// <summary>
+    /// A midnight configuration carrying a real CreatedByUserId came from
+    /// CreateTask/UpdateTask, i.e. a person chose 00:00-01:00. Never overwrite it.
+    /// </summary>
+    [Test]
+    public async Task RunIfNeededAsync_UserCreatedMidnightConfiguration_IsNotRepaired()
+    {
+        var (arp, _) = await SeedTaskWithMidnightConfiguration(createdByUserId: 4);
+
+        await _sut.RunIfNeededAsync();
+
+        Assert.That(GetSingleConfiguration(arp.Id).StartHour, Is.EqualTo(0.0));
+    }
+
+    /// <summary>
+    /// The repair is one-time, gated on a persisted marker. Once it has run, a user
+    /// is free to move an event to any timeslot -- midnight included -- and every
+    /// later restart must leave that choice alone. Without the marker, the
+    /// CreatedByUserId == 0 gate would re-fire on a backfill-created row the user
+    /// had deliberately moved back to 00:00.
+    /// </summary>
+    [Test]
+    public async Task RunIfNeededAsync_AfterRepairRan_UserMoveToMidnightSurvivesRestart()
+    {
+        var (arp, _) = await SeedTaskWithMidnightConfiguration(createdByUserId: 0);
+
+        // First restart: the one-time repair corrects the legacy marker.
+        await _sut.RunIfNeededAsync();
+        Assert.That(GetSingleConfiguration(arp.Id).StartHour, Is.EqualTo(9.0));
+
+        // The user then moves the event back to 00:00-01:00 via UpdateTask, which
+        // writes StartHour but leaves CreatedByUserId at its backfill value of 0.
+        var moved = GetSingleConfiguration(arp.Id);
+        moved.StartHour = 0;
+        moved.UpdatedByUserId = 4;
+        await moved.Update(BackendConfigurationPnDbContext!);
+
+        // Second restart: must not resurrect 09:00.
+        await _sut.RunIfNeededAsync();
+
+        Assert.That(GetSingleConfiguration(arp.Id).StartHour, Is.EqualTo(0.0),
+            "A one-time repair must never re-fire and override the user's own timeslot.");
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarTaskListIndexTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/CalendarTaskListIndexTest.cs
@@ -111,7 +111,8 @@ public class CalendarTaskListIndexTest : TestBaseSetup
     /// series' <c>Status</c>, which is the column <c>Index</c>'s
     /// <c>Filters.Status</c> filter targets.
     /// </summary>
-    private async Task<int> SeedSeries(int propertyId, int areaId, bool status)
+    private async Task<int> SeedSeries(int propertyId, int areaId, bool status,
+        int repeatType = 2, int repeatEvery = 1)
     {
         var areaRule = new AreaRule
         {
@@ -130,8 +131,8 @@ public class CalendarTaskListIndexTest : TestBaseSetup
             AreaId = areaId,
             StartDate = DateTime.UtcNow.Date,
             Status = status,
-            RepeatType = 2,
-            RepeatEvery = 1,
+            RepeatType = repeatType,
+            RepeatEvery = repeatEvery,
             WorkflowState = Constants.WorkflowStates.Created,
             CreatedByUserId = 1,
             UpdatedByUserId = 1
@@ -149,25 +150,7 @@ public class CalendarTaskListIndexTest : TestBaseSetup
     [Test]
     public async Task Index_FiltersByStatus_ReturnsOnlyActiveSeries()
     {
-        var area = new Area
-        {
-            Type = AreaTypesEnum.Type1,
-            ItemPlanningTagId = 0,
-            WorkflowState = Constants.WorkflowStates.Created,
-            CreatedByUserId = 1,
-            UpdatedByUserId = 1
-        };
-        await area.Create(BackendConfigurationPnDbContext!);
-
-        var property = new Property
-        {
-            Name = $"CalendarIndexProp-{Guid.NewGuid()}",
-            ItemPlanningTagId = 0,
-            WorkflowState = Constants.WorkflowStates.Created,
-            CreatedByUserId = 1,
-            UpdatedByUserId = 1
-        };
-        await property.Create(BackendConfigurationPnDbContext!);
+        var (property, area) = await SeedPropertyAndArea();
 
         var activeArpId = await SeedSeries(property.Id, area.Id, status: true);
         var inactiveArpId = await SeedSeries(property.Id, area.Id, status: false);
@@ -189,5 +172,78 @@ public class CalendarTaskListIndexTest : TestBaseSetup
         Assert.That(result.Model.Select(x => x.Id), Does.Not.Contain(inactiveArpId));
         Assert.That(result.Model.All(x => x.Status), Is.True,
             "Index filtered on Status = true must return only active series.");
+    }
+
+    /// <summary>
+    /// A series with no CalendarConfiguration must report the same default time as
+    /// the week grid (BackendConfigurationCalendarService.GetTasksForWeek, `?? 9.0`).
+    /// Index used `?? 0`, so the task list showed 00:00-01:00 and -- because the edit
+    /// modal saves back whatever it was handed -- UpdateTask then persisted midnight.
+    /// </summary>
+    [Test]
+    public async Task Index_SeriesWithoutConfiguration_DefaultsToNineToTenLikeWeekGrid()
+    {
+        var (property, area) = await SeedPropertyAndArea();
+        var arpId = await SeedSeries(property.Id, area.Id, status: true);
+
+        var result = await _calendarService.Index(new CalendarTaskIndexRequestModel
+        {
+            Filters = new CalendarTaskListFiltrationModel { PropertyIds = [property.Id] }
+        });
+
+        Assert.That(result.Success, Is.True, result.Message);
+        var row = result.Model.Single(x => x.Id == arpId);
+        Assert.That(row.StartHour, Is.EqualTo(9.0));
+        Assert.That(row.Duration, Is.EqualTo(1.0));
+        Assert.That(row.IsAllDay, Is.False);
+    }
+
+    /// <summary>
+    /// The one case the week grid does render at hour 0: an "always" series (RepeatType
+    /// 1, RepeatEvery 0) with no configuration is all-day, not a midnight timeslot.
+    /// Index never set IsAllDay, so the frontend placed it in the 00:00 row instead of
+    /// the all-day strip.
+    /// </summary>
+    [Test]
+    public async Task Index_AlwaysSeriesWithoutConfiguration_IsAllDay()
+    {
+        var (property, area) = await SeedPropertyAndArea();
+        var arpId = await SeedSeries(property.Id, area.Id, status: true,
+            repeatType: 1, repeatEvery: 0);
+
+        var result = await _calendarService.Index(new CalendarTaskIndexRequestModel
+        {
+            Filters = new CalendarTaskListFiltrationModel { PropertyIds = [property.Id] }
+        });
+
+        Assert.That(result.Success, Is.True, result.Message);
+        var row = result.Model.Single(x => x.Id == arpId);
+        Assert.That(row.IsAllDay, Is.True);
+        Assert.That(row.StartHour, Is.EqualTo(0.0));
+        Assert.That(row.Duration, Is.EqualTo(0.0));
+    }
+
+    private async Task<(Property Property, Area Area)> SeedPropertyAndArea()
+    {
+        var area = new Area
+        {
+            Type = AreaTypesEnum.Type1,
+            ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await area.Create(BackendConfigurationPnDbContext!);
+
+        var property = new Property
+        {
+            Name = $"CalendarIndexProp-{Guid.NewGuid()}",
+            ItemPlanningTagId = 0,
+            WorkflowState = Constants.WorkflowStates.Created,
+            CreatedByUserId = 1,
+            UpdatedByUserId = 1
+        };
+        await property.Create(BackendConfigurationPnDbContext!);
+        return (property, area);
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/TaskListBatchEformTagsTest.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/TaskListBatchEformTagsTest.cs
@@ -141,7 +141,8 @@ public class TaskListBatchEformTagsTest : TestBaseSetup
     /// Returns the ARP Id.
     /// </summary>
     private async Task<int> SeedTask(IEnumerable<int> siteIds, IEnumerable<int> tagIds = null,
-        bool status = true, int repeatType = 2, int eformId = 7)
+        bool status = true, int repeatType = 2, int eformId = 7,
+        bool withCalendarConfiguration = true)
     {
         var area = new Area
         {
@@ -208,12 +209,18 @@ public class TaskListBatchEformTagsTest : TestBaseSetup
             await planningTag.Create(BackendConfigurationPnDbContext!);
         }
 
-        var calConfig = new CalendarConfiguration
+        // A task-wizard task has no CalendarConfiguration until CreateTask or the
+        // startup backfill makes one, so the un-configured shape is reachable in
+        // production and BuildUpdateModel has to fall back for it.
+        if (withCalendarConfiguration)
         {
-            AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0,
-            WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
-        };
-        await calConfig.Create(BackendConfigurationPnDbContext!);
+            var calConfig = new CalendarConfiguration
+            {
+                AreaRulePlanningId = arp.Id, StartHour = 9.0, Duration = 1.0,
+                WorkflowState = Constants.WorkflowStates.Created, CreatedByUserId = 1, UpdatedByUserId = 1
+            };
+            await calConfig.Create(BackendConfigurationPnDbContext!);
+        }
 
         return arp.Id;
     }
@@ -422,5 +429,29 @@ public class TaskListBatchEformTagsTest : TestBaseSetup
         Assert.That(result.Message, Does.Contain("Task not found"));
         Assert.That(_updateCalls, Has.Count.EqualTo(1));
         Assert.That(_updateCalls[0].Id, Is.EqualTo(validArpId));
+    }
+
+    /// <summary>
+    /// BuildUpdateModel feeds every batch operation into CalendarService.UpdateTask,
+    /// which writes StartHour unconditionally. For a wizard task that has no
+    /// CalendarConfiguration yet, falling back to 0 made any batch action silently
+    /// create one at midnight -- moving an event the grid was rendering at 09:00, and
+    /// stamping it with a real CreatedByUserId so the legacy-midnight repair can
+    /// never reclaim it. The fallback must match the read default.
+    /// </summary>
+    [Test]
+    public async Task AddTags_TaskWithoutConfiguration_RoundTripsNineToTenNotMidnight()
+    {
+        var arpId = await SeedTask([100], withCalendarConfiguration: false);
+
+        var result = await _taskListService.AddTags(new TaskListBatchTagsModel
+        {
+            TaskIds = [arpId], TagIds = [7]
+        });
+
+        Assert.That(result.Success, Is.True, result.Message);
+        Assert.That(_updateCalls, Has.Count.EqualTo(1));
+        Assert.That(_updateCalls[0].StartHour, Is.EqualTo(9.0));
+        Assert.That(_updateCalls[0].Duration, Is.EqualTo(1.0));
     }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -514,9 +514,7 @@ public class BackendConfigurationCalendarService(
                     continue;
 
                 calConfigsDict.TryGetValue(arp.Id, out var calConfig);
-                var isRepeatAlways = arp.RepeatType.HasValue && arp.RepeatType.Value == 1 && (arp.RepeatEvery ?? 0) == 0;
-                var hasNonAlwaysRepeat = arp.RepeatType.HasValue && arp.RepeatType.Value > 0 && !isRepeatAlways;
-                var isAllDay = calConfig == null && !hasNonAlwaysRepeat;
+                var isAllDay = ComputeIsAllDay(arp, calConfig);
 
                 var title = ResolveTaskTitle(arp.AreaRule?.AreaRuleTranslations, userLanguageId, null);
 
@@ -751,9 +749,7 @@ public class BackendConfigurationCalendarService(
                 if (!planningsDict.TryGetValue(arp.ItemPlanningId, out var movedPlanning)) continue;
 
                 calConfigsDict.TryGetValue(arp.Id, out var movedCalConfig);
-                var isRepeatAlways = arp.RepeatType.HasValue && arp.RepeatType.Value == 1 && (arp.RepeatEvery ?? 0) == 0;
-                var hasNonAlwaysRepeat = arp.RepeatType.HasValue && arp.RepeatType.Value > 0 && !isRepeatAlways;
-                var isAllDay = movedCalConfig == null && !hasNonAlwaysRepeat;
+                var isAllDay = ComputeIsAllDay(arp, movedCalConfig);
 
                 var title = ResolveTaskTitle(arp.AreaRule?.AreaRuleTranslations, userLanguageId, null);
 
@@ -951,9 +947,7 @@ public class BackendConfigurationCalendarService(
                         .ToList()
                     : [];
 
-                var compIsRepeatAlways = arp?.RepeatType.HasValue == true && arp.RepeatType.Value == 1 && (arp.RepeatEvery ?? 0) == 0;
-                var compHasNonAlwaysRepeat = arp?.RepeatType.HasValue == true && arp.RepeatType.Value > 0 && !compIsRepeatAlways;
-                var compIsAllDay = calConfig == null && !compHasNonAlwaysRepeat;
+                var compIsAllDay = ComputeIsAllDay(arp, calConfig);
 
                 var complianceCompleted = compliance.MicrotingSdkCaseId > 0
                     && weekComplianceCasesById.TryGetValue(compliance.MicrotingSdkCaseId, out var weekSdkCase)
@@ -1183,12 +1177,18 @@ public class BackendConfigurationCalendarService(
                     .Select(t => planningTagNames.TryGetValue(t.ItemPlanningTagId, out var n) ? n : null)
                     .Where(n => n != null).ToList();
 
+                // Same derivation GetTasksForWeek uses, so the list and the grid
+                // agree: an unconfigured series is all-day only when it has no
+                // real recurrence; otherwise it defaults to 09:00-10:00.
+                var indexIsAllDay = ComputeIsAllDay(arp, calConfig);
+
                 return new CalendarTaskResponseModel
                 {
                     Id = arp.Id,
                     Title = title,
-                    StartHour = calConfig?.StartHour ?? 0,
-                    Duration = calConfig?.Duration ?? 1,
+                    IsAllDay = indexIsAllDay,
+                    StartHour = indexIsAllDay ? 0 : calConfig?.StartHour ?? 9.0,
+                    Duration = indexIsAllDay ? 0 : calConfig?.Duration ?? 1.0,
                     TaskDate = arp.StartDate?.ToString("yyyy-MM-dd") ?? "",
                     Tags = tags,
                     AssigneeIds = assigneeIds,
@@ -4230,6 +4230,26 @@ public class BackendConfigurationCalendarService(
     // when its SDK case is retracted (WorkflowState=Removed AND Status=77) OR it
     // is past due (effectiveDate < now) and not completed (Status != 100). Rows
     // with no live SDK case fall back to the deadline-only check.
+    // Shared all-day predicate for every calendar/task-list projection: a series is
+    // all-day only when it has no CalendarConfiguration AND no real recurrence.
+    // "Always" (RepeatType 1 with RepeatEvery 0) is not a real recurrence, so it
+    // stays all-day; anything else falls back to the 09:00-10:00 read default.
+    // Kept in one place deliberately -- this expression was previously copied at
+    // six sites, and the copy in Index drifted to a midnight default, which put
+    // un-configured series in the 00:00 row and let the edit modal persist that
+    // back through UpdateTask.
+    private static bool ComputeIsAllDay(AreaRulePlanning? arp, CalendarConfiguration? calConfig)
+    {
+        if (calConfig != null)
+        {
+            return false;
+        }
+
+        var isRepeatAlways = arp is { RepeatType: 1 } && (arp.RepeatEvery ?? 0) == 0;
+        var hasNonAlwaysRepeat = arp is { RepeatType: > 0 } && !isRepeatAlways;
+        return !hasNonAlwaysRepeat;
+    }
+
     private static bool ComputeTaskIsExpired(
         Microting.eForm.Infrastructure.Data.Entities.Case? sdkCase,
         DateTime effectiveDate,
@@ -4971,9 +4991,7 @@ public class BackendConfigurationCalendarService(
                         .ToList()
                     : [];
 
-                var compIsRepeatAlways = arp?.RepeatType.HasValue == true && arp.RepeatType.Value == 1 && (arp.RepeatEvery ?? 0) == 0;
-                var compHasNonAlwaysRepeat = arp?.RepeatType.HasValue == true && arp.RepeatType.Value > 0 && !compIsRepeatAlways;
-                var compIsAllDay = calConfig == null && !compHasNonAlwaysRepeat;
+                var compIsAllDay = ComputeIsAllDay(arp, calConfig);
 
                 // Per-row Completed + TaskIsExpired derivation. Predicate
                 // matches the spec: completed = Case.Status==100;
@@ -5237,11 +5255,7 @@ public class BackendConfigurationCalendarService(
                     continue;
                 }
 
-                var isRepeatAlways = arp?.RepeatType.HasValue == true && arp.RepeatType.Value == 1
-                                     && (arp.RepeatEvery ?? 0) == 0;
-                var hasNonAlwaysRepeat = arp?.RepeatType.HasValue == true && arp.RepeatType.Value > 0
-                                         && !isRepeatAlways;
-                var isAllDay = calConfig == null && !hasNonAlwaysRepeat;
+                var isAllDay = ComputeIsAllDay(arp, calConfig);
 
                 var done = IsDone(compliance);
                 var sdkCase = compliance.MicrotingSdkCaseId > 0

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskListService/BackendConfigurationTaskListService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationTaskListService/BackendConfigurationTaskListService.cs
@@ -423,8 +423,13 @@ public class BackendConfigurationTaskListService(
                 .ToList(),
             WorkerTagIds = workerTagIds,
             ComplianceEnabled = arp.ComplianceEnabled,
-            StartHour = configuration?.StartHour ?? 0,
-            Duration = configuration?.Duration ?? 1,
+            // Must match the read fallback in BackendConfigurationCalendarService:
+            // UpdateTask writes StartHour unconditionally, so a 0 here would move an
+            // un-configured task the grid renders at 09:00 down to midnight -- and
+            // stamp the new row with a real CreatedByUserId, putting it permanently
+            // beyond the legacy-midnight repair in CalendarConfigurationBackfillService.
+            StartHour = configuration?.StartHour ?? 9.0,
+            Duration = configuration?.Duration ?? 1.0,
             BoardId = configuration?.BoardId,
             Color = configuration?.Color,
             RepeatEndMode = arp.RepeatEndMode,

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarConfigurationBackfillService/CalendarConfigurationBackfillService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/CalendarConfigurationBackfillService/CalendarConfigurationBackfillService.cs
@@ -17,8 +17,33 @@ public class CalendarConfigurationBackfillService(
     ItemsPlanningPnDbContext itemsPlanningPnDbContext,
     ILogger<CalendarConfigurationBackfillService> logger)
 {
+    // Hours-since-midnight the conversion assigns to a wizard planning, which
+    // carries no time of day of its own. Kept in sync with the `?? 9.0` read
+    // fallbacks in BackendConfigurationCalendarService.
+    private const double DefaultStartHour = 9.0;
+    private const double DefaultDuration = 1.0;
+
+    // The 00:00-01:00 shape the superseded backfill wrote, matched verbatim by the
+    // repair below. Named separately from the defaults above: these describe the rows
+    // being corrected, not the value being applied.
+    private const double LegacyStartHour = 0.0;
+    private const double LegacyDuration = 1.0;
+
+    // Set once the legacy-midnight repair below has run, so it never runs twice.
+    // Public so the integration fixture can clear it between tests.
+    //
+    // The prefix is the settings CLASS name, not the bound configuration section
+    // ("BackendConfigurationSettings"), so this key lands in a section nothing reads
+    // -- deliberate, and not a typo to correct: renaming it into the live section on
+    // an already-repaired database would leave the old marker unread and re-run the
+    // repair, overriding timeslots users had since chosen.
+    public const string LegacyStartHourRepairMarkerName =
+        "BackendConfigurationBaseSettings:LegacyCalendarStartHourRepaired";
+
     public async Task RunIfNeededAsync()
     {
+        await RepairLegacyMidnightConfigurationsAsync();
+
         // Wizard/calendar plannings lacking a board link (CalendarConfiguration row)
         var configuredArpIds = await dbContext.CalendarConfigurations
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
@@ -115,8 +140,8 @@ public class CalendarConfigurationBackfillService(
                         var configuration = new CalendarConfiguration
                         {
                             AreaRulePlanningId = arp.Id,
-                            StartHour = 9.0,
-                            Duration = 1.0,
+                            StartHour = DefaultStartHour,
+                            Duration = DefaultDuration,
                             BoardId = board.Id,
                             Color = null
                         };
@@ -130,6 +155,80 @@ public class CalendarConfigurationBackfillService(
                         arp.Id);
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// One-time correction of the 00:00-01:00 markers written by the first version
+    /// of this service, which seeded StartHour = 0 before the 09:00-10:00 change.
+    /// That change shipped without a data repair and the conversion below only ever
+    /// inserts, never updates, so those rows would render at midnight forever.
+    ///
+    /// Scoped by CreatedByUserId == 0: this pass runs at startup with no user
+    /// context, whereas CreateTask and UpdateTask both stamp a real user id, so a
+    /// zero identifies a row this service created rather than a time a person chose.
+    ///
+    /// Further narrowed to CreatedInGuide rules: only wizard-created tasks were ever
+    /// touched by the original backfill, so nothing else can carry a legacy marker.
+    ///
+    /// Gated on a persisted marker rather than on the data shape, because 09:00 and
+    /// 00:00 are equally legitimate values -- there is nothing in a repaired row to
+    /// distinguish it from one a user has since moved back to midnight. Without the
+    /// marker the gate above would re-fire on exactly that row at the next restart.
+    /// </summary>
+    private async Task RepairLegacyMidnightConfigurationsAsync()
+    {
+        var alreadyRepaired = await dbContext.PluginConfigurationValues
+            .AnyAsync(x => x.Name == LegacyStartHourRepairMarkerName);
+
+        if (alreadyRepaired)
+        {
+            return;
+        }
+
+        var legacyConfigurations = await dbContext.CalendarConfigurations
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(x => x.CreatedByUserId == 0)
+            .Where(x => x.StartHour == LegacyStartHour && x.Duration == LegacyDuration)
+            .Where(x => x.AreaRulePlanning.AreaRule.CreatedInGuide)
+            .ToListAsync();
+
+        foreach (var configuration in legacyConfigurations)
+        {
+            // Only the time is corrected; board and colour stay as they are.
+            configuration.StartHour = DefaultStartHour;
+            await configuration.Update(dbContext);
+        }
+
+        // Written even when nothing matched, so the scan is skipped from now on.
+        //
+        // Inserted as a single conditional statement rather than Add + SaveChanges:
+        // PluginConfigurationValues.Name is an unindexed longtext with no unique
+        // constraint, so two instances starting together would both see no marker and
+        // both insert one. BasePn's PluginConfigurationProvider.Load builds its
+        // settings dictionary with ToDictionary(c => c.Name, ...), which throws on a
+        // duplicate key -- a second row would make the plugin fail to load on every
+        // subsequent start, and nothing inside the plugin could then repair it.
+        // Letting the database evaluate NOT EXISTS and the insert atomically removes
+        // that race without needing a unique index (MySQL cannot index longtext
+        // without a prefix length).
+        await dbContext.Database.ExecuteSqlRawAsync(
+            @"INSERT INTO `PluginConfigurationValues`
+                  (`Name`, `Value`, `CreatedAt`, `UpdatedAt`, `Version`,
+                   `WorkflowState`, `CreatedByUserId`, `UpdatedByUserId`)
+              SELECT {0}, 'true', {1}, {1}, 1, {2}, 1, 0 FROM DUAL
+              WHERE NOT EXISTS (
+                  SELECT 1 FROM `PluginConfigurationValues` `existing`
+                  WHERE `existing`.`Name` = {0})",
+            LegacyStartHourRepairMarkerName,
+            DateTime.UtcNow,
+            Constants.WorkflowStates.Created);
+
+        if (legacyConfigurations.Count > 0)
+        {
+            logger.LogInformation(
+                "CalendarConfigurationBackfill: repaired {Count} legacy midnight calendar configurations to {StartHour}:00",
+                legacyConfigurations.Count, DefaultStartHour);
         }
     }
 


### PR DESCRIPTION
## Problem

Task-wizard plannings converted into calendar tasks render at **00:00–01:00** instead of 09:00–10:00.

Calendar events are derived at read time from `AreaRulePlannings` joined to `CalendarConfigurations`, which holds the only time-of-day (`StartHour`, a `double NOT NULL` with no DB default). A task-wizard planning stores **no time of day at all**, so a converted planning's time comes entirely from the config row the startup backfill writes.

`CalendarConfigurationBackfillService` originally seeded `StartHour = 0` (`fac1e0aa`, 2026-07-19). `fa8740bf` (2026-08-14) changed the literal to `9.0` but shipped **no data repair**, and the insert is gated on marker absence — so every row written before that deploy keeps midnight forever. Those rows are also unreachable by the later stale-marker pass (`e6bc577c`), which re-selects Week rows only while `RepeatWeekdaysCsv` is empty — and that commit had already populated it.

Not a timezone issue: the API returns a bare fractional-hour number and the hand-rolled grid positions it as `startHour × 65px`.

## Changes

**One-time repair**, gated on a persisted `PluginConfigurationValues` marker rather than on the data shape — 09:00 and 00:00 are equally legitimate stored values, so nothing in a repaired row distinguishes it from one a user has since moved back to midnight. Without the marker the gate would re-fire on exactly that row at the next restart.

Legacy rows are identified by `CreatedByUserId == 0`: the startup pass has no user context, while `CreateTask` and `UpdateTask` both stamp a real user id. `UpdatedByUserId`/`Version` cannot be used — `UpdateTask` rewrites `StartHour` unconditionally from a modal prefilled with the stored `0`, so an unrelated edit re-persists midnight under a real user id (this had already happened to one row in production data).

The marker is written as a **single conditional SQL insert**. `PluginConfigurationValues.Name` is an unindexed `longtext` with no unique constraint, and BasePn's `PluginConfigurationProvider.Load` builds its settings dictionary with `ToDictionary(c => c.Name, ...)` — two instances starting together would insert two markers and the plugin would then fail to load on every subsequent start, unrecoverably from inside the plugin.

**Two further paths that kept producing midnight rows:**

- `Index` projected `StartHour` with `?? 0` while all other read sites use `?? 9.0`, and never set `IsAllDay` — so the task list disagreed with the week grid, and the edit modal saved 00:00 back through `UpdateTask`.
- `BackendConfigurationTaskListService.BuildUpdateModel` had the same `?? 0` on a **write** path feeding seven batch operations into `UpdateTask`, creating fresh midnight rows stamped with a real user id and therefore permanently beyond this repair.

**Refactor:** the `isAllDay` derivation was copy-pasted at six sites and the `Index` copy is the one that drifted — consolidated into `ComputeIsAllDay`.

## Verification

Integration suite: **131 passed, 0 failed** across 13 fixtures. Six new tests, each watched fail first; the `CreatedByUserId` gate was mutation-tested (removing it makes the guard test fail).

Against restored tenant 1076:

| Step | Result |
|---|---|
| Backend start | `repaired 8 legacy midnight calendar configurations to 9:00` |
| DB after | all 8 rows `0 → 9`, `Version` +1 each, exactly 1 marker row |
| Week API for the reported event | `startHour: 9`, `isAllDay: false` |
| Calendar DOM | `top: 585px` (÷65 = hour 9), label `09:00 – 10:00` |
| User moves event to **00:00**, then restart | **stays at 00:00**, `Version` unchanged, no backfill log line |

That last row is the load-bearing one: at that point the row matched the repair gate exactly, and only the one-time marker prevented it being overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016saJQTv49GY9WQGkx3xfA6