### PR TITLE
Open ad-hoc tasks to every user of the backend-configuration plugin

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceAreaCrudTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceAreaCrudTests.cs
@@ -325,6 +325,11 @@ public class AdhocServiceAreaCrudTests : TestBaseSetup
         await area.Create(BackendConfigurationPnDbContext!);
         var sut = CreateSut();
 
+        // Pins RequirePropertyAccessAsync, not a caller: no production caller
+        // passes (0, false) since 2026-08-24 (the web passes full access; gRPC
+        // rejects an unresolvable identity). The predicate is what keeps the
+        // gRPC path property-scoped, so it is asserted directly.
+
         // CreateAreas already names the propertyId explicitly - nothing to
         // enumerate - so it keeps the plain unauthorized signal.
         Assert.ThrowsAsync<AdhocTaskUnauthorizedException>(async () =>

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceHistoryTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceHistoryTests.cs
@@ -449,6 +449,14 @@ public class AdhocServiceHistoryTests : TestBaseSetup
     [Test]
     public async Task ListHistory_NonAdmin_OnlyReturnsCallersVisibleTasks()
     {
+        // Same standing as IndexTasks_NonAdmin_OnlyReturnsCallersVisibleTasks:
+        // ListHistory has NO gRPC call site - AdhocGrpcService never calls it -
+        // so the web (Historik) is its only caller and it always passes
+        // isAdmin: true since 2026-08-24. This therefore exercises a parameter
+        // combination no current caller produces, and is NOT what keeps the
+        // mobile path scoped. It is kept as the contract for the
+        // non-full-access branch of the visibility predicate, should a caller
+        // ever pass false again.
         var property = await CreatePropertyAsync();
         await GrantPropertyAccessAsync(property.Id, 1);
         await GrantPropertyAccessAsync(property.Id, 7);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceIndexTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceIndexTests.cs
@@ -190,6 +190,20 @@ public class AdhocServiceIndexTests : TestBaseSetup
     [Test]
     public async Task IndexTasks_NonAdmin_OnlyReturnsCallersVisibleTasks()
     {
+        // Exercises a parameter combination no current caller produces.
+        // IndexTasks has NO gRPC call site at all - AdhocGrpcService never
+        // calls it (its 19 call sites cover only ListProperties (twice),
+        // ListTasks, GetTask, CreateTask, UpdateTask, SetCompleted, Archive,
+        // Reopen, Delete, AddComment, ListAreas, ListWorkers, ListTags,
+        // CreateTag, RenameTag, DeleteTag, SavePhoto and GetPhoto) - so the
+        // web is its only caller, and since
+        // 2026-08-24 the web always passes isAdmin: true. Unlike the
+        // RequireCreator/tag-guard tests elsewhere, this does NOT keep the
+        // gRPC path narrow; there is no gRPC path here to keep narrow.
+        // It is kept because it pins the non-full-access branch of the
+        // shared visibility predicate as a contract: if a caller ever passes
+        // false again (a mobile index, a scoped report), this is what says
+        // what that must mean. Deleting it would leave the branch untested.
         var property = await CreatePropertyAsync();
         await GrantPropertyAccessAsync(property.Id, 1);
         await GrantPropertyAccessAsync(property.Id, 7);

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceReferenceDataTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceReferenceDataTests.cs
@@ -539,6 +539,68 @@ public class AdhocServiceReferenceDataTests : TestBaseSetup
             await sut.RenameTag(0, zeroOwnedTag.Id, "renamed"));
     }
 
+    // --- Accepted consequence of the "web is unrestricted" decision
+    // (2026-08-24): a full-access caller does not only manage the global tags
+    // nobody owns (above) - it reaches into another worker's personal,
+    // phone-created tag, renaming it and deleting it off other people's
+    // tasks. These pin that DECISION, not the wiring: if it is ever judged
+    // wrong it has to be changed here deliberately rather than drifting. ---
+
+    [Test]
+    public async Task RenameTag_FullAccess_RenamesAnotherWorkersPersonalTag()
+    {
+        var sut = CreateSut();
+        // Worker 7's own tag, created exactly as the phone creates one
+        // (isAdmin false => OwnerWorkerId = 7).
+        var phoneTag = await sut.CreateTag(7, "phone-tag");
+
+        var renamed = await sut.RenameTag(0, phoneTag.Id, "web-renamed", isAdmin: true);
+
+        Assert.That(renamed.Name, Is.EqualTo("web-renamed"));
+        // Still worker 7's personal tag - the rename does not re-own it.
+        Assert.That(renamed.IsUserTag, Is.True);
+
+        var tagRow = await BackendConfigurationPnDbContext!.AdhocTags
+            .IgnoreQueryFilters()
+            .FirstAsync(t => t.Id == phoneTag.Id);
+        Assert.That(tagRow.Name, Is.EqualTo("web-renamed"));
+        Assert.That(tagRow.OwnerWorkerId, Is.EqualTo(7));
+    }
+
+    [Test]
+    public async Task DeleteTag_FullAccess_DeletesAnotherWorkersPersonalTag_AndCascadesOffTheirTask()
+    {
+        var property = await CreatePropertyAsync();
+        var sut = CreateSut();
+        var phoneTag = await sut.CreateTag(7, "phone-tag");
+
+        // Worker 7's own task, carrying worker 7's own tag.
+        var task = new AdhocTaskEntity
+        {
+            Title = "t",
+            Description = "d",
+            PropertyId = property.Id,
+            CreatedByWorkerId = 7,
+        };
+        await task.Create(BackendConfigurationPnDbContext!);
+        var join = new AdhocTaskTag { AdhocTaskId = task.Id, AdhocTagId = phoneTag.Id };
+        await join.Create(BackendConfigurationPnDbContext!);
+
+        await sut.DeleteTag(0, phoneTag.Id, isAdmin: true);
+
+        var tagRow = await BackendConfigurationPnDbContext!.AdhocTags
+            .IgnoreQueryFilters()
+            .FirstAsync(t => t.Id == phoneTag.Id);
+        Assert.That(tagRow.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+
+        // ...and the tag disappears from worker 7's task, not just from the
+        // web caller's own view.
+        var joinRow = await BackendConfigurationPnDbContext.AdhocTaskTags
+            .IgnoreQueryFilters()
+            .FirstAsync(tt => tt.Id == join.Id);
+        Assert.That(joinRow.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+    }
+
     [Test]
     public async Task DeleteTag_Throws_ForNonAdminWorkerZero_EvenOnAWorkerZeroOwnedTag()
     {

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceReferenceDataTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceReferenceDataTests.cs
@@ -331,9 +331,12 @@ public class AdhocServiceReferenceDataTests : TestBaseSetup
     [Test]
     public async Task ListTags_NonAdmin_DashboardWorkerId_OnlySeesGlobalTags()
     {
-        // Documents the chosen policy: non-admin dashboard callers keep the
-        // pre-fix "global tags only" view. DashboardWorkerId (0) owns
-        // nothing, so this is unchanged behavior, not a new restriction.
+        // Pins ListTags' owner predicate, not a caller: an identity without
+        // the admin flag sees global tags plus its own, and worker 0 owns
+        // nothing. Since 2026-08-24 the web passes full access here (and so
+        // does see every worker's personal tags), and gRPC rejects an
+        // unresolvable identity - but this predicate is what keeps a real
+        // mobile worker's tag list to global + own.
         var globalTag = new AdhocTag { Name = "global" };
         await globalTag.Create(BackendConfigurationPnDbContext!);
         var mobileTag = new AdhocTag { Name = "mobile-one", OwnerWorkerId = 1 };
@@ -507,6 +510,9 @@ public class AdhocServiceReferenceDataTests : TestBaseSetup
     [Test]
     public void CreateTag_Throws_ForNonAdminWorkerZero()
     {
+        // Pins RequireRealIdentityOrAdmin, not a caller: tag mutations demand a
+        // real identity, and worker 0 is not one. No production caller passes
+        // (0, false) since 2026-08-24 - see the note on RenameTag below.
         var sut = CreateSut();
 
         Assert.ThrowsAsync<AdhocTaskUnauthorizedException>(async () =>
@@ -518,7 +524,13 @@ public class AdhocServiceReferenceDataTests : TestBaseSetup
     {
         // A tag stamped OwnerWorkerId = 0 (e.g. created before the C1/I1
         // guards existed) must still not be manageable through the shared
-        // pseudo-identity without the admin flag.
+        // pseudo-identity without the full-access flag.
+        //
+        // Pins the predicate, not a caller: since 2026-08-24 nothing in
+        // production passes (0, false) - AdhocController passes full access and
+        // AdhocGrpcService rejects an unresolvable identity with Unauthenticated
+        // before the service is reached. The guard is kept, and asserted, so a
+        // later edit cannot widen the gRPC path unnoticed.
         var zeroOwnedTag = new AdhocTag { Name = "zero-owned", OwnerWorkerId = 0 };
         await zeroOwnedTag.Create(BackendConfigurationPnDbContext!);
         var sut = CreateSut();
@@ -530,6 +542,8 @@ public class AdhocServiceReferenceDataTests : TestBaseSetup
     [Test]
     public async Task DeleteTag_Throws_ForNonAdminWorkerZero_EvenOnAWorkerZeroOwnedTag()
     {
+        // Same predicate as RenameTag above: worker 0 without the full-access
+        // flag owns nothing. Kept for the same reason - see the note there.
         var zeroOwnedTag = new AdhocTag { Name = "zero-owned", OwnerWorkerId = 0 };
         await zeroOwnedTag.Create(BackendConfigurationPnDbContext!);
         var sut = CreateSut();

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceTaskCrudTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceTaskCrudTests.cs
@@ -603,6 +603,62 @@ public class AdhocServiceTaskCrudTests : TestBaseSetup
     }
 
     [Test]
+    public async Task Delete_FullAccess_SoftDeletesTaskCreatedByAnotherWorker_CascadingToAllChildren()
+    {
+        // Accepted consequence of the "web is unrestricted" decision
+        // (2026-08-24): the web passes (workerId 0, full access) on DELETE, so
+        // RequireCreator is bypassed and a task a worker created on their
+        // PHONE can be removed from the dashboard - together with their
+        // assignments, assignment log, comments and photos. It is the Microting
+        // soft delete (WorkflowState = Removed): the rows survive and stay
+        // recoverable in the database, but the task is gone from every list and
+        // from the mobile client. This pins that DECISION, not the wiring.
+        var property = await CreatePropertyAsync();
+        await GrantPropertyAccessAsync(property.Id, 7);
+        var tag = new AdhocTag { Name = "phone-task-tag" };
+        await tag.Create(BackendConfigurationPnDbContext!);
+        var sut = CreateSut();
+
+        var created = await sut.CreateTask(7, MakeCreateModel(property.Id, assignedWorkerIds: [9], tagIds: [tag.Id]));
+        Assert.That(created.CreatedByWorkerId, Is.EqualTo(7));
+        await sut.AddComment(7, created.Id, "from the phone");
+        var photo = new AdhocTaskPhoto { AdhocTaskId = created.Id, UploadedDataId = 1, ContentType = "image/jpeg" };
+        await photo.Create(BackendConfigurationPnDbContext!);
+
+        await sut.Delete(0, created.Id, isAdmin: true);
+
+        var taskRow = await BackendConfigurationPnDbContext!.AdhocTasks
+            .IgnoreQueryFilters()
+            .FirstAsync(t => t.Id == created.Id);
+        Assert.That(taskRow.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+
+        var assignmentRow = await BackendConfigurationPnDbContext.AdhocTaskAssignments
+            .IgnoreQueryFilters()
+            .FirstAsync(a => a.AdhocTaskId == created.Id);
+        Assert.That(assignmentRow.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+
+        var assignmentLogRow = await BackendConfigurationPnDbContext.AdhocTaskAssignmentLogs
+            .IgnoreQueryFilters()
+            .FirstAsync(l => l.AdhocTaskId == created.Id);
+        Assert.That(assignmentLogRow.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+
+        var commentRow = await BackendConfigurationPnDbContext.AdhocTaskComments
+            .IgnoreQueryFilters()
+            .FirstAsync(c => c.AdhocTaskId == created.Id);
+        Assert.That(commentRow.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+
+        var photoRow = await BackendConfigurationPnDbContext.AdhocTaskPhotos
+            .IgnoreQueryFilters()
+            .FirstAsync(p => p.AdhocTaskId == created.Id);
+        Assert.That(photoRow.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+
+        var tagJoinRow = await BackendConfigurationPnDbContext.AdhocTaskTags
+            .IgnoreQueryFilters()
+            .FirstAsync(tt => tt.AdhocTaskId == created.Id);
+        Assert.That(tagJoinRow.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+    }
+
+    [Test]
     public async Task AddComment_AllowedForAssignedWorker_AddsCommentRow()
     {
         var property = await CreatePropertyAsync();

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceTaskCrudTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceTaskCrudTests.cs
@@ -476,11 +476,18 @@ public class AdhocServiceTaskCrudTests : TestBaseSetup
             await sut.Delete(2, created.Id));
     }
 
-    // --- C1: pseudo-identity 0 (REST dashboard caller) never satisfies the
-    // creator gate. Dashboard-created tasks are stamped CreatedByWorkerId = 0,
-    // so without the workerId == 0 guard in RequireCreator ANY authenticated
-    // non-admin web user (workerId 0, isAdmin false) would pass the creator
-    // check on every dashboard-created task. ---
+    // --- C1: pseudo-identity 0 never satisfies the creator gate. Web-created
+    // tasks are stamped CreatedByWorkerId = 0, so without the workerId == 0
+    // guard in RequireCreator a (0, false) caller would pass the creator check
+    // on every web-created task.
+    //
+    // These pin RequireCreator's predicate, not a caller. Since 2026-08-24 no
+    // production caller produces (0, false): AdhocController passes full access
+    // on every route, and AdhocGrpcService rejects an unresolvable identity
+    // with Unauthenticated before the service is reached. Keep them anyway -
+    // the predicate is what keeps the gRPC path narrow, and it is exactly the
+    // kind of code a later "simplification" would widen without any other test
+    // noticing. Do not delete them as unreachable. ---
 
     [Test]
     public async Task Archive_Throws_ForNonAdminWorkerZero_OnWorkerZeroCreatedTask()

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceVisibilityTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Integration.Test/AdhocServiceVisibilityTests.cs
@@ -269,6 +269,12 @@ public class AdhocServiceVisibilityTests : TestBaseSetup
     [Test]
     public async Task ListTasks_NotAdmin_WithNoPropertyAccess_ReturnsEmpty()
     {
+        // Pins ListTasks' visibility predicate, not a caller: without the
+        // admin flag, an identity with no PropertyWorker row sees nothing.
+        // No production caller passes (0, false) since 2026-08-24 - the web
+        // passes full access and gRPC rejects an unresolvable identity - but
+        // this predicate is what keeps the gRPC path scoped, so it is asserted
+        // directly rather than left to be inferred.
         var property = await CreatePropertyAsync();
         var sut = CreateSut();
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/Controllers/AdhocControllerTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/Controllers/AdhocControllerTests.cs
@@ -1,0 +1,152 @@
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BackendConfiguration.Pn.Controllers;
+using BackendConfiguration.Pn.Infrastructure.Models.Adhoc;
+using BackendConfiguration.Pn.Services.BackendConfigurationAdhocService;
+using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BackendConfiguration.Pn.Test.Controllers;
+
+/// <summary>
+/// Access-policy tests for <see cref="AdhocController"/>: the shared
+/// <see cref="IBackendConfigurationAdhocService"/> is faked (NSubstitute), so
+/// these exercise only what the REST façade forwards as caller identity — no
+/// DB, no S3.
+///
+/// The pinned property (2026-08-24): every route passes the synthetic
+/// dashboard worker id <c>0</c> AND full access <c>true</c>, unconditionally.
+/// The controller consults no user/role service to decide visibility, so
+/// nothing about the caller's role can narrow — or widen — what a web user
+/// sees. The mobile gRPC path is deliberately unaffected; its own hardcoded
+/// <c>isAdmin == false</c> expectations live in
+/// <c>GrpcServices/AdhocGrpcServiceMappingTests</c>.
+/// </summary>
+[TestFixture]
+public class AdhocControllerTests
+{
+    private const int DashboardWorkerId = 0;
+    private const bool FullAccess = true;
+
+    private static AdhocController CreateSut(
+        IBackendConfigurationAdhocService adhocService = null,
+        IBackendConfigurationLocalizationService localizationService = null)
+    {
+        adhocService ??= Substitute.For<IBackendConfigurationAdhocService>();
+        localizationService ??= Substitute.For<IBackendConfigurationLocalizationService>();
+        return new AdhocController(adhocService, localizationService);
+    }
+
+    // ---- the controller has no user/role dependency at all ----
+
+    [Test]
+    public void Constructor_TakesNoUserOrRoleService()
+    {
+        var parameterTypes = typeof(AdhocController)
+            .GetConstructors()
+            .Single()
+            .GetParameters()
+            .Select(p => p.ParameterType.Name)
+            .ToList();
+
+        Assert.That(parameterTypes, Is.EquivalentTo(new[]
+        {
+            nameof(IBackendConfigurationAdhocService),
+            nameof(IBackendConfigurationLocalizationService)
+        }));
+    }
+
+    // ---- tasks ----
+
+    [Test]
+    public async Task Index_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.Index(new AdhocTaskFiltersModel());
+
+        await adhocService.Received(1).IndexTasks(DashboardWorkerId, FullAccess, Arg.Any<AdhocTaskFiltersModel>());
+    }
+
+    [Test]
+    public async Task GetTask_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.GetTask(42);
+
+        await adhocService.Received(1).GetTask(DashboardWorkerId, 42, FullAccess);
+    }
+
+    [Test]
+    public async Task CreateTask_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var model = new AdhocTaskCreateModel { Title = "Fix the leak", PropertyId = 10 };
+        var sut = CreateSut(adhocService);
+
+        await sut.CreateTask(model);
+
+        await adhocService.Received(1).CreateTask(DashboardWorkerId, model, FullAccess);
+    }
+
+    [Test]
+    public async Task UpdateTask_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var model = new AdhocTaskCreateModel { Title = "Fix the leak", PropertyId = 10 };
+        var sut = CreateSut(adhocService);
+
+        await sut.UpdateTask(42, model);
+
+        await adhocService.Received(1).UpdateTask(DashboardWorkerId, 42, model, FullAccess);
+    }
+
+    [Test]
+    public async Task DeleteTask_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.DeleteTask(42);
+
+        await adhocService.Received(1).Delete(DashboardWorkerId, 42, FullAccess);
+    }
+
+    // ---- photos ----
+
+    [Test]
+    public async Task UploadPhoto_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var file = Substitute.For<IFormFile>();
+        file.Length.Returns(3L);
+        file.ContentType.Returns("image/png");
+        file.CopyToAsync(Arg.Any<Stream>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        var sut = CreateSut(adhocService);
+
+        await sut.UploadPhoto(42, file);
+
+        await adhocService.Received(1)
+            .SavePhoto(DashboardWorkerId, 42, Arg.Any<byte[]>(), "image/png", FullAccess);
+    }
+
+    [Test]
+    public async Task GetPhoto_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        adhocService.GetPhoto(DashboardWorkerId, 99, FullAccess)
+            .Returns(((Stream)new MemoryStream([1, 2, 3]), "image/png"));
+        var sut = CreateSut(adhocService);
+
+        await sut.GetPhoto(99);
+
+        await adhocService.Received(1).GetPhoto(DashboardWorkerId, 99, FullAccess);
+    }
+}

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/Controllers/AdhocControllerTests.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn.Test/Controllers/AdhocControllerTests.cs
@@ -6,7 +6,9 @@ using BackendConfiguration.Pn.Controllers;
 using BackendConfiguration.Pn.Infrastructure.Models.Adhoc;
 using BackendConfiguration.Pn.Services.BackendConfigurationAdhocService;
 using BackendConfiguration.Pn.Services.BackendConfigurationLocalizationService;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microting.EformBackendConfigurationBase.Infrastructure.Const;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -20,9 +22,17 @@ namespace BackendConfiguration.Pn.Test.Controllers;
 ///
 /// The pinned property (2026-08-24): every route passes the synthetic
 /// dashboard worker id <c>0</c> AND full access <c>true</c>, unconditionally.
-/// The controller consults no user/role service to decide visibility, so
-/// nothing about the caller's role can narrow — or widen — what a web user
-/// sees. The mobile gRPC path is deliberately unaffected; its own hardcoded
+/// All 23 routes are pinned one test each - tasks (index/history/get/create/
+/// update/copy/completed/archive/reopen/delete/comment), reference data
+/// (properties/workers/areas + the three area mutations), tags (list/create/
+/// rename/delete) and photos (upload/get) - so adding a route without a
+/// matching test is the only way the claim can go stale. The controller
+/// consults no user/role service to decide visibility, so nothing about the
+/// caller's role can narrow — or widen — what a web user sees. What DOES
+/// bound the reach is the class-level authorization policy —
+/// pinned by <see cref="Controller_RequiresBackendConfigurationPluginAccessPolicy"/>
+/// — which keeps a user with no backend-configuration access out entirely.
+/// The mobile gRPC path is deliberately unaffected; its own hardcoded
 /// <c>isAdmin == false</c> expectations live in
 /// <c>GrpcServices/AdhocGrpcServiceMappingTests</c>.
 /// </summary>
@@ -117,6 +127,218 @@ public class AdhocControllerTests
         await sut.DeleteTask(42);
 
         await adhocService.Received(1).Delete(DashboardWorkerId, 42, FullAccess);
+    }
+
+    [Test]
+    public async Task HistoryIndex_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.HistoryIndex(new AdhocHistoryFiltersModel());
+
+        await adhocService.Received(1)
+            .ListHistory(DashboardWorkerId, FullAccess, Arg.Any<AdhocHistoryFiltersModel>());
+    }
+
+    [Test]
+    public async Task CopyTask_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.CopyTask(42, new AdhocCopyTaskModel { IncludeComments = true });
+
+        await adhocService.Received(1).CopyTask(DashboardWorkerId, FullAccess, 42, true);
+    }
+
+    [Test]
+    public async Task SetCompleted_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.SetCompleted(42, new AdhocSetCompletedModel { Completed = true, CompletedByWorkerId = 7 });
+
+        await adhocService.Received(1).SetCompleted(DashboardWorkerId, 42, true, FullAccess, 7);
+    }
+
+    [Test]
+    public async Task Archive_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.Archive(42);
+
+        await adhocService.Received(1).Archive(DashboardWorkerId, 42, FullAccess);
+    }
+
+    [Test]
+    public async Task Reopen_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.Reopen(42);
+
+        await adhocService.Received(1).Reopen(DashboardWorkerId, 42, FullAccess);
+    }
+
+    [Test]
+    public async Task AddComment_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.AddComment(42, new AdhocCommentCreateModel { Text = "looked at it" });
+
+        await adhocService.Received(1).AddComment(DashboardWorkerId, 42, "looked at it", FullAccess);
+    }
+
+    // ---- reference data ----
+    //
+    // properties/workers are the "sees more than their own" surface: full
+    // access makes them return every property and every worker name for the
+    // customer, regardless of the caller's PropertyWorker rows. The area
+    // mutations reach the same way.
+
+    [Test]
+    public async Task ListProperties_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.ListProperties();
+
+        await adhocService.Received(1).ListProperties(DashboardWorkerId, FullAccess);
+    }
+
+    [Test]
+    public async Task ListWorkers_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.ListWorkers(10);
+
+        await adhocService.Received(1).ListWorkers(DashboardWorkerId, 10, FullAccess);
+    }
+
+    [Test]
+    public async Task ListAreas_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.ListAreas(10);
+
+        await adhocService.Received(1).ListAreas(DashboardWorkerId, 10, FullAccess);
+    }
+
+    [Test]
+    public async Task CreateAreas_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var model = new AdhocAreaCreateModel { PropertyId = 10, Names = ["Barn", "Stald"] };
+        var sut = CreateSut(adhocService);
+
+        await sut.CreateAreas(model);
+
+        await adhocService.Received(1).CreateAreas(DashboardWorkerId, 10, model.Names, FullAccess);
+    }
+
+    [Test]
+    public async Task RenameArea_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.RenameArea(5, new AdhocAreaRenameModel { Name = "Lade" });
+
+        await adhocService.Received(1).RenameArea(DashboardWorkerId, 5, "Lade", FullAccess);
+    }
+
+    [Test]
+    public async Task DeleteArea_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.DeleteArea(5);
+
+        await adhocService.Received(1).DeleteArea(DashboardWorkerId, 5, FullAccess);
+    }
+
+    // ---- tags ----
+    //
+    // The widest-reaching consequence of the 2026-08-24 change: full access
+    // makes ListTags return every worker's personal tags, makes CreateTag write
+    // a global tag (OwnerWorkerId = null) that shows up in every mobile
+    // worker's tag list, and lets rename/delete act on a tag a worker created
+    // on their phone. These pin that the controller forwards full access on all
+    // four - if one ever stops, the web tag semantics change silently.
+
+    [Test]
+    public async Task ListTags_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.ListTags();
+
+        await adhocService.Received(1).ListTags(DashboardWorkerId, FullAccess);
+    }
+
+    [Test]
+    public async Task CreateTag_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.CreateTag(new AdhocTagCreateModel { Name = "Roof" });
+
+        await adhocService.Received(1).CreateTag(DashboardWorkerId, "Roof", FullAccess);
+    }
+
+    [Test]
+    public async Task RenameTag_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.RenameTag(7, new AdhocTagCreateModel { Name = "Facade" });
+
+        await adhocService.Received(1).RenameTag(DashboardWorkerId, 7, "Facade", FullAccess);
+    }
+
+    [Test]
+    public async Task DeleteTag_PassesDashboardWorkerZeroAndFullAccess()
+    {
+        var adhocService = Substitute.For<IBackendConfigurationAdhocService>();
+        var sut = CreateSut(adhocService);
+
+        await sut.DeleteTag(7);
+
+        await adhocService.Received(1).DeleteTag(DashboardWorkerId, 7, FullAccess);
+    }
+
+    // ---- the plugin boundary is enforced server-side ----
+
+    [Test]
+    public void Controller_RequiresBackendConfigurationPluginAccessPolicy()
+    {
+        var authorize = typeof(AdhocController)
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: false)
+            .Cast<AuthorizeAttribute>()
+            .Single();
+
+        // "Unrestricted" means unrestricted for users OF THIS PLUGIN. Without
+        // the policy, any authenticated eForm user could call these routes
+        // directly and get customer-wide tasks, properties and worker names -
+        // the Angular route guard does not stop a REST call.
+        Assert.That(authorize.Policy,
+            Is.EqualTo(BackendConfigurationClaims.AccessBackendConfigurationPlugin));
     }
 
     // ---- photos ----

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/AdhocController.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/AdhocController.cs
@@ -33,6 +33,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microting.eFormApi.BasePn.Infrastructure.Models.API;
 using Microting.eFormApi.BasePn.Infrastructure.Models.Common;
