### PR TITLE
Cancel first in this plugin's dialogs

### DIFF
--- a/eform-client/cypress/e2e/plugins/backend-configuration-pn/g/task-wizard.edit-assignment.spec.cy.ts
+++ b/eform-client/cypress/e2e/plugins/backend-configuration-pn/g/task-wizard.edit-assignment.spec.cy.ts
@@ -153,7 +153,7 @@ describe('Area rules type 1', () => {
     //cy.get('#pairingModalTableBody > div > div > div > table > tbody > .mat-mdc-row > .mat-column-name');
     let row = () => cy.get('#pairingModalTableBody > div > div > div > table > tbody > .mat-mdc-row').contains(workerForCreate.name).parent().parent().parent().scrollIntoView();
     row().find('mat-checkbox').should('have.class', 'mat-mdc-checkbox-checked');
-    cy.get('#changeAssignmentsCancel > .mdc-button__label').click();
+    cy.get('#changeAssignmentsCancel').click();
     cy.get('#backend-configuration-pn-task-wizard').click();
     cy.intercept('GET', '**/api/backend-configuration-pn/properties/get-folder-dtos?**').as('getFolders');
     cy.intercept('POST', '**/api/templates/index').as('getTemplates');
@@ -217,7 +217,7 @@ describe('Area rules type 1', () => {
     row().find('mat-checkbox').should('not.have.class', 'mat-mdc-checkbox-checked');
     row = () => cy.get('#pairingModalTableBody > div > div > div > table > tbody > .mat-mdc-row').contains(workerForCreate2.name).parent().parent().parent().scrollIntoView();
     row().find('mat-checkbox').should('have.class', 'mat-mdc-checkbox-checked');
-    cy.get('#changeAssignmentsCancel > .mdc-button__label').click();
+    cy.get('#changeAssignmentsCancel').click();
     /* ==== End Cypress Studio ==== */
   });
   after(() => {

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/g/task-wizard.edit-assignment.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/g/task-wizard.edit-assignment.spec.ts
@@ -170,7 +170,7 @@ test.describe('Area rules type 1', () => {
       .filter({ hasText: workerForCreate.name });
     await worker1Row.scrollIntoViewIfNeeded();
     await expect(worker1Row.locator('mat-checkbox')).toHaveClass(/mat-mdc-checkbox-checked/);
-    await page.locator('#changeAssignmentsCancel > .mdc-button__label').click();
+    await page.locator('#changeAssignmentsCancel').click();
 
     await page.locator('#backend-configuration-pn-task-wizard').click();
     await expect(page.locator('.cdk-row')).toHaveCount(1, { timeout: 30000 });
@@ -240,7 +240,7 @@ test.describe('Area rules type 1', () => {
       .filter({ hasText: workerForCreate2.name });
     await worker2Row2.scrollIntoViewIfNeeded();
     await expect(worker2Row2.locator('mat-checkbox')).toHaveClass(/mat-mdc-checkbox-checked/);
-    await page.locator('#changeAssignmentsCancel > .mdc-button__label').click();
+    await page.locator('#changeAssignmentsCancel').click();
     /* ==== End Cypress Studio ==== */
   });
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/components/area-rule-entity-list-modal/area-rule-entity-list-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/components/area-rule-entity-list-modal/area-rule-entity-list-modal.component.html
@@ -20,17 +20,17 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
-    class="btn-primary"
-    (click)="onUpdateEntityList()"
-    id="entityListSaveBtn"
-  >
-    {{ 'Save' | translate }}
-  </button>
-  <button
     class="btn-cancel"
     (click)="hide()"
     id="entityListSaveCancelBtn"
   >
     {{'Cancel' | translate}}
+  </button>
+  <button
+    class="btn-primary"
+    (click)="onUpdateEntityList()"
+    id="entityListSaveBtn"
+  >
+    {{ 'Save' | translate }}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/components/area-rule-plan-modal/area-rule-plan-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/components/area-rule-plan-modal/area-rule-plan-modal.component.html
@@ -313,18 +313,18 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
+    class="btn-cancel"
+    (click)="hide()"
+    id="updateAreaRulePlanningSaveCancelBtn"
+  >
+    {{'Cancel' | translate}}
+  </button>
+  <button
     class="btn-primary"
     (click)="onUpdateAreaRulePlan()"
     id="updateAreaRulePlanningSaveBtn"
     [disabled]="isDisabledSaveBtn()"
   >
     {{'Save' | translate}}
-  </button>
-  <button
-    class="btn-cancel"
-    (click)="hide()"
-    id="updateAreaRulePlanningSaveCancelBtn"
-  >
-    {{'Cancel' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/components/properties/property-actions/property-delete-modal/property-delete-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/components/properties/property-actions/property-delete-modal/property-delete-modal.component.html
@@ -19,17 +19,17 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end align-items-center gap-12">
   <button
-    class="btn-delete"
-    (click)="deleteProperty()"
-    id="propertyDeleteDeleteBtn"
-  >
-    {{'Delete' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     (click)="hide()"
     id="propertyDeleteCancelBtn"
   >
     {{'Cancel' | translate}}
+  </button>
+  <button
+    class="btn-delete"
+    (click)="deleteProperty()"
+    id="propertyDeleteDeleteBtn"
+  >
+    {{'Delete' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/components/properties/property-actions/property-docx-report-modal/property-docx-report-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/components/properties/property-actions/property-docx-report-modal/property-docx-report-modal.component.html
@@ -36,18 +36,18 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
+    class="btn-cancel"
+    (click)="hide()"
+    id="cancelDownloadReportBtn"
+  >
+    {{'Cancel' | translate}}
+  </button>
+  <button
     class="btn-primary"
     (click)="onDownloadReport()"
     id="DownloadReportBtn"
     [disabled]="isDisabledDownloadButton"
   >
     {{'Download' | translate}}
-  </button>
-  <button
-    class="btn-cancel"
-    (click)="hide()"
-    id="cancelDownloadReportBtn"
-  >
-    {{'Cancel' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/components/reports/case-delete/case-delete.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/components/reports/case-delete/case-delete.component.html
@@ -40,15 +40,15 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end align-items-center gap-24">
   <button
-    class="btn-delete"
-    id="planningDeleteDeleteBtn"
-    (click)="deletePlanning()">
-    {{'Delete' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     id="planningDeleteCancelBtn"
     (click)="hide()">
     {{'Close' | translate}}
+  </button>
+  <button
+    class="btn-delete"
+    id="planningDeleteDeleteBtn"
+    (click)="deletePlanning()">
+    {{'Delete' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/area-rules/components/area-rule-delete-modal/area-rule-delete-modal.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/area-rules/components/area-rule-delete-modal/area-rule-delete-modal.component.html
@@ -27,17 +27,17 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
-    class="btn-delete"
-    id="areaRuleDeleteDeleteBtn"
-    (click)="onDeleteAreaRule()"
-  >
-    {{'Delete' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     id="areaRuleDeleteCancelBtn"
     (click)="hide()"
   >
     {{'Cancel' | translate}}
+  </button>
+  <button
+    class="btn-delete"
+    id="areaRuleDeleteDeleteBtn"
+    (click)="onDeleteAreaRule()"
+  >
+    {{'Delete' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/compliance/components/compliance-delete/compliance-delete.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/compliance/components/compliance-delete/compliance-delete.component.html
@@ -2,15 +2,15 @@
 
 <div mat-dialog-actions class="d-flex flex-row justify-content-end align-items-center gap-24">
   <button
-    class="btn-delete"
-    id="planningDeleteDeleteBtn"
-    (click)="deleteCompliance()">
-    {{'Delete' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     id="planningDeleteCancelBtn"
     (click)="hide()">
     {{'Close' | translate}}
+  </button>
+  <button
+    class="btn-delete"
+    id="planningDeleteDeleteBtn"
+    (click)="deleteCompliance()">
+    {{'Delete' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-actions/document-delete/documents-document-delete.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-actions/document-delete/documents-document-delete.component.html
@@ -72,18 +72,18 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end align-items-center gap-12">
   <button
-    class="btn-delete"
-    (click)="submitCaseDelete()"
-    id="deleteDocumentSaveBtn"
-  >
-    {{ 'Delete' | translate }}
-  </button>
-  <button
    class="btn-cancel"
     (click)="hide()"
     id="deleteDocumentCancelBtn"
   >
     {{ 'Cancel' | translate }}
+  </button>
+  <button
+    class="btn-delete"
+    (click)="submitCaseDelete()"
+    id="deleteDocumentSaveBtn"
+  >
+    {{ 'Delete' | translate }}
   </button>
 </div>
 

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-folders/documents-folder-create/documents-folder-create.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-folders/documents-folder-create/documents-folder-create.component.html
@@ -47,17 +47,17 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end gap-24">
   <button
-    class="btn-primary btn-primary--icon-left"
-    id="folderSaveBtn"
-    (click)="createFolder()"
-  >
-    {{ 'Create' | translate }}
-  </button>
-  <button
     class="btn-cancel"
     id="cancelCreateBtn"
     (click)="hide()"
   >
     {{ 'Cancel' | translate }}
+  </button>
+  <button
+    class="btn-primary btn-primary--icon-left"
+    id="folderSaveBtn"
+    (click)="createFolder()"
+  >
+    {{ 'Create' | translate }}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-folders/documents-folder-delete/documents-folder-delete.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-folders/documents-folder-delete/documents-folder-delete.component.html
@@ -27,17 +27,17 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
-    class="btn-delete"
-    id="saveDeleteBtn"
-    (click)="deleteFolder()"
-  >
-    {{'Delete' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     id="cancelDeleteBtn"
     (click)="hide()"
   >
     {{'Cancel' | translate}}
+  </button>
+  <button
+    class="btn-delete"
+    id="saveDeleteBtn"
+    (click)="deleteFolder()"
+  >
+    {{'Delete' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-folders/documents-folder-edit/documents-folder-edit.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/documents/components/documents-folders/documents-folder-edit/documents-folder-edit.component.html
@@ -47,17 +47,17 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
-    class="btn-primary btn-primary--icon-left"
-    id="saveEditBtn"
-    (click)="updateFolder()"
-  >
-    {{ 'Save' | translate }}
-  </button>
-  <button
     class="btn-cancel"
     id="cancelEditBtn"
     (click)="hide()"
   >
     {{ 'Cancel' | translate }}
+  </button>
+  <button
+    class="btn-primary btn-primary--icon-left"
+    id="saveEditBtn"
+    (click)="updateFolder()"
+  >
+    {{ 'Save' | translate }}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-actions/file-tags-edit/file-tags-edit.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/files/components/files-actions/file-tags-edit/file-tags-edit.component.html
@@ -19,18 +19,18 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end align-items-center gap-24">
   <button
+    class="btn-cancel"
+    id="cancelSaveFileTagsBtn"
+    (click)="hide()"
+  >
+    {{ 'Cancel' | translate }}
+  </button>
+  <button
     class="btn-primary btn-primary--icon-left"
     id="fileTagsSaveBtn"
     (click)="updateFile()"
     [disabled]="disabled"
   >
     {{ 'Update' | translate }}
-  </button>
-  <button
-    class="btn-cancel"
-    id="cancelSaveFileTagsBtn"
-    (click)="hide()"
-  >
-    {{ 'Cancel' | translate }}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/reports/components/case-delete/case-delete.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/reports/components/case-delete/case-delete.component.html
@@ -40,15 +40,15 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end align-items-center gap-24">
   <button
-    class="btn-delete"
-    id="planningDeleteDeleteBtn"
-    (click)="deletePlanning()">
-    {{'Delete' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     id="planningDeleteCancelBtn"
     (click)="hide()">
     {{'Close' | translate}}
+  </button>
+  <button
+    class="btn-delete"
+    id="planningDeleteDeleteBtn"
+    (click)="deletePlanning()">
+    {{'Delete' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-actions/task-tracker-shown-columns/task-tracker-shown-columns.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-tracker/components/task-tracker-actions/task-tracker-shown-columns/task-tracker-shown-columns.component.html
@@ -13,17 +13,17 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
-    class="btn-primary"
-    (click)="save()"
-    id="saveColumns"
-  >
-    {{'Save' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     (click)="hide()"
     id="cancelSaveColumns"
   >
     {{'Cancel' | translate}}
+  </button>
+  <button
+    class="btn-primary"
+    (click)="save()"
+    id="saveColumns"
+  >
+    {{'Save' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-multiple-deactivate/task-wizard-multiple-deactivate.component.html
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/modules/task-wizard/components/task-wizard-actions/task-wizard-multiple-deactivate/task-wizard-multiple-deactivate.component.html
@@ -1,15 +1,15 @@
 <h3 mat-dialog-title>{{ 'Are you sure you want to deactivate' | translate }} {{ selectedTaskCount }} {{ 'tasks' | translate }}?</h3>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
-    class="btn-delete"
-    id="tasksMultipleDeactivateConfirmBtn"
-    (click)="onDeactivateMultipleTasks()">
-    {{'Deactivate' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     id="tasksMultipleDeactivateCancelBtn"
     (click)="hide()">
     {{'Cancel' | translate}}
+  </button>
+  <button
+    class="btn-delete"
+    id="tasksMultipleDeactivateConfirmBtn"
+    (click)="onDeactivateMultipleTasks()">
+    {{'Deactivate' | translate}}
   </button>
 </div>


### PR DESCRIPTION
Ordering half of the button work. Depends on **microting/eform-angular-frontend#8017**, which decides the convention and teaches the shared gate to enforce it.

Reorders **15 dialog action rows** so the dismissing button leads.

## Why this was a separate decision

The [audit](https://claude.ai/code/artifact/bbbbd984-00fc-4f39-8a86-b98ac1b3c3df) deliberately left ordering open: 42 core dialogs and 48 plugin dialogs rendered `[Save][Cancel]` against 12 the other way, so cancel-first was the *minority*. It is also the one button inconsistency users actually feel — it moves the button under their cursor between one dialog and the next — so it warranted a decision rather than whichever way a sweep happened to run.

## It is a pure move

Whole `<button>` elements swap position; nothing is retyped. Verified by diffing removed against added lines in this repo — the line multisets are identical, so no `id`, binding, tooltip, icon or translate pipe changed in transit. That check is the point: a re-typed button is how an `id` silently disappears and takes an e2e selector with it.

No touched row carries `cdkFocusInitial`, so no autofocus target moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sXLtgzZU8QL9m84GqMkoJ