+using Microting.EformBackendConfigurationBase.Infrastructure.Const;
 using Services.BackendConfigurationAdhocService;
 using Services.BackendConfigurationLocalizationService;
 
@@ -56,19 +57,35 @@ using Services.BackendConfigurationLocalizationService;
 /// passes the constant <see cref="DashboardHasFullAccess"/> at every call
 /// site instead of a role check, so the shared service's property-access /
 /// creator / assigned / everyone predicates are bypassed for web calls.
-/// Reach is still bounded by the plugin-wide
-/// <c>backend_configuration_plugin_access</c> route gate; the
-/// <c>adhoc_enable</c> claim is retained but enforced nowhere.
+///
+/// Reach is bounded HERE, server-side: the class-level
+/// <c>[Authorize(Policy = BackendConfigurationClaims.AccessBackendConfigurationPlugin)]</c>
+/// requires the <c>backend_configuration_plugin_access</c> claim on every
+/// route. That policy is registered by the host from the plugin's own
+/// <c>PluginPermissions</c> rows (one policy per claim name, see
+/// <c>AuthServiceCollectionExtensions.AddEFormAuth</c>), which is the same
+/// mechanism <c>TimePlanningSettingsController</c> and
+/// <c>InnerResourcesController</c> use. Do NOT rely on the Angular route
+/// guard for this: it only hides the page, it does not stop a direct REST
+/// call. "Unrestricted" means unrestricted for users OF THIS PLUGIN — a user
+/// with no backend-configuration access is still refused. The standard
+/// <c>user</c> role is granted "Access BackendConfiguration Plugin" at seed
+/// time (<c>EformBackendConfigurationPlugin.SeedDatabase</c>), so a normal
+/// plugin user passes. The <c>adhoc_enable</c> claim is retained but enforced
+/// nowhere.
 ///
 /// This is deliberately wider than "sees more tasks", and was confirmed as
 /// such: <c>isAdmin</c> is not a pure read filter. Web-created tags are
 /// written global (<c>OwnerWorkerId = null</c>) and any user may rename or
 /// delete another worker's phone-created tag; <c>ListTags</c> surfaces every
 /// worker's personal tags; <c>properties</c>/<c>workers</c> return every
-/// property and every worker name for the customer; and <c>DELETE</c> hard-
-/// deletes a task a worker created on their phone. Those effects land in data
-/// the mobile clients read — what stays scoped is the mobile *caller*, not
-/// the data.
+/// property and every worker name for the customer; and <c>DELETE</c> removes
+/// a task a worker created on their phone. That delete is the Microting soft
+/// delete (<c>WorkflowState = Removed</c>, cascading the same way onto the
+/// task's assignments, logs, comments and photos): the rows survive and are
+/// recoverable in the database, but the task disappears from the mobile
+/// client and from every list. Those effects land in data the mobile clients
+/// read — what stays scoped is the mobile *caller*, not the data.
 ///
 /// <see cref="DashboardWorkerId"/> (0) survives as a synthetic identity, not
 /// as a grant: it is what web-written rows are stamped with
@@ -85,7 +102,7 @@ using Services.BackendConfigurationLocalizationService;
 /// of the web policy; moving it into <c>BackendConfigurationAdhocService</c>
 /// (e.g. by widening <c>CanSee</c>) would extend it to every phone.
 /// </summary>
-[Authorize]
+[Authorize(Policy = BackendConfigurationClaims.AccessBackendConfigurationPlugin)]
 [Route("api/backend-configuration-pn/adhoc")]
 public class AdhocController : Controller
 {
@@ -99,8 +116,11 @@ public class AdhocController : Controller
     // This constant is the whole of that policy. The mobile gRPC path is NOT
     // affected: AdhocGrpcService resolves a real worker via GrpcSiteResolver and
     // passes isAdmin: false. Widening the service's CanSee predicate instead of
-    // this flag WOULD leak every customer's tasks to every phone — do not move
-    // this decision into the service.
+    // this flag WOULD hand every phone in the customer every task in that
+    // customer's database — the platform is database-per-customer, so the
+    // blast radius stops at the customer boundary, but inside it it is total:
+    // every property, every worker's tasks, on every phone. Do not move this
+    // decision into the service.
     private const bool DashboardHasFullAccess = true;
 
     private readonly IBackendConfigurationAdhocService _adhocService;

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/AdhocController.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Controllers/AdhocController.cs
@@ -31,7 +31,6 @@ using Infrastructure.Models.Adhoc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microting.eFormApi.BasePn.Abstractions;
 using Microting.eFormApi.BasePn.Infrastructure.Models.API;
 using Microting.eFormApi.BasePn.Infrastructure.Models.Common;
 using Services.BackendConfigurationAdhocService;
@@ -50,20 +49,41 @@ using Services.BackendConfigurationLocalizationService;
 /// the SQL-translatable filters down to the database and only maps the
 /// current page's tasks to the full model shape.
 ///
-/// Caller identity: dashboard users authenticate via the eFormAPI web
-/// identity (there is no per-request SDK worker/site to resolve, unlike the
-/// mobile gRPC path's <c>GrpcSiteResolver</c>). Every call therefore uses a
-/// synthetic <see cref="DashboardWorkerId"/> of 0 plus an <c>isAdmin</c> flag
-/// resolved once per request from <see cref="IUserService.IsAdmin"/>. When
-/// <c>isAdmin</c> is true the shared service bypasses its property-access/
-/// creator/assigned/everyone visibility predicates entirely (an admin sees
-/// and mutates every task for the customer); when false, worker id 0 has no
-/// <c>PropertyWorker</c> row, so the property-access/visibility predicates
-/// deny every read. Note that dashboard-created tasks ARE stamped
-/// <c>CreatedByWorkerId = 0</c>, so the creator gate (and the tag-ownership
-/// gate) additionally treat pseudo-identity 0 as owning nothing unless the
-/// caller is an admin — see <c>RequireCreator</c> and the tag guards in
-/// <c>BackendConfigurationAdhocService</c>.
+/// Caller identity and access: dashboard users authenticate via the eFormAPI
+/// web identity; there is no per-request SDK worker/site to resolve (unlike
+/// the mobile gRPC path's <c>GrpcSiteResolver</c>). Since 2026-08-24 every
+/// authenticated web caller gets the behaviour an admin had: the controller
+/// passes the constant <see cref="DashboardHasFullAccess"/> at every call
+/// site instead of a role check, so the shared service's property-access /
+/// creator / assigned / everyone predicates are bypassed for web calls.
+/// Reach is still bounded by the plugin-wide
+/// <c>backend_configuration_plugin_access</c> route gate; the
+/// <c>adhoc_enable</c> claim is retained but enforced nowhere.
+///
+/// This is deliberately wider than "sees more tasks", and was confirmed as
+/// such: <c>isAdmin</c> is not a pure read filter. Web-created tags are
+/// written global (<c>OwnerWorkerId = null</c>) and any user may rename or
+/// delete another worker's phone-created tag; <c>ListTags</c> surfaces every
+/// worker's personal tags; <c>properties</c>/<c>workers</c> return every
+/// property and every worker name for the customer; and <c>DELETE</c> hard-
+/// deletes a task a worker created on their phone. Those effects land in data
+/// the mobile clients read — what stays scoped is the mobile *caller*, not
+/// the data.
+///
+/// <see cref="DashboardWorkerId"/> (0) survives as a synthetic identity, not
+/// as a grant: it is what web-written rows are stamped with
+/// (<c>CreatedByWorkerId</c>, comment <c>AuthorWorkerId</c>, assignment-log
+/// <c>ChangedByWorkerId</c>), so web-authored records are owned by nobody and
+/// "created by" identifies no one. It no longer decides what a web caller may
+/// see — the full-access flag does.
+///
+/// The mobile gRPC path is deliberately different and must stay that way:
+/// <c>AdhocGrpcService</c> resolves a real worker via <c>GrpcSiteResolver</c>
+/// (rejecting an unresolvable identity with <c>Unauthenticated</c>) and
+/// passes <c>isAdmin: false</c> explicitly, so mobile callers stay scoped to
+/// their own site's properties/assignments. The constant below is the whole
+/// of the web policy; moving it into <c>BackendConfigurationAdhocService</c>
+/// (e.g. by widening <c>CanSee</c>) would extend it to every phone.
 /// </summary>
 [Authorize]
 [Route("api/backend-configuration-pn/adhoc")]
@@ -71,21 +91,28 @@ public class AdhocController : Controller
 {
     private const int DashboardWorkerId = 0;
 
+    // Ad-hoc is unrestricted for dashboard callers (2026-08-24): every
+    // authenticated web user has the behaviour an admin has. Passed instead of
+    // IUserService.IsAdmin() so the shared service's property-access / creator /
+    // assigned predicates are bypassed for web callers.
+    //
+    // This constant is the whole of that policy. The mobile gRPC path is NOT
+    // affected: AdhocGrpcService resolves a real worker via GrpcSiteResolver and
+    // passes isAdmin: false. Widening the service's CanSee predicate instead of
+    // this flag WOULD leak every customer's tasks to every phone — do not move
+    // this decision into the service.
+    private const bool DashboardHasFullAccess = true;
+
     private readonly IBackendConfigurationAdhocService _adhocService;
     private readonly IBackendConfigurationLocalizationService _localizationService;
-    private readonly IUserService _userService;
 
     public AdhocController(
         IBackendConfigurationAdhocService adhocService,
-        IBackendConfigurationLocalizationService localizationService,
-        IUserService userService)
+        IBackendConfigurationLocalizationService localizationService)
     {
         _adhocService = adhocService;
         _localizationService = localizationService;
-        _userService = userService;
     }
-
-    private bool IsAdmin => _userService.IsAdmin();
 
     // -----------------------------------------------------------------
     // Tasks
@@ -96,7 +123,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<AdhocTaskIndexResultModel>> Index([FromBody] AdhocTaskFiltersModel filters)
     {
         return await ExecuteAsync(
-            () => _adhocService.IndexTasks(DashboardWorkerId, IsAdmin, filters ?? new AdhocTaskFiltersModel()),
+            () => _adhocService.IndexTasks(DashboardWorkerId, DashboardHasFullAccess, filters ?? new AdhocTaskFiltersModel()),
             "ErrorWhileGettingAdhocTasks");
     }
 
@@ -105,7 +132,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<Paged<AdhocTaskHistoryRowModel>>> HistoryIndex([FromBody] AdhocHistoryFiltersModel filters)
     {
         return await ExecuteAsync(
-            () => _adhocService.ListHistory(DashboardWorkerId, IsAdmin, filters ?? new AdhocHistoryFiltersModel()),
+            () => _adhocService.ListHistory(DashboardWorkerId, DashboardHasFullAccess, filters ?? new AdhocHistoryFiltersModel()),
             "ErrorWhileGettingAdhocHistory");
     }
 
@@ -114,7 +141,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<AdhocTaskModel>> CopyTask(int id, [FromBody] AdhocCopyTaskModel model)
     {
         return await ExecuteAsync(
-            () => _adhocService.CopyTask(DashboardWorkerId, IsAdmin, id, model?.IncludeComments ?? false),
+            () => _adhocService.CopyTask(DashboardWorkerId, DashboardHasFullAccess, id, model?.IncludeComments ?? false),
             "ErrorWhileCopyingAdhocTask");
     }
 
@@ -123,7 +150,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<AdhocTaskModel>> GetTask(int id)
     {
         return await ExecuteAsync(
-            () => _adhocService.GetTask(DashboardWorkerId, id, IsAdmin),
+            () => _adhocService.GetTask(DashboardWorkerId, id, DashboardHasFullAccess),
             "ErrorWhileGettingAdhocTask");
     }
 
@@ -131,7 +158,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<AdhocTaskModel>> CreateTask([FromBody] AdhocTaskCreateModel model)
     {
         return await ExecuteAsync(
-            () => _adhocService.CreateTask(DashboardWorkerId, model, IsAdmin),
+            () => _adhocService.CreateTask(DashboardWorkerId, model, DashboardHasFullAccess),
             "ErrorWhileCreatingAdhocTask");
     }
 
@@ -140,7 +167,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<AdhocTaskModel>> UpdateTask(int id, [FromBody] AdhocTaskCreateModel model)
     {
         return await ExecuteAsync(
-            () => _adhocService.UpdateTask(DashboardWorkerId, id, model, IsAdmin),
+            () => _adhocService.UpdateTask(DashboardWorkerId, id, model, DashboardHasFullAccess),
             "ErrorWhileUpdatingAdhocTask");
     }
 
@@ -150,7 +177,7 @@ public class AdhocController : Controller
     {
         var completed = model?.Completed ?? true;
         return await ExecuteAsync(
-            () => _adhocService.SetCompleted(DashboardWorkerId, id, completed, IsAdmin, model?.CompletedByWorkerId),
+            () => _adhocService.SetCompleted(DashboardWorkerId, id, completed, DashboardHasFullAccess, model?.CompletedByWorkerId),
             "ErrorWhileUpdatingAdhocTask");
     }
 
@@ -159,7 +186,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<AdhocTaskModel>> Archive(int id)
     {
         return await ExecuteAsync(
-            () => _adhocService.Archive(DashboardWorkerId, id, IsAdmin),
+            () => _adhocService.Archive(DashboardWorkerId, id, DashboardHasFullAccess),
             "ErrorWhileUpdatingAdhocTask");
     }
 
@@ -168,7 +195,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<AdhocTaskModel>> Reopen(int id)
     {
         return await ExecuteAsync(
-            () => _adhocService.Reopen(DashboardWorkerId, id, IsAdmin),
+            () => _adhocService.Reopen(DashboardWorkerId, id, DashboardHasFullAccess),
             "ErrorWhileUpdatingAdhocTask");
     }
 
@@ -177,7 +204,7 @@ public class AdhocController : Controller
     public async Task<OperationResult> DeleteTask(int id)
     {
         return await ExecuteAsync(
-            () => _adhocService.Delete(DashboardWorkerId, id, IsAdmin),
+            () => _adhocService.Delete(DashboardWorkerId, id, DashboardHasFullAccess),
             "ErrorWhileDeletingAdhocTask");
     }
 
@@ -186,7 +213,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<AdhocTaskModel>> AddComment(int id, [FromBody] AdhocCommentCreateModel model)
     {
         return await ExecuteAsync(
-            () => _adhocService.AddComment(DashboardWorkerId, id, model?.Text ?? string.Empty, IsAdmin),
+            () => _adhocService.AddComment(DashboardWorkerId, id, model?.Text ?? string.Empty, DashboardHasFullAccess),
             "ErrorWhileUpdatingAdhocTask");
     }
 
@@ -199,7 +226,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<List<AdhocPropertyModel>>> ListProperties()
     {
         return await ExecuteAsync(
-            () => _adhocService.ListProperties(DashboardWorkerId, IsAdmin),
+            () => _adhocService.ListProperties(DashboardWorkerId, DashboardHasFullAccess),
             "ErrorWhileGettingAdhocProperties");
     }
 
@@ -208,7 +235,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<List<AdhocAreaModel>>> ListAreas(int propertyId)
     {
         return await ExecuteAsync(
-            () => _adhocService.ListAreas(DashboardWorkerId, propertyId, IsAdmin),
+            () => _adhocService.ListAreas(DashboardWorkerId, propertyId, DashboardHasFullAccess),
             "ErrorWhileGettingAdhocAreas");
     }
 
@@ -217,7 +244,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<List<AdhocAreaModel>>> CreateAreas([FromBody] AdhocAreaCreateModel model)
     {
         return await ExecuteAsync(
-            () => _adhocService.CreateAreas(DashboardWorkerId, model?.PropertyId ?? 0, model?.Names ?? [], IsAdmin),
+            () => _adhocService.CreateAreas(DashboardWorkerId, model?.PropertyId ?? 0, model?.Names ?? [], DashboardHasFullAccess),
             "ErrorWhileCreatingAdhocAreas");
     }
 
@@ -226,7 +253,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<AdhocAreaModel>> RenameArea(int id, [FromBody] AdhocAreaRenameModel model)
     {
         return await ExecuteAsync(
-            () => _adhocService.RenameArea(DashboardWorkerId, id, model?.Name ?? string.Empty, IsAdmin),
+            () => _adhocService.RenameArea(DashboardWorkerId, id, model?.Name ?? string.Empty, DashboardHasFullAccess),
             "ErrorWhileUpdatingAdhocArea");
     }
 
@@ -235,7 +262,7 @@ public class AdhocController : Controller
     public async Task<OperationResult> DeleteArea(int id)
     {
         return await ExecuteAsync(
-            () => _adhocService.DeleteArea(DashboardWorkerId, id, IsAdmin),
+            () => _adhocService.DeleteArea(DashboardWorkerId, id, DashboardHasFullAccess),
             "ErrorWhileDeletingAdhocArea");
     }
 
@@ -244,7 +271,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<List<AdhocWorkerModel>>> ListWorkers(int propertyId)
     {
         return await ExecuteAsync(
-            () => _adhocService.ListWorkers(DashboardWorkerId, propertyId, IsAdmin),
+            () => _adhocService.ListWorkers(DashboardWorkerId, propertyId, DashboardHasFullAccess),
             "ErrorWhileGettingAdhocWorkers");
     }
 
@@ -256,13 +283,12 @@ public class AdhocController : Controller
     [Route("tags")]
     public async Task<OperationDataResult<List<AdhocTagModel>>> ListTags()
     {
-        // Admins see every non-removed tag customer-wide (global + every
-        // worker's personal tags, including mobile-created ones) so they
-        // show up in the web Etiketter list; non-admins keep the
-        // global-only view the synthetic DashboardWorkerId already implied
-        // (worker 0 owns nothing).
+        // Full access means every non-removed tag customer-wide (global +
+        // every worker's personal tags, including mobile-created ones) shows
+        // up in the web Etiketter list. Since 2026-08-24 that holds for every
+        // web caller, not just admins.
         return await ExecuteAsync(
-            () => _adhocService.ListTags(DashboardWorkerId, IsAdmin),
+            () => _adhocService.ListTags(DashboardWorkerId, DashboardHasFullAccess),
             "ErrorWhileGettingAdhocTags");
     }
 
@@ -270,12 +296,12 @@ public class AdhocController : Controller
     [Route("tags")]
     public async Task<OperationDataResult<AdhocTagModel>> CreateTag([FromBody] AdhocTagCreateModel model)
     {
-        // A dashboard admin curates shared tags for the customer - REST
-        // CreateTag creates a global tag (OwnerWorkerId = null) when the
-        // caller is an admin; mobile's CreateTag (gRPC, always isAdmin=false)
-        // keeps its existing "owner = caller" semantics unchanged.
+        // The dashboard curates shared tags for the customer - REST CreateTag
+        // creates a global tag (OwnerWorkerId = null) because it passes full
+        // access; mobile's CreateTag (gRPC, always isAdmin=false) keeps its
+        // existing "owner = caller" semantics unchanged.
         return await ExecuteAsync(
-            () => _adhocService.CreateTag(DashboardWorkerId, model?.Name ?? string.Empty, IsAdmin),
+            () => _adhocService.CreateTag(DashboardWorkerId, model?.Name ?? string.Empty, DashboardHasFullAccess),
             "ErrorWhileCreatingAdhocTag");
     }
 
@@ -284,7 +310,7 @@ public class AdhocController : Controller
     public async Task<OperationDataResult<AdhocTagModel>> RenameTag(int id, [FromBody] AdhocTagCreateModel model)
     {
         return await ExecuteAsync(
-            () => _adhocService.RenameTag(DashboardWorkerId, id, model?.Name ?? string.Empty, IsAdmin),
+            () => _adhocService.RenameTag(DashboardWorkerId, id, model?.Name ?? string.Empty, DashboardHasFullAccess),
             "ErrorWhileUpdatingAdhocTag");
     }
 
@@ -293,7 +319,7 @@ public class AdhocController : Controller
     public async Task<OperationResult> DeleteTag(int id)
     {
         return await ExecuteAsync(
-            () => _adhocService.DeleteTag(DashboardWorkerId, id, IsAdmin),
+            () => _adhocService.DeleteTag(DashboardWorkerId, id, DashboardHasFullAccess),
             "ErrorWhileDeletingAdhocTag");
     }
 
@@ -317,7 +343,7 @@ public class AdhocController : Controller
 
             var contentType = file.ContentType ?? string.Empty;
             var photoId = await _adhocService
-                .SavePhoto(DashboardWorkerId, id, stream.ToArray(), contentType, IsAdmin)
+                .SavePhoto(DashboardWorkerId, id, stream.ToArray(), contentType, DashboardHasFullAccess)
                 .ConfigureAwait(false);
 
             return new AdhocTaskPhotoModel { Id = photoId, ContentType = contentType };
@@ -331,7 +357,7 @@ public class AdhocController : Controller
         try
         {
             var (content, contentType) = await _adhocService
-                .GetPhoto(DashboardWorkerId, photoId, IsAdmin)
+                .GetPhoto(DashboardWorkerId, photoId, DashboardHasFullAccess)
                 .ConfigureAwait(false);
             return File(content, string.IsNullOrEmpty(contentType) ? "application/octet-stream" : contentType);
         }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Data/Seed/Data/BackendConfigurationPermissionsSeedData.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Data/Seed/Data/BackendConfigurationPermissionsSeedData.cs
@@ -74,6 +74,17 @@ public static class BackendConfigurationPermissionsSeedData
         },
         new PluginPermission
         {
+            // RETAINED BUT UNENFORCED (2026-08-24): ad-hoc is open to every
+            // authenticated user of the plugin, so nothing reads this claim any
+            // more - the route guard was dropped and no [Authorize] policy or
+            // controller references it. The entry stays because removing it
+            // properly means deleting the PluginPermissions /
+            // PluginGroupPermissions rows through a base-repo migration, which
+            // is a separate change. Until then the admin-settings toggle for it
+            // has no effect. Note this is NOT precedent: every other claim in
+            // this plugin (files, task-management, ...) is still enforced by a
+            // live PermissionGuard, so adhoc_enable is the only one enforced
+            // nowhere - tracked as a follow-up, not as house style.
             PermissionName = "Enable adhoc",
             // TODO upstream to Microting.EformBackendConfigurationBase.Infrastructure.Const.
             // BackendConfigurationClaims.EnableAdhoc once a base-repo release train is open.

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Data/Seed/Data/BackendConfigurationPermissionsSeedData.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Data/Seed/Data/BackendConfigurationPermissionsSeedData.cs
@@ -81,10 +81,18 @@ public static class BackendConfigurationPermissionsSeedData
             // properly means deleting the PluginPermissions /
             // PluginGroupPermissions rows through a base-repo migration, which
             // is a separate change. Until then the admin-settings toggle for it
-            // has no effect. Note this is NOT precedent: every other claim in
-            // this plugin (files, task-management, ...) is still enforced by a
-            // live PermissionGuard, so adhoc_enable is the only one enforced
-            // nowhere - tracked as a follow-up, not as house style.
+            // has no effect.
+            //
+            // Verified 2026-08-24: only four claims in this plugin are actually
+            // enforced anywhere. backend_configuration_plugin_access (parent
+            // route PermissionGuard, plus AdhocController's [Authorize] policy),
+            // properties_get, task_management_enable (route PermissionGuard and
+            // a checkClaim in property-worker-create-edit-modal) and
+            // document_management_enable. properties_create, property_edit,
+            // chemical_management_enable and time_registration_enable are seeded
+            // here but read by nothing, and the `files` route's PermissionGuard
+            // is commented out. So adhoc_enable is NOT the only unenforced claim
+            // - but that is drift to clean up, not a licence to add more.
             PermissionName = "Enable adhoc",
             // TODO upstream to Microting.EformBackendConfigurationBase.Infrastructure.Const.
             // BackendConfigurationClaims.EnableAdhoc once a base-repo release train is open.

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/BackendConfigurationAdhocService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/BackendConfigurationAdhocService.cs
@@ -362,11 +362,12 @@ public class BackendConfigurationAdhocService(
             }
 
             task.Completed = true;
-            // A dashboard admin (synthetic workerId 0) completing without
-            // selecting a performer stamps NULL, not 0 - worker id 0 is not
-            // a real SDK site, and history/name resolution treats a null
-            // CompletedByWorkerId as "no recorded performer". gRPC callers
-            // always have a real, positive site id here.
+            // A web caller (the synthetic workerId 0 the dashboard always
+            // passes) completing without selecting a performer stamps NULL,
+            // not 0 - worker id 0 is not a real SDK site, and history/name
+            // resolution treats a null CompletedByWorkerId as "no recorded
+            // performer". gRPC callers always have a real, positive site id
+            // here.
             task.CompletedByWorkerId = stampedWorkerId == 0 ? null : stampedWorkerId;
             task.CompletedAt = DateTime.UtcNow;
         }
@@ -885,9 +886,14 @@ public class BackendConfigurationAdhocService(
             throw new AdhocTagNotFoundException(tagId);
         }
 
-        // Admins manage every tag — in particular the global ones
-        // (OwnerWorkerId == null), which no worker owns and which were
-        // otherwise unmanageable by anyone. Non-admins only their own.
+        // A full-access caller manages every tag — the global ones
+        // (OwnerWorkerId == null), which no worker owns and which would
+        // otherwise be unmanageable by anyone, and equally another worker's
+        // personal, phone-created tag. Since 2026-08-24 that is every web
+        // caller, not just admins: an accepted consequence of the "web is
+        // unrestricted" decision. Without the flag a caller manages only
+        // tags they own themselves — which is what holds the gRPC path
+        // narrow.
         if (!isAdmin && tag.OwnerWorkerId != workerId)
         {
             throw new AdhocTaskUnauthorizedException(
@@ -1278,10 +1284,14 @@ public class BackendConfigurationAdhocService(
         // The web path deliberately bypasses this since 2026-08-24:
         // AdhocController passes DashboardHasFullAccess = true, so the isAdmin
         // early-return above fires for every authenticated web user and they
-        // may archive/reopen/delete/update any task - including hard-deleting
-        // one a worker created on their phone. Accepted consequence of the
-        // "web is unrestricted" decision, not a controller bug. Keep the
-        // guard: it is what still holds the gRPC path narrow.
+        // may archive/reopen/delete/update any task - including deleting one a
+        // worker created on their phone. That delete is the Microting soft
+        // delete (Delete sets WorkflowState = Removed on the task and cascades
+        // the same onto its assignments, logs, comments and photos), so the
+        // task vanishes from mobile and from every list but the rows remain
+        // recoverable in the database. Accepted consequence of the "web is
+        // unrestricted" decision, not a controller bug. Keep the guard: it is
+        // what still holds the gRPC path narrow.
         if (workerId == 0 || task.CreatedByWorkerId != workerId)
         {
             throw new AdhocTaskUnauthorizedException(

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/BackendConfigurationAdhocService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/BackendConfigurationAdhocService.cs
@@ -851,10 +851,21 @@ public class BackendConfigurationAdhocService(
     /// <summary>
     /// Tag mutations require a real identity: worker id 0 is the REST
     /// dashboard's synthetic caller (AdhocController.DashboardWorkerId) and
-    /// owns nothing — a non-admin web user must never create/rename/delete
-    /// tags through the shared pseudo-identity. Admins pass (they curate the
-    /// customer's global tags); gRPC callers always have real, positive SDK
-    /// site ids and never hit this guard.
+    /// owns nothing, so it may not create/rename/delete tags on its own.
+    ///
+    /// What this guarantees is about gRPC: a mobile caller always resolves to
+    /// a real, positive SDK site id (AdhocGrpcService rejects an unresolvable
+    /// one with Unauthenticated) and passes isAdmin: false, so it never
+    /// reaches this throw and never gains the admin tag semantics below.
+    ///
+    /// The web path deliberately bypasses this since 2026-08-24:
+    /// AdhocController passes DashboardHasFullAccess = true at every call
+    /// site, so every authenticated web user takes the isAdmin branch — web
+    /// CreateTag writes global tags (OwnerWorkerId = null) and web
+    /// rename/delete may act on another worker's phone-created tag. That is
+    /// the accepted consequence of the "web is unrestricted" decision, not a
+    /// bug in the controller. Keep the guard: it is what still holds the gRPC
+    /// path narrow.
     /// </summary>
     private static void RequireRealIdentityOrAdmin(int workerId, bool isAdmin, string action)
     {
@@ -1254,13 +1265,23 @@ public class BackendConfigurationAdhocService(
         }
 
         // Worker id 0 is the REST dashboard's synthetic caller identity
-        // (AdhocController.DashboardWorkerId), and dashboard-created tasks
-        // are themselves stamped CreatedByWorkerId = 0 - so a plain equality
-        // check would let EVERY authenticated non-admin web user pass the
-        // creator gate on every dashboard-created task. Pseudo-identity 0
-        // owns nothing: only an admin (already returned above) may act on
-        // worker-0-created tasks. gRPC callers always resolve to real,
-        // positive SDK site ids and are unaffected by this guard.
+        // (AdhocController.DashboardWorkerId), and web-created tasks are
+        // themselves stamped CreatedByWorkerId = 0 - so a plain equality check
+        // would let any (0, isAdmin false) caller pass the creator gate on
+        // every web-created task. Pseudo-identity 0 owns nothing.
+        //
+        // What this guarantees is about gRPC: a mobile caller always resolves
+        // to a real, positive SDK site id (AdhocGrpcService rejects an
+        // unresolvable one with Unauthenticated) and passes isAdmin: false, so
+        // it may only act on tasks it actually created.
+        //
+        // The web path deliberately bypasses this since 2026-08-24:
+        // AdhocController passes DashboardHasFullAccess = true, so the isAdmin
+        // early-return above fires for every authenticated web user and they
+        // may archive/reopen/delete/update any task - including hard-deleting
+        // one a worker created on their phone. Accepted consequence of the
+        // "web is unrestricted" decision, not a controller bug. Keep the
+        // guard: it is what still holds the gRPC path narrow.
         if (workerId == 0 || task.CreatedByWorkerId != workerId)
         {
             throw new AdhocTaskUnauthorizedException(

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/IBackendConfigurationAdhocService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationAdhocService/IBackendConfigurationAdhocService.cs
@@ -39,11 +39,21 @@ using Microting.eFormApi.BasePn.Infrastructure.Models.Common;
 /// explicitly rather than resolving it internally, so both façades - and
 /// tests - drive authorization identically.
 ///
-/// <paramref name="isAdmin"/> (default false everywhere) is the dashboard's
-/// bypass: an admin caller (REST, per B6's "workerId = 0 + isAdmin" caller
-/// identity) skips the property-access/creator/assigned/everyone visibility
-/// predicate entirely and sees/mutates every task for the customer. Mobile
-/// callers (gRPC) always pass false.
+/// <paramref name="isAdmin"/> (default false everywhere) is the full-access
+/// bypass: a caller passing true skips the property-access/creator/assigned/
+/// everyone visibility predicate entirely and sees/mutates every task for the
+/// customer. The name is historical - read it as "has full access", not "is
+/// an administrator": since 2026-08-24 <c>AdhocController</c> passes the
+/// constant <c>DashboardHasFullAccess = true</c> at EVERY call site (paired
+/// with the synthetic <c>workerId = 0</c>) rather than consulting a role
+/// service, so every authenticated web caller takes the true branch, not just
+/// admins. Web reach is bounded instead by the controller's class-level
+/// <c>AccessBackendConfigurationPlugin</c> policy.
+///
+/// Mobile is deliberately unaffected: <c>AdhocGrpcService</c> resolves a real
+/// worker and passes <c>isAdmin: false</c> explicitly at all 19 of its call
+/// sites, so the false branch - and every predicate below that keys off it -
+/// is what keeps the mobile path scoped to the caller's own site.
 /// </summary>
 public interface IBackendConfigurationAdhocService
 {
@@ -72,8 +82,8 @@ public interface IBackendConfigurationAdhocService
     /// as <c>CreatedByWorkerId</c>. <paramref name="isAdmin"/> (B6 dashboard
     /// bypass, default false) skips the "caller must have property access to
     /// <c>model.PropertyId</c>" gate — the dashboard has no real SDK worker
-    /// identity to check access for, so an admin caller creates tasks on the
-    /// customer's behalf directly.
+    /// identity to check access for, so a web caller creates tasks on the
+    /// customer's behalf directly, on any property.
     /// </summary>
     Task<AdhocTaskModel> CreateTask(int workerId, AdhocTaskCreateModel model, bool isAdmin = false);
 
@@ -144,9 +154,9 @@ public interface IBackendConfigurationAdhocService
     /// (both within the batch and against the property's active areas), so
     /// re-submitting a list is idempotent. Returns the refreshed active
     /// list. Access mirrors <see cref="ListAreas"/>
-    /// (<c>RequirePropertyAccessAsync</c>): admins pass; non-admins need a
-    /// <c>PropertyWorker</c> row. Throws <see cref="ArgumentException"/> for
-    /// an unknown property.
+    /// (<c>RequirePropertyAccessAsync</c>): full-access callers pass;
+    /// everyone else needs a <c>PropertyWorker</c> row. Throws
+    /// <see cref="ArgumentException"/> for an unknown property.
     /// </summary>
     Task<List<AdhocAreaModel>> CreateAreas(int workerId, int propertyId, List<string> names, bool isAdmin = false);
 
@@ -180,42 +190,55 @@ public interface IBackendConfigurationAdhocService
     /// <summary>
     /// Global tags (<c>OwnerWorkerId == null</c>) plus <paramref name="workerId"/>'s
     /// own personal tags. When <paramref name="isAdmin"/> is true the owner
-    /// filter is skipped entirely - the dashboard admin sees every
-    /// non-removed tag customer-wide, including every worker's personal
-    /// tags (mobile-created tags included), so they show up in the web
-    /// Etiketter list rather than being silently hidden.
+    /// filter is skipped entirely - the caller sees every non-removed tag
+    /// customer-wide, including every worker's personal tags (mobile-created
+    /// tags included), so they show up in the web Etiketter list rather than
+    /// being silently hidden. Every web caller passes true since 2026-08-24,
+    /// so that customer-wide view is what the dashboard always shows.
     /// </summary>
     Task<List<AdhocTagModel>> ListTags(int workerId, bool isAdmin = false);
 
     /// <summary>
     /// Creates a personal tag owned by <paramref name="workerId"/>, unless
-    /// <paramref name="isAdmin"/> is true (M5/P3 dashboard-only), in which
-    /// case it creates a global tag (<c>OwnerWorkerId = null</c>) - an admin
-    /// curating shared tags for the customer. Mobile <c>CreateTag</c>
-    /// semantics (owner = caller) are unchanged; mobile never passes
-    /// <paramref name="isAdmin"/>. Throws
-    /// <see cref="AdhocTaskUnauthorizedException"/> for the non-admin REST
-    /// pseudo-identity (workerId 0, isAdmin false) - identity 0 owns nothing.
+    /// <paramref name="isAdmin"/> is true, in which case it creates a global
+    /// tag (<c>OwnerWorkerId = null</c>) owned by nobody and visible to
+    /// everyone. Since 2026-08-24 every web caller takes that branch, so all
+    /// tags created from the dashboard are shared, customer-wide tags. Mobile
+    /// <c>CreateTag</c> semantics (owner = caller) are unchanged - mobile
+    /// passes <c>isAdmin: false</c> explicitly
+    /// (<c>AdhocGrpcService.CreateTag</c>), as it does at every call site.
+    /// Throws <see cref="AdhocTaskUnauthorizedException"/> for the
+    /// combination (workerId 0, isAdmin false) - identity 0 owns nothing. No
+    /// current caller produces that combination; the guard is what stops the
+    /// gRPC path from ever writing an unowned tag.
     /// </summary>
     Task<AdhocTagModel> CreateTag(int workerId, string name, bool isAdmin = false);
 
     /// <summary>
     /// Renames a tag <paramref name="workerId"/> owns, or - when
-    /// <paramref name="isAdmin"/> is true - any tag, notably the global ones
-    /// (<c>OwnerWorkerId == null</c>) that no worker owns. Throws
-    /// <see cref="AdhocTaskUnauthorizedException"/> for non-admins on global
-    /// tags or tags owned by another worker, and for the non-admin REST
-    /// pseudo-identity (workerId 0, isAdmin false).
+    /// <paramref name="isAdmin"/> is true - any tag at all: the global ones
+    /// (<c>OwnerWorkerId == null</c>) that no worker owns, and equally
+    /// another worker's personal, phone-created tag. Since 2026-08-24 every
+    /// web caller has that reach; it is an accepted consequence of the "web
+    /// is unrestricted" decision, not an oversight. Throws
+    /// <see cref="AdhocTaskUnauthorizedException"/> when
+    /// <paramref name="isAdmin"/> is false and the tag is global or owned by
+    /// another worker, and for the combination (workerId 0, isAdmin false),
+    /// which no current caller produces.
     /// </summary>
     Task<AdhocTagModel> RenameTag(int workerId, int tagId, string name, bool isAdmin = false);
 
     /// <summary>
-    /// Soft-deletes a tag <paramref name="workerId"/> owns (any tag when
-    /// <paramref name="isAdmin"/> is true, notably global ones), plus every
-    /// <c>AdhocTaskTag</c> join referencing it. Throws
-    /// <see cref="AdhocTaskUnauthorizedException"/> for non-admins on global
-    /// tags or tags owned by another worker, and for the non-admin REST
-    /// pseudo-identity (workerId 0, isAdmin false).
+    /// Soft-deletes a tag <paramref name="workerId"/> owns - any tag when
+    /// <paramref name="isAdmin"/> is true, global ones and another worker's
+    /// personal tag alike - plus every <c>AdhocTaskTag</c> join referencing
+    /// it, so the tag also disappears from other people's tasks. Since
+    /// 2026-08-24 every web caller has that reach (accepted consequence of
+    /// the "web is unrestricted" decision). Throws
+    /// <see cref="AdhocTaskUnauthorizedException"/> when
+    /// <paramref name="isAdmin"/> is false and the tag is global or owned by
+    /// another worker, and for the combination (workerId 0, isAdmin false),
+    /// which no current caller produces.
     /// </summary>
     Task DeleteTag(int workerId, int tagId, bool isAdmin = false);
 

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/AdhocGrpcService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/GrpcServices/AdhocGrpcService.cs
@@ -21,9 +21,12 @@ namespace BackendConfiguration.Pn.Services.GrpcServices;
 /// when the resolver returns 0) and forwards to
 /// <see cref="IBackendConfigurationAdhocService"/> — the shared task CRUD +
 /// visibility service also consumed by <c>AdhocController</c> (B6, dashboard
-/// REST). Mobile callers always pass <c>isAdmin=false</c> (the service's
-/// default) — visibility here is entirely governed by that service's
-/// TaskVisibility-mirroring predicates.
+/// REST). Mobile callers always pass <c>isAdmin: false</c>, written out at
+/// every call site rather than left to the interface default (2026-08-24), so
+/// that the mobile scoping guarantee does not hinge on a default argument —
+/// <c>AdhocController</c> now passes <c>true</c> unconditionally, and this is
+/// the line that keeps that decision on the web side. Visibility here is
+/// entirely governed by that service's TaskVisibility-mirroring predicates.
 ///
 /// Typed service exceptions map to RPC status codes:
 /// <see cref="AdhocTaskNotFoundException"/>/<see cref="AdhocTagNotFoundException"/>/
@@ -61,7 +64,7 @@ public class AdhocGrpcService(
         // worker identity), so resolve it via the site resolver, mirroring
         // BackendConfigurationAdhocService.ListWorkers' own Site.Name lookup.
         var displayName = await siteResolver.GetDisplayNameAsync(workerId).ConfigureAwait(false);
-        var properties = await adhocService.ListProperties(workerId).ConfigureAwait(false);
+        var properties = await adhocService.ListProperties(workerId, isAdmin: false).ConfigureAwait(false);
 
         var response = new CurrentWorker
         {
@@ -78,7 +81,7 @@ public class AdhocGrpcService(
         var scope = MapScope(request.Scope);
         var propertyId = ParseOptionalId(request.PropertyId);
 
-        var tasks = await adhocService.ListTasks(workerId, scope, propertyId).ConfigureAwait(false);
+        var tasks = await adhocService.ListTasks(workerId, scope, propertyId, isAdmin: false).ConfigureAwait(false);
 
         var response = new ListTasksResponse();
         response.Tasks.AddRange(tasks.Select(MapTask));
@@ -90,7 +93,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var taskId = ParseRequiredId(request.TaskId, "task_id");
 
-        var task = await RunAsync(() => adhocService.GetTask(workerId, taskId)).ConfigureAwait(false);
+        var task = await RunAsync(() => adhocService.GetTask(workerId, taskId, isAdmin: false)).ConfigureAwait(false);
         return new GetTaskResponse { Task = MapTask(task) };
     }
 
@@ -99,7 +102,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var model = MapCreateModel(request);
 
-        var task = await RunAsync(() => adhocService.CreateTask(workerId, model)).ConfigureAwait(false);
+        var task = await RunAsync(() => adhocService.CreateTask(workerId, model, isAdmin: false)).ConfigureAwait(false);
         return new TaskResponse { Task = MapTask(task) };
     }
 
@@ -109,7 +112,7 @@ public class AdhocGrpcService(
         var taskId = ParseRequiredId(request.Id, "id");
         var model = MapCreateModel(request);
 
-        var task = await RunAsync(() => adhocService.UpdateTask(workerId, taskId, model)).ConfigureAwait(false);
+        var task = await RunAsync(() => adhocService.UpdateTask(workerId, taskId, model, isAdmin: false)).ConfigureAwait(false);
         return new TaskResponse { Task = MapTask(task) };
     }
 
@@ -118,7 +121,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var taskId = ParseRequiredId(request.TaskId, "task_id");
 
-        var task = await RunAsync(() => adhocService.SetCompleted(workerId, taskId, request.Completed))
+        var task = await RunAsync(() => adhocService.SetCompleted(workerId, taskId, request.Completed, isAdmin: false))
             .ConfigureAwait(false);
         return new TaskResponse { Task = MapTask(task) };
     }
@@ -128,7 +131,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var taskId = ParseRequiredId(request.TaskId, "task_id");
 
-        var task = await RunAsync(() => adhocService.Archive(workerId, taskId)).ConfigureAwait(false);
+        var task = await RunAsync(() => adhocService.Archive(workerId, taskId, isAdmin: false)).ConfigureAwait(false);
         return new TaskResponse { Task = MapTask(task) };
     }
 
@@ -137,7 +140,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var taskId = ParseRequiredId(request.TaskId, "task_id");
 
-        var task = await RunAsync(() => adhocService.Reopen(workerId, taskId)).ConfigureAwait(false);
+        var task = await RunAsync(() => adhocService.Reopen(workerId, taskId, isAdmin: false)).ConfigureAwait(false);
         return new TaskResponse { Task = MapTask(task) };
     }
 
@@ -146,7 +149,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var taskId = ParseRequiredId(request.TaskId, "task_id");
 
-        await RunVoidAsync(() => adhocService.Delete(workerId, taskId)).ConfigureAwait(false);
+        await RunVoidAsync(() => adhocService.Delete(workerId, taskId, isAdmin: false)).ConfigureAwait(false);
         return new DeleteResponse();
     }
 
@@ -155,7 +158,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var taskId = ParseRequiredId(request.TaskId, "task_id");
 
-        var task = await RunAsync(() => adhocService.AddComment(workerId, taskId, request.Text ?? string.Empty))
+        var task = await RunAsync(() => adhocService.AddComment(workerId, taskId, request.Text ?? string.Empty, isAdmin: false))
             .ConfigureAwait(false);
         return new TaskResponse { Task = MapTask(task) };
     }
@@ -165,7 +168,7 @@ public class AdhocGrpcService(
         ServerCallContext context)
     {
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
-        var properties = await adhocService.ListProperties(workerId).ConfigureAwait(false);
+        var properties = await adhocService.ListProperties(workerId, isAdmin: false).ConfigureAwait(false);
 
         var response = new ListAdhocPropertiesResponse();
         response.Properties.AddRange(properties.Select(p => new PropertyRef
@@ -181,7 +184,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var propertyId = ParseRequiredId(request.PropertyId, "property_id");
 
-        var areas = await RunAsync(() => adhocService.ListAreas(workerId, propertyId)).ConfigureAwait(false);
+        var areas = await RunAsync(() => adhocService.ListAreas(workerId, propertyId, isAdmin: false)).ConfigureAwait(false);
 
         var response = new ListAreasResponse();
         response.Areas.AddRange(areas.Select(a => new AreaRef
@@ -198,7 +201,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var propertyId = ParseRequiredId(request.PropertyId, "property_id");
 
-        var workers = await RunAsync(() => adhocService.ListWorkers(workerId, propertyId)).ConfigureAwait(false);
+        var workers = await RunAsync(() => adhocService.ListWorkers(workerId, propertyId, isAdmin: false)).ConfigureAwait(false);
 
         var response = new ListWorkersResponse();
         response.Workers.AddRange(workers.Select(w => new WorkerRef
@@ -212,7 +215,7 @@ public class AdhocGrpcService(
     public override async Task<ListTagsResponse> ListTags(ListTagsRequest request, ServerCallContext context)
     {
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
-        var tags = await adhocService.ListTags(workerId).ConfigureAwait(false);
+        var tags = await adhocService.ListTags(workerId, isAdmin: false).ConfigureAwait(false);
 
         var response = new ListTagsResponse();
         response.Tags.AddRange(tags.Select(MapTag));
@@ -222,7 +225,7 @@ public class AdhocGrpcService(
     public override async Task<TagResponse> CreateTag(CreateTagRequest request, ServerCallContext context)
     {
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
-        var tag = await RunAsync(() => adhocService.CreateTag(workerId, request.Name ?? string.Empty))
+        var tag = await RunAsync(() => adhocService.CreateTag(workerId, request.Name ?? string.Empty, isAdmin: false))
             .ConfigureAwait(false);
         return new TagResponse { Tag = MapTag(tag) };
     }
@@ -232,7 +235,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var tagId = ParseRequiredId(request.Id, "id");
 
-        var tag = await RunAsync(() => adhocService.RenameTag(workerId, tagId, request.Name ?? string.Empty))
+        var tag = await RunAsync(() => adhocService.RenameTag(workerId, tagId, request.Name ?? string.Empty, isAdmin: false))
             .ConfigureAwait(false);
         return new TagResponse { Tag = MapTag(tag) };
     }
@@ -242,7 +245,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var tagId = ParseRequiredId(request.Id, "id");
 
-        await RunVoidAsync(() => adhocService.DeleteTag(workerId, tagId)).ConfigureAwait(false);
+        await RunVoidAsync(() => adhocService.DeleteTag(workerId, tagId, isAdmin: false)).ConfigureAwait(false);
         return new DeleteTagResponse();
     }
 
@@ -307,7 +310,7 @@ public class AdhocGrpcService(
                 "UploadPhoto stream contained no image bytes."));
         }
 
-        var photoId = await RunAsync(() => adhocService.SavePhoto(workerId, taskId, ms.ToArray(), contentType))
+        var photoId = await RunAsync(() => adhocService.SavePhoto(workerId, taskId, ms.ToArray(), contentType, isAdmin: false))
             .ConfigureAwait(false);
 
         return new UploadPhotoResponse { PhotoId = photoId.ToString(CultureInfo.InvariantCulture) };
@@ -327,7 +330,7 @@ public class AdhocGrpcService(
         var workerId = await ResolveWorkerIdAsync().ConfigureAwait(false);
         var photoId = ParseRequiredId(request.PhotoId, "photo_id");
 
-        var (content, contentType) = await RunAsync(() => adhocService.GetPhoto(workerId, photoId))
+        var (content, contentType) = await RunAsync(() => adhocService.GetPhoto(workerId, photoId, isAdmin: false))
             .ConfigureAwait(false);
 
         await using (content.ConfigureAwait(false))

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/BackendConfigurationAdhoc.page.ts
@@ -474,6 +474,20 @@ export class BackendConfigurationAdhocPage {
 
   // ----- Drawer photos (#1099/#1100) -----------------------------------------
 
+  /**
+   * The drawer's hidden photo picker - the `<input type="file">` inside
+   * `label.photo-upload-btn` (`adhoc-task-drawer.component.html`).
+   * `setInputFiles` works on a hidden input; same idiom as
+   * `w/calendar-attachments.spec.ts` with `#calendarEventAttachInput`.
+   * In EDIT mode the selection uploads immediately
+   * (`onFilesSelected` -> `POST .../adhoc/{id}/photos`), so the round-trip
+   * can be awaited; in CREATE mode it only queues a preview
+   * (`queuedPhotoThumbs()`).
+   */
+  photoUploadInput(): Locator {
+    return this.page.locator('.adhoc-drawer .photo-upload-btn input[type="file"]');
+  }
+
   /** Existing (server-side) photo thumbnails in the open drawer. */
   photoThumbs(): Locator {
     return this.page.locator('.adhoc-drawer [data-e2e="adhoc-photo-thumb"]');

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-nonadmin-access.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-nonadmin-access.spec.ts
@@ -445,7 +445,24 @@ test.describe.serial('Adhoc overblik — non-admin unrestricted access', () => {
     );
     await adhocPage.photoThumbs().first().click();
     const photoResponse = await photoResponsePromise;
-    expect(photoResponse.status()).toBe(200);
+
+    // Assert NOT-403 rather than ==200, deliberately.
+    //
+    // What this test exists to prove (spec §4.2 step 5) is that opening a photo
+    // does not end the session: `GET .../adhoc/photos/{id}` is the plugin's only
+    // `Forbid()`, and the global HttpErrorInterceptor escalates any 403 into
+    // `logout()`. Only 401/403 do that; every other status is inert for session
+    // survival.
+    //
+    // ==200 additionally required the blob to come back, which CI cannot do:
+    // `AdhocPhotoStorage.GetAsync` reads through `core.GetFileFromS3Storage`
+    // and the workflow starts no object-storage service, so retrieval answers
+    // 500 there. That is NOT caused by this change — `(workerId 0, isAdmin
+    // true)` is exactly the path admins already took, so an admin gets the same
+    // 500; no spec had ever fetched a photo, so nothing surfaced it before.
+    // Asserting ==200 here would pin CI infrastructure, not this permission
+    // change.
+    expect([401, 403]).not.toContain(photoResponse.status());
 
     // Give the interceptor's 403 path (refresh token → retry → logout →
     // router.navigate(['/auth'])) more than enough time to fire if the

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-nonadmin-access.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-nonadmin-access.spec.ts
@@ -48,12 +48,13 @@ import { BackendConfigurationAdhocPage } from '../BackendConfigurationAdhoc.page
  * Structural notes:
  *   - The copied helper sets the group's `redirectLink` to
  *     `/plugins/backend-configuration-pn/property-workers`, so the
- *     non-admin session lands THERE first; `goToAdhoc()` navigates via the
- *     SIDEBAR (`#backend-configuration-pn` → `#backend-configuration-pn-adhoc`),
- *     and that sidebar click is what carries the session to ad-hoc. The
- *     menu item is declared with `Permissions = []`
- *     (`EformBackendConfigurationPlugin.cs` `GetNavigationMenu`), so it is
- *     visible to every user regardless of claims.
+ *     non-admin session lands THERE first and `goToAdhocAsNonAdmin()`
+ *     carries it to ad-hoc — preferring the SIDEBAR
+ *     (`#backend-configuration-pn` → `#backend-configuration-pn-adhoc`,
+ *     declared with `Permissions = []`), but BOUNDED, with a direct-URL
+ *     fallback, because the sidebar's presence for this claims set is a
+ *     server-side/DB question this spec cannot control. See that helper's
+ *     doc comment.
  *   - Every positive "the app works" assertion is taken BEFORE any guarded
  *     `page.goto`: after a guard-cancelled INITIAL navigation no route
  *     activates at all, so even the claim-independent footer
@@ -66,6 +67,10 @@ import { BackendConfigurationAdhocPage } from '../BackendConfigurationAdhoc.page
  */
 const BASE_URL = 'http://localhost:4200';
 const USER_PASSWORD = 'Secret_password_2026!';
+// Every sidebar wait/click in `goToAdhocAsNonAdmin` is bounded by this.
+// `playwright.config.ts` declares no `actionTimeout`, so an unbounded click
+// would inherit `test.setTimeout(300000)` and hang the shard for 15 minutes.
+const SIDEBAR_TIMEOUT = 30000;
 const rand = generateRandmString(8).toLowerCase();
 
 // Re-uses the existing image fixture (the drawer's file input is
@@ -224,16 +229,59 @@ async function setupNonAdminUser(page: Page, rand: string): Promise<string> {
 }
 
 /**
- * The drawer's photo picker. `BackendConfigurationAdhocPage` exposes the
- * resulting thumbnails (`photoThumbs()`/`queuedPhotoThumbs()`) and the
- * delete flow, but has NO helper for ADDING a photo, so the hidden
- * `<input type="file">` inside `label.photo-upload-btn`
- * (`adhoc-task-drawer.component.html`) is addressed here. `setInputFiles`
- * on a `hidden` file input is the same idiom `w/calendar-attachments.spec.ts`
- * uses for `#calendarEventAttachInput`.
+ * Navigates an ALREADY-LOGGED-IN non-admin session to "Adhoc overblik".
+ *
+ * Preferred path is the SIDEBAR (spec 4.2): an in-app navigation, so the SPA
+ * never re-bootstraps with the ad-hoc URL as its INITIAL navigation. But
+ * whether the plugin sidebar renders for THIS claims set is not settled:
+ * every backend-configuration menu item is seeded with `Permissions = []`
+ * (`EformBackendConfigurationPlugin.cs` `GetNavigationMenu`) and the
+ * front-end only hides a leaf whose guard list is non-empty
+ * (`navigation.component.html` `checkGuards`), yet `MenuService`
+ * `GetCurrentUserMenu` ALSO filters server-side for non-admins
+ * (`FilterMenuForUser`), where a plugin item survives only when it has no
+ * `MenuItemSecurityGroups` rows or one of them is this user's group - a DB
+ * state this spec does not control. `r/property-workers-nonadmin-no-logout.
+ * spec.ts:233-235` records the sidebar as ABSENT for exactly this fixture.
+ *
+ * `playwright.config.ts` sets no `actionTimeout`, so an unbounded `.click()`
+ * on an entry that never appears would burn the whole
+ * `test.setTimeout(300000)` - 15 minutes of shard-`z` hang per test. Hence:
+ * bounded waits, then a direct `page.goto` fallback. The fallback is safe
+ * because `adhoc-tasks` is `canActivate: [AuthGuard]` now - the same reason
+ * `q/calendar-admin-gating.spec.ts` navigates its non-admin to `/calendar`
+ * with a plain `page.goto`.
+ *
+ * Either way the load-bearing proof is unchanged: the ROUTE must ACTIVATE.
+ * If `PermissionGuard` + `adhoc_enable` came back, the cancelled navigation
+ * would leave a blank shell and the `#main-list-view` wait below would fail.
+ *
+ * CALLERS MUST have taken their positive app-shell assertion
+ * (`#sign-out-dropdown`) BEFORE calling this - see the suite header.
  */
-function drawerPhotoInput(page: Page) {
-  return page.locator('.adhoc-drawer .photo-upload-btn input[type="file"]');
+async function goToAdhocAsNonAdmin(
+  page: Page,
+  adhocPage: BackendConfigurationAdhocPage,
+): Promise<void> {
+  const pluginEntry = adhocPage.backendConfigurationPnButton();
+  const adhocEntry = adhocPage.backendConfigurationPnAdhocButton();
+  try {
+    if (!(await adhocEntry.isVisible())) {
+      await pluginEntry.waitFor({ state: 'visible', timeout: SIDEBAR_TIMEOUT });
+      await pluginEntry.click({ timeout: SIDEBAR_TIMEOUT });
+    }
+    await adhocEntry.waitFor({ state: 'visible', timeout: SIDEBAR_TIMEOUT });
+    await adhocEntry.click({ timeout: SIDEBAR_TIMEOUT });
+  } catch (error) {
+    // Sidebar unusable for this claims set - say so loudly, then take the
+    // URL. This must NOT swallow a guard regression: the wait below is what
+    // proves the route opened.
+    console.log(
+      `sidebar ad-hoc entry not usable for this non-admin (${(error as Error).message.split('\n')[0]}) - falling back to direct URL`,
+    );
+    await page.goto(`${BASE_URL}/plugins/backend-configuration-pn/adhoc-tasks`);
+  }
+  await adhocPage.mainListView().waitFor({ state: 'visible', timeout: 30000 });
 }
 
 test.describe.serial('Adhoc overblik — non-admin unrestricted access', () => {
@@ -275,7 +323,7 @@ test.describe.serial('Adhoc overblik — non-admin unrestricted access', () => {
         && r.request().method() === 'POST',
       { timeout: 60000 },
     );
-    await drawerPhotoInput(page).setInputFiles(PHOTO_FIXTURE);
+    await adhocPage.photoUploadInput().setInputFiles(PHOTO_FIXTURE);
     const uploadResponse = await uploadResponsePromise;
     expect(uploadResponse.status()).toBe(200);
 
@@ -314,10 +362,10 @@ test.describe.serial('Adhoc overblik — non-admin unrestricted access', () => {
     // layout is mounted, so the claim-independent footer must exist.
     await expect(page.locator('#sign-out-dropdown')).toBeVisible();
 
-    // Sidebar navigation — NOT a `page.goto`, so the SPA never re-bootstraps
-    // with the ad-hoc URL as its initial navigation.
+    // Sidebar-first navigation with a bounded fallback — see
+    // `goToAdhocAsNonAdmin`. Never an unbounded click.
     const adhocPage = new BackendConfigurationAdhocPage(page);
-    await adhocPage.goToAdhoc();
+    await goToAdhocAsNonAdmin(page, adhocPage);
 
     expect(page.url()).toContain('/plugins/backend-configuration-pn/adhoc-tasks');
     await expect(adhocPage.mainListView()).toBeVisible();
@@ -340,7 +388,7 @@ test.describe.serial('Adhoc overblik — non-admin unrestricted access', () => {
     await expect(page.locator('#sign-out-dropdown')).toBeVisible();
 
     const adhocPage = new BackendConfigurationAdhocPage(page);
-    await adhocPage.goToAdhoc();
+    await goToAdhocAsNonAdmin(page, adhocPage);
 
     await adhocPage.search(taskTitle);
     await expect(adhocPage.row(taskTitle)).toBeVisible({ timeout: 20000 });
@@ -379,7 +427,7 @@ test.describe.serial('Adhoc overblik — non-admin unrestricted access', () => {
     await expect(page.locator('#sign-out-dropdown')).toBeVisible();
 
     const adhocPage = new BackendConfigurationAdhocPage(page);
-    await adhocPage.goToAdhoc();
+    await goToAdhocAsNonAdmin(page, adhocPage);
     await adhocPage.search(taskTitle);
     await expect(adhocPage.row(taskTitle)).toBeVisible({ timeout: 20000 });
 

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-nonadmin-access.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-nonadmin-access.spec.ts
@@ -1,0 +1,423 @@
+import { test, expect, Page } from '@playwright/test';
+import * as path from 'path';
+import { generateRandmString } from '../../../helper-functions';
+import { BackendConfigurationPropertiesPage } from '../BackendConfigurationProperties.page';
+import { BackendConfigurationAdhocPage } from '../BackendConfigurationAdhoc.page';
+
+/**
+ * Adhoc overblik — NON-ADMIN access suite (spec
+ * `2026-08-24-adhoc-tasks-unrestricted-access-design.md`, §4.2).
+ *
+ * End-to-end proof for the permission change: the `adhoc-tasks` route no
+ * longer carries `PermissionGuard` + `data.requiredPermission:
+ * 'adhoc_enable'` (it is `canActivate: [AuthGuard]` now, like `calendar`/
+ * `compliances`/`property-workers`), and `AdhocController` passes the
+ * constant `DashboardHasFullAccess = true` instead of
+ * `IUserService.IsAdmin()` at every call site — so a plain `user`-role web
+ * caller gets exactly the ad-hoc behaviour an admin had.
+ *
+ * The three non-admin tests below assert the two halves separately,
+ * because only the second one distinguishes a real fix from merely
+ * unblocking navigation:
+ *
+ *   1. the list view MOUNTS (the route guard is gone);
+ *   2. the seeded task IS VISIBLE even though this user is not assigned to
+ *      its property (the server-side identity gate is gone — before the
+ *      change the page would have rendered permanently empty, since the
+ *      shared service's `CanSee` resolves property access through
+ *      `PropertyWorkers.WorkerId == sdkSiteId` and the web pseudo-identity
+ *      is worker `0`, which owns no such row);
+ *   3. opening that task's photo does not end the session — `GET
+ *      .../adhoc/photos/{id}` was the plugin's only `Forbid()`, and the
+ *      global `HttpErrorInterceptor` turns any 403 into a token refresh
+ *      and, on failure, `authStateService.logout()` (→ `/auth`).
+ *
+ * `loginViaApi`/`loginAs`/`setupNonAdminUser` are copied VERBATIM from
+ * `r/property-workers-nonadmin-no-logout.spec.ts` (`loginViaApi` from line
+ * 29, `setupNonAdminUser` lines 70-172), as `q/calendar-admin-gating.spec.ts`
+ * and `x/task-list-admin-gating.spec.ts` already do — only the group/user
+ * name strings are suite-local. Its plugin-claim list deliberately OMITS
+ * `adhoc_enable`: that omission is the whole point of the fixture, so do
+ * NOT add the claim. The helper creates a security group, core claims, a
+ * redirect link, plugin access and a `user`-role account and NOTHING else —
+ * in particular it performs no property assignment, and the account is
+ * created with `isDeviceUser: false`, so this user has no SDK worker/site
+ * and therefore no `PropertyWorkers` row for the seeded property. That is
+ * exactly the condition assertion 2 needs.
+ *
+ * Structural notes:
+ *   - The copied helper sets the group's `redirectLink` to
+ *     `/plugins/backend-configuration-pn/property-workers`, so the
+ *     non-admin session lands THERE first; `goToAdhoc()` navigates via the
+ *     SIDEBAR (`#backend-configuration-pn` → `#backend-configuration-pn-adhoc`),
+ *     and that sidebar click is what carries the session to ad-hoc. The
+ *     menu item is declared with `Permissions = []`
+ *     (`EformBackendConfigurationPlugin.cs` `GetNavigationMenu`), so it is
+ *     visible to every user regardless of claims.
+ *   - Every positive "the app works" assertion is taken BEFORE any guarded
+ *     `page.goto`: after a guard-cancelled INITIAL navigation no route
+ *     activates at all, so even the claim-independent footer
+ *     (`#sign-out-dropdown`, hosted by `FullLayoutComponent` on the `''`
+ *     parent route) is absent — see the same reasoning in
+ *     `x/task-list-admin-gating.spec.ts`.
+ *   - Shard `z` does NOT load the shard-a DB dump, so this file is
+ *     `describe.serial` with `seed:` tests first, like every other `z`
+ *     spec.
+ */
+const BASE_URL = 'http://localhost:4200';
+const USER_PASSWORD = 'Secret_password_2026!';
+const rand = generateRandmString(8).toLowerCase();
+
+// Re-uses the existing image fixture (the drawer's file input is
+// `accept="image/*"`); there is no adhoc-specific fixture tree, and
+// `p/calendar-copy.spec.ts` / `w/calendar-attachments*.spec.ts` already
+// resolve this same directory from other shards.
+const PHOTO_FIXTURE = path.resolve(__dirname, '../fixtures/calendar-attachments/sample.png');
+
+const property = {
+  name: `adhoc-na-${rand}`,
+  chrNumber: generateRandmString(5),
+  address: generateRandmString(5),
+  cvrNumber: '4444444',
+};
+const taskTitle = `Adhoc-NonAdmin-Task-${rand}`;
+
+async function loginViaApi(page: Page, email: string, password: string): Promise<string> {
+  const res = await page.request.post(`${BASE_URL}/api/auth/token`, {
+    form: { username: email, password: password, grant_type: 'password' },
+  });
+  const json = await res.json();
+  return json?.model?.accessToken || '';
+}
+
+async function loginAs(page: Page, email: string, password: string): Promise<void> {
+  const loginBtn = page.locator('#loginBtn');
+  await loginBtn.waitFor({ state: 'visible', timeout: 60000 });
+  await page.locator('#username').fill(email);
+  await page.locator('#password').fill(password);
+  const loginResponsePromise = page.waitForResponse(
+    (r) => r.url().includes('/api/auth/token'),
+    { timeout: 30000 },
+  ).catch(() => null);
+  await loginBtn.click();
+  await loginResponsePromise;
+  // Wait for the post-login redirect to leave /auth (group redirectLink).
+  await page.waitForURL((url) => !url.pathname.startsWith('/auth'), { timeout: 20000 })
+    .catch(() => console.log(`loginAs ${email}: still on ${page.url()}`));
+  await page.waitForTimeout(1000);
+}
+
+/**
+ * Creates a security group carrying exactly the reported customer setup:
+ * core device-users + tags permissions ("backend") and plugin access to
+ * backend-configuration + time-planning ("timeregistration"), then a
+ * non-admin web user in that group. All via admin API calls.
+ * Returns the created user's email.
+ *
+ * NOTE (this suite): the plugin-claim list below intentionally does NOT
+ * contain `adhoc_enable` — the route is open to every plugin user now, and
+ * granting the claim would make the suite pass even if the guard came back.
+ */
+async function setupNonAdminUser(page: Page, rand: string): Promise<string> {
+  const token = await loginViaApi(page, 'admin@admin.com', 'secretpassword');
+  const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+  const groupName = `adhoc-nonadmin-${rand}`;
+  const userEmail = `adhocuser-${rand}@test.com`;
+
+  // 1. Security group
+  await page.request.post(`${BASE_URL}/api/security/groups`, {
+    headers, data: { userIds: [], name: groupName },
+  });
+  const indexRes = await page.request.post(`${BASE_URL}/api/security/groups/index`, {
+    headers,
+    data: { sort: 'Id', nameFilter: groupName, pageIndex: 0, pageSize: 100, isSortDsc: false, offset: 0 },
+  });
+  const groups = (await indexRes.json())?.model?.entities || [];
+  const groupId = groups.find((g: any) => g.groupName === groupName)?.id || 0;
+  expect(groupId).toBeGreaterThan(0);
+
+  // 2. Core permissions: device users (page access + create/edit) and eForm
+  //    tags (create/edit/assign tags) — the affected customer group's set.
+  const coreClaims = [
+    'device_users_read', 'device_users_create', 'device_users_update',
+    'eforms_read_tags', 'eforms_update_tags',
+    'eforms_read', 'cases_read', 'case_read',
+  ];
+  const permsRes = await page.request.get(`${BASE_URL}/api/security/permissions/${groupId}`, { headers });
+  const permTypes = (await permsRes.json())?.model?.permissionTypes || [];
+  const permissions: any[] = [];
+  for (const pt of permTypes) {
+    for (const p of pt.permissions || []) {
+      permissions.push({ ...p, isEnabled: p.isEnabled || coreClaims.includes(p.claimName) });
+    }
+  }
+  await page.request.put(`${BASE_URL}/api/security/permissions`, {
+    headers, data: { groupId, permissions },
+  });
+
+  // Land non-admin logins directly on the property-workers page. Ad-hoc is
+  // reached from there via the sidebar (see the suite header) — this
+  // redirect is deliberately NOT pointed at adhoc-tasks, so the sidebar
+  // navigation, not the landing page, is what proves the route is open.
+  await page.request.put(`${BASE_URL}/api/security/groups/settings`, {
+    headers,
+    data: { id: groupId, redirectLink: '/plugins/backend-configuration-pn/property-workers' },
+  });
+
+  // 3. Plugin permissions: backend-configuration + time-planning access.
+  //    `adhoc_enable` is omitted ON PURPOSE (see this function's doc).
+  const pluginsRes = await page.request.get(
+    `${BASE_URL}/api/plugins-management/installed?sort=id&isSortDsc=true&pageSize=1000&pageIndex=0&offset=0`,
+    { headers },
+  );
+  const plugins = (await pluginsRes.json())?.model?.pluginsList || [];
+  const wantedPluginClaims: Record<string, string[]> = {
+    'eform-backend-configuration-plugin': [
+      'backend_configuration_plugin_access', 'properties_get',
+      'time_registration_enable', 'task_management_enable', 'document_management_enable',
+    ],
+    'eform-angular-time-planning-plugin': [
+      'time_planning_plugin_access', 'time_planning_flex_get', 'time_planning_working_hours_get',
+    ],
+  };
+  for (const plugin of plugins) {
+    const wanted = wantedPluginClaims[plugin.pluginId];
+    if (!wanted) continue;
+    const permUrl = `${BASE_URL}/api/plugins-permissions/group-permissions/${plugin.id}`;
+    const currentPerms = (await (await page.request.get(permUrl, { headers })).json())?.model || [];
+    const permIdMap: Record<string, number> = {};
+    for (const gp of currentPerms) {
+      for (const perm of gp.permissions || []) {
+        permIdMap[perm.claimName] = perm.permissionId;
+      }
+    }
+    const pluginPerms = wanted.map((claimName, i) => ({
+      isEnabled: true,
+      claimName,
+      permissionId: permIdMap[claimName] || i + 1,
+      permissionName: claimName,
+    }));
+    await page.request.put(permUrl, { headers, data: [{ permissions: pluginPerms, groupId }] });
+  }
+
+  // 4. Non-admin user in that group.
+  const createUserRes = await page.request.post(`${BASE_URL}/api/admin/create-user`, {
+    headers,
+    data: {
+      id: 0,
+      firstName: `AdhocUser${rand}`,
+      lastName: 'NonAdmin',
+      userName: userEmail,
+      email: userEmail,
+      password: USER_PASSWORD,
+      passwordConfimation: USER_PASSWORD,
+      role: 'user',
+      groupId,
+      isDeviceUser: false,
+    },
+  });
+  const createUserJson = await createUserRes.json().catch(() => null);
+  console.log(`create-user ${userEmail}: status=${createUserRes.status()} success=${createUserJson?.success}`);
+  expect(createUserJson?.success).toBe(true);
+
+  return userEmail;
+}
+
+/**
+ * The drawer's photo picker. `BackendConfigurationAdhocPage` exposes the
+ * resulting thumbnails (`photoThumbs()`/`queuedPhotoThumbs()`) and the
+ * delete flow, but has NO helper for ADDING a photo, so the hidden
+ * `<input type="file">` inside `label.photo-upload-btn`
+ * (`adhoc-task-drawer.component.html`) is addressed here. `setInputFiles`
+ * on a `hidden` file input is the same idiom `w/calendar-attachments.spec.ts`
+ * uses for `#calendarEventAttachInput`.
+ */
+function drawerPhotoInput(page: Page) {
+  return page.locator('.adhoc-drawer .photo-upload-btn input[type="file"]');
+}
+
+test.describe.serial('Adhoc overblik — non-admin unrestricted access', () => {
+  let userEmail = '';
+
+  // =======================================================================
+  // Seed 1 (ADMIN) — property + one ad-hoc task on it + one photo.
+  // =======================================================================
+  test('seed: property, one ad-hoc task and a photo on it (as admin)', async ({ page }) => {
+    test.setTimeout(300000);
+    await page.goto(BASE_URL);
+    await loginAs(page, 'admin@admin.com', 'secretpassword');
+    await page.locator('#newEFormBtn').waitFor({ state: 'visible', timeout: 120000 });
+
+    const propertiesPage = new BackendConfigurationPropertiesPage(page);
+    await propertiesPage.goToProperties();
+    await propertiesPage.createProperty(property);
+
+    const adhocPage = new BackendConfigurationAdhocPage(page);
+    await adhocPage.goToAdhoc();
+
+    await adhocPage.openNewTask();
+    await adhocPage.selectDrawerProperty(property.name);
+    await adhocPage.drawerTitleInput().fill(taskTitle);
+    await adhocPage.saveDrawer(true);
+    await expect(adhocPage.row(taskTitle)).toBeVisible({ timeout: 15000 });
+
+    // The photo is attached in EDIT mode rather than queued during create:
+    // edit-mode selection uploads immediately
+    // (`adhoc-task-drawer.component.ts` `onFilesSelected`), so the POST can
+    // be awaited and asserted here instead of racing the post-create
+    // queued-upload chain.
+    await adhocPage.openRowMenu(taskTitle);
+    await adhocPage.editMenuItem().click();
+    await adhocPage.drawerRoot().waitFor({ state: 'visible', timeout: 15000 });
+
+    const uploadResponsePromise = page.waitForResponse(
+      (r) => /\/api\/backend-configuration-pn\/adhoc\/\d+\/photos$/.test(r.url())
+        && r.request().method() === 'POST',
+      { timeout: 60000 },
+    );
+    await drawerPhotoInput(page).setInputFiles(PHOTO_FIXTURE);
+    const uploadResponse = await uploadResponsePromise;
+    expect(uploadResponse.status()).toBe(200);
+
+    await expect(adhocPage.photoThumbs()).toHaveCount(1, { timeout: 20000 });
+    await adhocPage.saveDrawer();
+    await expect(adhocPage.row(taskTitle)).toBeVisible({ timeout: 15000 });
+  });
+
+  // =======================================================================
+  // Seed 2 (ADMIN) — the `user`-role account WITHOUT `adhoc_enable` and
+  // without any assignment to the property seeded above.
+  // =======================================================================
+  test('seed: create non-admin user without adhoc_enable (as admin)', async ({ page }) => {
+    test.setTimeout(300000);
+    await page.goto(BASE_URL);
+    await loginAs(page, 'admin@admin.com', 'secretpassword');
+    await page.locator('#newEFormBtn').waitFor({ state: 'visible', timeout: 120000 });
+
+    userEmail = await setupNonAdminUser(page, rand);
+    expect(userEmail).not.toBe('');
+  });
+
+  // =======================================================================
+  // 1/3 — the route is open: the list view mounts for a non-admin.
+  // =======================================================================
+  test('non-admin reaches ad-hoc tasks and the list view mounts', async ({ page }) => {
+    test.setTimeout(300000);
+    expect(userEmail).not.toBe('');
+
+    await page.goto(BASE_URL);
+    await loginAs(page, userEmail, USER_PASSWORD);
+    expect(page.url()).not.toContain('/auth');
+
+    // Positive app-shell assertion BEFORE any guarded navigation (see the
+    // suite header): on the group's `redirectLink` landing page the full
+    // layout is mounted, so the claim-independent footer must exist.
+    await expect(page.locator('#sign-out-dropdown')).toBeVisible();
+
+    // Sidebar navigation — NOT a `page.goto`, so the SPA never re-bootstraps
+    // with the ad-hoc URL as its initial navigation.
+    const adhocPage = new BackendConfigurationAdhocPage(page);
+    await adhocPage.goToAdhoc();
+
+    expect(page.url()).toContain('/plugins/backend-configuration-pn/adhoc-tasks');
+    await expect(adhocPage.mainListView()).toBeVisible();
+    await expect(adhocPage.grid()).toBeVisible({ timeout: 20000 });
+    await expect(adhocPage.newTaskBtn()).toBeVisible();
+  });
+
+  // =======================================================================
+  // 2/3 — the load-bearing assertion: the seeded task is VISIBLE to a user
+  // with no assignment to its property. Merely unblocking the route would
+  // leave this list empty.
+  // =======================================================================
+  test('non-admin sees the seeded task on a property it is not assigned to', async ({ page }) => {
+    test.setTimeout(300000);
+    expect(userEmail).not.toBe('');
+
+    await page.goto(BASE_URL);
+    await loginAs(page, userEmail, USER_PASSWORD);
+    expect(page.url()).not.toContain('/auth');
+    await expect(page.locator('#sign-out-dropdown')).toBeVisible();
+
+    const adhocPage = new BackendConfigurationAdhocPage(page);
+    await adhocPage.goToAdhoc();
+
+    await adhocPage.search(taskTitle);
+    await expect(adhocPage.row(taskTitle)).toBeVisible({ timeout: 20000 });
+    // ...and it really is the admin-seeded task on the unassigned property.
+    await expect(adhocPage.columnCell(taskTitle, 'propertyName')).toContainText(property.name);
+
+    // The property itself is offered in the toolbar filter too
+    // (`GET /adhoc/properties` returns every property for the customer —
+    // §2 consequence 4), which is the same widening seen from the list.
+    await adhocPage.selectPropertyFilter(property.name);
+    await expect(adhocPage.row(taskTitle)).toBeVisible({ timeout: 20000 });
+  });
+
+  // =======================================================================
+  // 3/3 — the photo endpoint was the plugin's only `Forbid()`; a 403 there
+  // used to be escalated into a logout by the global HttpErrorInterceptor.
+  // =======================================================================
+  test('non-admin opens the task photo and stays logged in', async ({ page }) => {
+    test.setTimeout(300000);
+    expect(userEmail).not.toBe('');
+
+    // Collect EVERY photo-endpoint response for the whole test: the
+    // thumbnail's `authImage` pipe fetches the same guarded URL when the
+    // drawer opens, before the click below, so a 403 there would end the
+    // session before the explicit open ever happened.
+    const photoStatuses: number[] = [];
+    page.on('response', (r) => {
+      if (r.url().includes('/api/backend-configuration-pn/adhoc/photos/')) {
+        photoStatuses.push(r.status());
+      }
+    });
+
+    await page.goto(BASE_URL);
+    await loginAs(page, userEmail, USER_PASSWORD);
+    expect(page.url()).not.toContain('/auth');
+    await expect(page.locator('#sign-out-dropdown')).toBeVisible();
+
+    const adhocPage = new BackendConfigurationAdhocPage(page);
+    await adhocPage.goToAdhoc();
+    await adhocPage.search(taskTitle);
+    await expect(adhocPage.row(taskTitle)).toBeVisible({ timeout: 20000 });
+
+    // Open the task read-only (row menu → "Vis"), then click the thumbnail,
+    // which fetches every photo blob through `GET .../adhoc/photos/{id}`.
+    await adhocPage.openRowMenu(taskTitle);
+    await adhocPage.viewMenuItem().click();
+    await adhocPage.drawerRoot().waitFor({ state: 'visible', timeout: 20000 });
+    await expect(adhocPage.photoThumbs()).toHaveCount(1, { timeout: 20000 });
+
+    const photoResponsePromise = page.waitForResponse(
+      (r) => r.url().includes('/api/backend-configuration-pn/adhoc/photos/')
+        && r.request().method() === 'GET',
+      { timeout: 60000 },
+    );
+    await adhocPage.photoThumbs().first().click();
+    const photoResponse = await photoResponsePromise;
+    expect(photoResponse.status()).toBe(200);
+
+    // Give the interceptor's 403 path (refresh token → retry → logout →
+    // router.navigate(['/auth'])) more than enough time to fire if the
+    // endpoint had forbidden the read.
+    await page.waitForTimeout(5000);
+
+    expect(photoStatuses).not.toContain(403);
+    expect(page.url()).not.toContain('/auth');
+    await expect(page.locator('#sign-out-dropdown')).toBeVisible();
+
+    // Hard proof the session survived rather than merely the URL: `logout()`
+    // resets the auth store to `authInitialState` (accessToken ''), and
+    // `AuthSyncStorageService` mirrors that state into localStorage['auth'].
+    const accessTokenAfter = await page.evaluate(() => {
+      try {
+        return JSON.parse(localStorage.getItem('auth') ?? '{}')?.token?.accessToken ?? '';
+      } catch {
+        return '';
+      }
+    });
+    expect(accessTokenAfter).not.toBe('');
+  });
+});

--- a/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-table-filter.spec.ts
+++ b/eform-client/playwright/e2e/plugins/backend-configuration-pn/z/adhoc-table-filter.spec.ts
@@ -14,16 +14,19 @@ import { BackendConfigurationAdhocPage } from '../BackendConfigurationAdhoc.page
  * the "Ny opgave" drawer), then filter/search/column-picker assertions
  * against that seeded pair.
  *
- * Runs as `admin@admin.com` throughout (`LoginPage.login()` default). The
- * dashboard's `adhoc-tasks` route is `PermissionGuard`-gated on
- * `adhoc_enable` (`backend-configuration-pn.routing.ts`); this suite relies
- * on the same convention every other `PermissionGuard`-gated route in this
- * plugin already relies on across the existing shard suite (`properties`,
- * `task-management`, etc. - none of which grant per-group permissions for
- * the admin user before navigating) - admin sessions carry every known
- * claim as `'True'` without a separate grant step. If that assumption ever
- * changes, this suite's very first navigation (`goToAdhoc()`) is the single
- * point of failure, not any individual assertion below.
+ * Runs as `admin@admin.com` throughout (`LoginPage.login()` default), but
+ * NOT because the route requires it: since spec
+ * `2026-08-24-adhoc-tasks-unrestricted-access-design.md` the dashboard's
+ * `adhoc-tasks` route is plain `canActivate: [AuthGuard]`
+ * (`backend-configuration-pn.routing.ts`) - the old `PermissionGuard` +
+ * `data.requiredPermission: 'adhoc_enable'` gate is gone, and
+ * `AdhocController` grants every web caller full access, so any user of
+ * this plugin reaches the page and sees every task customer-wide. The only
+ * requirement left is the parent route's
+ * `backend_configuration_plugin_access`, which the admin session carries.
+ * The non-admin half of that behaviour is covered by
+ * `z/adhoc-nonadmin-access.spec.ts`; this suite stays admin-only simply
+ * because it seeds its own data.
  */
 const BASE_URL = 'http://localhost:4200';
 const rand = generateRandmString(8).toLowerCase();

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/backend-configuration-pn.routing.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/backend-configuration-pn.routing.spec.ts
@@ -1,0 +1,88 @@
+import {Route} from '@angular/router';
+import {AuthGuard, PermissionGuard} from 'src/app/common/guards';
+
+// The plugin components barrel ('./components', imported by the routing
+// module for its eagerly-referenced components) re-exports
+// BackendConfigurationCaseModule, which transitively imports the host's
+// entire src/app/modules barrel — that chain reaches
+// admin-settings.component.ts and its ESM-only `uuid` dependency, which the
+// host jest transform does not process (transformIgnorePatterns only lets
+// *.mjs and an allowlist through). This spec only inspects the route
+// definitions, so mock the barrel to keep the module graph scoped to the
+// routing table. jest.mock is hoisted above the imports, so the real barrel
+// is never loaded. Same treatment as report-table.component.spec.ts.
+jest.mock('./components', () => ({
+  GoogleDriveAccountsComponent: class MockGoogleDriveAccountsComponent {},
+  GoogleDriveOAuthFinishComponent: class MockGoogleDriveOAuthFinishComponent {},
+  PropertiesContainerComponent: class MockPropertiesContainerComponent {},
+  PropertyAreasComponent: class MockPropertyAreasComponent {},
+  ReportContainerComponent: class MockReportContainerComponent {},
+}));
+
+import {routes} from './backend-configuration-pn.routing';
+
+// Depth-first lookup by path. Indices shift whenever a route is added, so the
+// route under test is always located by its `path`, never by position.
+function findRoute(routeList: Route[], path: string): Route | undefined {
+  for (const route of routeList ?? []) {
+    if (route.path === path) {
+      return route;
+    }
+    const match = findRoute(route.children ?? [], path);
+    if (match) {
+      return match;
+    }
+  }
+  return undefined;
+}
+
+describe('BackendConfigurationPnRouting', () => {
+  it('exposes the plugin routes with a single root route', () => {
+    expect(routes.length).toBe(1);
+    expect(routes[0].children?.length).toBeGreaterThan(0);
+  });
+
+  describe('adhoc-tasks route', () => {
+    // Ad-hoc tasks are intentionally open to every user of this plugin
+    // (spec 2026-08-24-adhoc-tasks-unrestricted-access-design). The
+    // adhoc_enable claim was never granted to non-admin roles and is enforced
+    // nowhere server-side, so PermissionGuard silently cancelled navigation
+    // for exactly the users the page is for. AuthGuard is the deliberate
+    // "open to any logged-in user" marker shared with calendar, compliances
+    // and property-workers. Nothing else would notice PermissionGuard being
+    // reinstated — this spec is that guard.
+    it('is registered as a child of the plugin root route', () => {
+      const route = findRoute(routes, 'adhoc-tasks');
+
+      expect(route).toBeDefined();
+      expect(route.loadChildren).toBeDefined();
+    });
+
+    it('is guarded by AuthGuard only — open to any logged-in plugin user', () => {
+      const route = findRoute(routes, 'adhoc-tasks');
+
+      expect(route.canActivate).toContain(AuthGuard);
+    });
+
+    it('does not use PermissionGuard', () => {
+      const route = findRoute(routes, 'adhoc-tasks');
+
+      expect(route.canActivate).not.toContain(PermissionGuard);
+    });
+
+    it('declares no requiredPermission', () => {
+      const route = findRoute(routes, 'adhoc-tasks');
+
+      expect(route.data?.['requiredPermission']).toBeUndefined();
+    });
+  });
+
+  it('keeps the plugin-wide access gate on the root route', () => {
+    // Out of scope for 2026-08-24: opening the parent would change access to
+    // every page in the plugin, not just ad-hoc tasks.
+    expect(routes[0].canActivate?.length).toBe(1);
+    expect(routes[0].data?.['requiredPermission']).toBe(
+      'backend_configuration_plugin_access'
+    );
+  });
+});

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/backend-configuration-pn.routing.spec.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/backend-configuration-pn.routing.spec.ts
@@ -38,8 +38,11 @@ function findRoute(routeList: Route[], path: string): Route | undefined {
 
 describe('BackendConfigurationPnRouting', () => {
   it('exposes the plugin routes with a single root route', () => {
+    const rootRoute = findRoute(routes, '');
+
     expect(routes.length).toBe(1);
-    expect(routes[0].children?.length).toBeGreaterThan(0);
+    expect(rootRoute).toBeDefined();
+    expect(rootRoute.children?.length).toBeGreaterThan(0);
   });
 
   describe('adhoc-tasks route', () => {
@@ -49,8 +52,10 @@ describe('BackendConfigurationPnRouting', () => {
     // nowhere server-side, so PermissionGuard silently cancelled navigation
     // for exactly the users the page is for. AuthGuard is the deliberate
     // "open to any logged-in user" marker shared with calendar, compliances
-    // and property-workers. Nothing else would notice PermissionGuard being
-    // reinstated — this spec is that guard.
+    // and property-workers. This spec is the fast guard against
+    // PermissionGuard being reinstated; the e2e suite added with the same
+    // change (playwright .../z/adhoc-nonadmin-access.spec.ts) would fail
+    // too, but only in CI and only end-to-end.
     it('is registered as a child of the plugin root route', () => {
       const route = findRoute(routes, 'adhoc-tasks');
 
@@ -61,7 +66,12 @@ describe('BackendConfigurationPnRouting', () => {
     it('is guarded by AuthGuard only — open to any logged-in plugin user', () => {
       const route = findRoute(routes, 'adhoc-tasks');
 
-      expect(route.canActivate).toContain(AuthGuard);
+      // Exact array, not `toContain`: `[AuthGuard, IsAdminGuard]` contains
+      // AuthGuard too, and IsAdminGuard would re-close the page to exactly
+      // the users it was opened for — and it is already imported by this
+      // routing table and used by other plugin routes, so it is one word
+      // away.
+      expect(route.canActivate).toEqual([AuthGuard]);
     });
 
     it('does not use PermissionGuard', () => {
@@ -80,8 +90,11 @@ describe('BackendConfigurationPnRouting', () => {
   it('keeps the plugin-wide access gate on the root route', () => {
     // Out of scope for 2026-08-24: opening the parent would change access to
     // every page in the plugin, not just ad-hoc tasks.
-    expect(routes[0].canActivate?.length).toBe(1);
-    expect(routes[0].data?.['requiredPermission']).toBe(
+    const rootRoute = findRoute(routes, '');
+
+    expect(rootRoute).toBeDefined();
+    expect(rootRoute.canActivate?.length).toBe(1);
+    expect(rootRoute.data?.['requiredPermission']).toBe(
       'backend_configuration_plugin_access'
     );
   });

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/backend-configuration-pn.routing.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/backend-configuration-pn.routing.ts
@@ -66,11 +66,18 @@ export const routes: Routes = [
           ),
       },
       {
+        // Intentionally open to every user of this plugin (spec
+        // 2026-08-24-adhoc-tasks-unrestricted-access-design). The
+        // adhoc_enable claim was never granted to non-admin roles and is
+        // enforced nowhere server-side, so the guard only ever cancelled
+        // navigation for the users who were supposed to use the page.
+        // The parent route still requires backend_configuration_plugin_access.
+        // AuthGuard is deliberate — it is the explicit "open to any logged-in
+        // user" pattern also used by calendar, compliances and
+        // property-workers. Do not re-add PermissionGuard or a
+        // requiredPermission here.
         path: 'adhoc-tasks',
-        canActivate: [PermissionGuard],
-        data: {
-          requiredPermission: BackendConfigurationPnClaims.enableAdhoc,
-        },
+        canActivate: [AuthGuard],
         loadChildren: () =>
           import('./modules/adhoc/adhoc.module').then(
             (m) => m.AdhocModule

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/enums/backend-configuration-pn-claims.const.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/enums/backend-configuration-pn-claims.const.ts
@@ -1,10 +1,15 @@
 export const BackendConfigurationPnClaims = {
   accessBackendConfigurationPlugin: 'backend_configuration_plugin_access',
   // Retained but unenforced (2026-08-24): the adhoc-tasks route no longer
-  // guards on this claim and no backend attribute references the policy. The
+  // guards on THIS claim, and no backend attribute references it either. The
   // permission is still seeded, so the admin-settings toggle exists but has no
   // effect. Kept so the seeded row stays legible; proper removal needs a
   // base-repo migration (see spec 2026-08-24-adhoc-tasks-unrestricted-access).
+  //
+  // Unenforced does NOT mean ungated: AdhocController carries
+  // [Authorize(Policy = BackendConfigurationClaims.AccessBackendConfigurationPlugin)],
+  // so the ad-hoc endpoints still require accessBackendConfigurationPlugin
+  // below. What was dropped is the per-feature claim, not the plugin boundary.
   enableAdhoc: 'adhoc_enable',
   createProperties: 'properties_create',
   getProperties: 'properties_get',

--- a/eform-client/src/app/plugins/modules/backend-configuration-pn/enums/backend-configuration-pn-claims.const.ts
+++ b/eform-client/src/app/plugins/modules/backend-configuration-pn/enums/backend-configuration-pn-claims.const.ts
@@ -1,5 +1,10 @@
 export const BackendConfigurationPnClaims = {
   accessBackendConfigurationPlugin: 'backend_configuration_plugin_access',
+  // Retained but unenforced (2026-08-24): the adhoc-tasks route no longer
+  // guards on this claim and no backend attribute references the policy. The
+  // permission is still seeded, so the admin-settings toggle exists but has no
+  // effect. Kept so the seeded row stays legible; proper removal needs a
+  // base-repo migration (see spec 2026-08-24-adhoc-tasks-unrestricted-access).
   enableAdhoc: 'adhoc_enable',
   createProperties: 'properties_create',
   getProperties: 'properties_get',


### PR DESCRIPTION
A normal eForm user could not reach `plugins/backend-configuration-pn/adhoc-tasks`. Two gates stacked, and only the first is the one people look at.

## Why it was blocked

**The route guard.** It required the `adhoc_enable` claim, which is never granted to any non-admin group: `"Enable adhoc"` is absent from the plugin's hard-coded user-role list, and that loop only flips `PluginGroupPermissions` rows that already exist, never inserting one. A missing row reads as denied. Meanwhile the menu item is declared `Permissions = []`, so those users saw an "Adhoc overview" link that silently did nothing — the likely origin of the report.

**The identity gate.** The backend never enforced that claim at all. `AdhocController` was plain `[Authorize]` and passed a synthetic worker id of `0`, so the shared service's property-access predicates denied every read for non-admins regardless. **Granting the claim, or simply dropping the guard, would have produced a page that loads and stays permanently empty.**

**Why it presented as a logout.** `GET /adhoc/photos/{id}` was the plugin's only `Forbid()`, and the global `HttpErrorInterceptor` escalates any 403 into `logout()`.

## The change

- The route drops `PermissionGuard` for `canActivate: [AuthGuard]` — the explicit "open to any logged-in user" pattern already used by `calendar`, `compliances` and `property-workers`.
- `AdhocController` passes `DashboardHasFullAccess` instead of `IUserService.IsAdmin()` at all 23 call sites. `IUserService` is no longer consulted and is removed.
- **`AdhocController` gains `[Authorize(Policy = AccessBackendConfigurationPlugin)]`** — see below.

The shared `BackendConfigurationAdhocService` is deliberately **not** modified; its diff here is comments only. Web and mobile share that service, so widening its `CanSee` predicate rather than the controller's flag would have handed every phone in the customer full visibility. Changing what the web controller passes leaves the mobile caller scoped by construction.

Related hardening: `AdhocGrpcService` passed no `isAdmin` argument at all, resting the whole "mobile stays scoped" guarantee on a default parameter value. It is now written out as `isAdmin: false` at all 19 call sites.

## What review caught

Removing a *permission* check removed an *authentication* boundary. `backend_configuration_plugin_access` existed only as an Angular route guard; what actually kept non-plugin users out of the API was the worker-0 identity gate — the gate this PR removes. Without the new policy, any authenticated user of the installation could call the ad-hoc API directly for every task, property and worker name.

Also corrected: a comment written to replace a false claim was itself false; "hard delete" was wrong (it is the Microting soft delete, recoverable); the service interface still described `isAdmin` as an admin bypass, and its "mobile never passes `isAdmin`" was falsified by this very diff.

## Accepted consequences

Confirmed before implementing. Users see tasks for properties they are not assigned to; web-created tasks, comments and assignment logs stay authored by nobody (worker 0); tags created from the web become global and appear in every mobile worker's list, and any user may rename or delete another worker's personal tag; every property and worker name is listed to the `user` role; and phone-created tasks can be deleted from the web.

## Tests

- Jest spec pinning the route's guards — `toEqual([AuthGuard])`, since `toContain` passes for `[AuthGuard, IsAdminGuard]` and would silently re-close the page.
- `AdhocControllerTests` pinning all 23 routes plus that the controller takes no user/role service at all. None existed before.
- Playwright suite proving a non-admin **without** `adhoc_enable` reaches the page, sees a task on a property it is not assigned to, and survives opening its photo.
- Two accepted consequences that had no coverage anywhere now do: cross-user tag rename/delete with the join cascade, and soft-deleting another worker's task with its full child cascade.
- The twelve `(worker 0, isAdmin false)` integration tests are kept and re-commented. They are not guarding a reachable mobile state — `ResolveWorkerIdAsync` throws `Unauthenticated` on a zero id — and for `IndexTasks`/`ListHistory` there is no gRPC caller at all.

Spec: `docs/superpowers/specs/2026-08-24-adhoc-tasks-unrestricted-access-design.md`

**Ops note:** new menu items are not reconciled into an already-enabled plugin at boot. If "Adhoc overview" is missing entirely on the affected install, the plugin must be disabled and re-enabled in Admin → Plugins. Separate pre-existing core bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sXLtgzZU8QL9m84GqMkoJ